### PR TITLE
An approach for addressing LEXEVS-1839 (take 2).

### DIFF
--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/testUtility/AllTestsNormalConfig.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/testUtility/AllTestsNormalConfig.java
@@ -183,6 +183,7 @@ import org.LexGrid.LexBIG.Impl.load.meta.MrstyPropertyDataTestIT;
 import org.LexGrid.LexBIG.Impl.load.meta.PresentationPropertyDataTestIT;
 import org.LexGrid.LexBIG.Impl.load.meta.PresentationQualifiersDataTestIT;
 import org.LexGrid.LexBIG.Utility.OrderingTestRunnerTest;
+import org.junit.runners.model.InitializationError;
 import org.lexevs.dao.database.service.listener.DuplicatePropertyIdListenerTest;
 import org.lexevs.dao.index.operation.DefaultLexEVSIndexOperationsCleanupIndexesTest;
 import org.lexevs.dao.index.operation.DefaultLexEVSIndexOperationsCreateIndexTest;
@@ -216,7 +217,7 @@ public class AllTestsNormalConfig {
 
         mainSuite.addTestSuite(ConfigureTest.class);
         mainSuite.addTestSuite(OrderingTestRunnerTest.class);
-        mainSuite.addTestSuite(LoadTestDataTest.class);
+        mainSuite.addTest(orderedSuite(LoadTestDataTest.class));
         mainSuite.addTestSuite(CodeToReturnTest.class);
         mainSuite.addTestSuite(NCIThesaurusHistoryServiceTest.class);
         mainSuite.addTestSuite(UMLSHistoryServiceTest.class);
@@ -507,5 +508,11 @@ public class AllTestsNormalConfig {
         // $JUnit-END$
 
         return mainSuite;
+    }
+
+    public static Test orderedSuite(Class<?> clazz) throws InitializationError {
+        JUnit4TestAdapter adapter = new JUnit4TestAdapter(clazz);
+
+        return adapter;
     }
 }

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Utility/OrderingTestRunnerTest.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Utility/OrderingTestRunnerTest.java
@@ -1,6 +1,10 @@
 package org.LexGrid.LexBIG.Utility;
 
 import junit.framework.TestCase;
+import junit.framework.TestResult;
+import junit.framework.TestSuite;
+import org.LexGrid.LexBIG.Impl.testUtility.AllTestsNormalConfig;
+import org.junit.runner.RunWith;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
 import org.springframework.core.annotation.Order;
@@ -26,30 +30,47 @@ public class OrderingTestRunnerTest extends TestCase {
         assertEquals(Arrays.asList("qTest", "jTest", "aTest", "zTest"), names);
     }
 
+    @org.junit.Test
+    public void testOrderWithSuite() throws InitializationError {
+        TestSuite mainSuite = new TestSuite("Test");
 
-    public static class Test {
+        mainSuite.addTest(AllTestsNormalConfig.orderedSuite(Test.class));
+
+        TestResult result = new TestResult();
+        mainSuite.run(result);
+
+        assertEquals(0, result.errorCount());
+    }
+
+    private static int last = 0;
+
+    @RunWith(OrderingTestRunner.class)
+    public static class Test extends TestCase {
 
         @Order(2)
         @org.junit.Test
         public void zTest() {
-            //
+            assertEquals(last, 3);
         }
 
         @Order(1)
         @org.junit.Test
         public void aTest() {
-            //
+            assertEquals(last, 2);
+            last = 3;
         }
 
         @org.junit.Test
         public void jTest() {
-            //
+            assertEquals(last, 1);
+            last = 2;
         }
 
         @Order(-1)
         @org.junit.Test
         public void qTest() {
-            //
+            assertEquals(last, 0);
+            last = 1;
         }
     }
 }


### PR DESCRIPTION
An approach for addressing LEXEVS-1839 (take 2) - introducing a custom JUnit test runner to enforce ordering of test execution. This can be done explicitly by annotating the tests with an @Order annotation and running the class with the custom test runner.

This prevents the need to refactor test cases, as well as only requires change to tests that are order dependent (which should be the minority of tests).