### PR TITLE
Some more ordering changes for LEXEVS-1839.

### DIFF
--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/TestUtil.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/TestUtil.java
@@ -21,6 +21,7 @@ package org.LexGrid.LexBIG.Impl.function;
 import java.util.Enumeration;
 
 import org.LexGrid.LexBIG.DataModel.Collections.CodingSchemeRenderingList;
+import org.LexGrid.LexBIG.DataModel.Core.AbsoluteCodingSchemeVersionReference;
 import org.LexGrid.LexBIG.DataModel.Core.CodingSchemeSummary;
 import org.LexGrid.LexBIG.DataModel.Core.types.CodingSchemeVersionStatus;
 import org.LexGrid.LexBIG.DataModel.InterfaceElements.CodingSchemeRendering;
@@ -30,6 +31,7 @@ import org.LexGrid.LexBIG.Exceptions.LBInvocationException;
 import org.LexGrid.LexBIG.Impl.testUtility.ServiceHolder;
 import org.LexGrid.LexBIG.LexBIGService.LexBIGService;
 import org.LexGrid.LexBIG.LexBIGService.LexBIGServiceManager;
+import org.LexGrid.LexBIG.Utility.Constructors;
 import org.LexGrid.LexBIG.Utility.ConvenienceMethods;
 
 public class TestUtil {
@@ -135,5 +137,18 @@ public static synchronized boolean verifyScheme(String localName, String urn, St
         result = !verifyScheme(null, urn, version, null);
 
         return result;
+    }
+
+    public static void removeAll() throws Exception {
+        LexBIGService lbs = ServiceHolder.instance().getLexBIGService();
+        LexBIGServiceManager lbsm = lbs.getServiceManager(null);
+
+        for(CodingSchemeRendering csr : lbs.getSupportedCodingSchemes().getCodingSchemeRendering()) {
+            AbsoluteCodingSchemeVersionReference ref = Constructors.createAbsoluteCodingSchemeVersionReference(csr.getCodingSchemeSummary());
+
+            lbsm.deactivateCodingSchemeVersion(ref, null);
+            lbsm.removeCodingSchemeVersion(ref);
+        }
+
     }
 }

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/history/TestProductionTags.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/history/TestProductionTags.java
@@ -18,9 +18,6 @@
  */
 package org.LexGrid.LexBIG.Impl.function.history;
 
-import java.io.File;
-import java.util.Arrays;
-
 import org.LexGrid.LexBIG.DataModel.Collections.LocalNameList;
 import org.LexGrid.LexBIG.DataModel.Core.AbsoluteCodingSchemeVersionReference;
 import org.LexGrid.LexBIG.DataModel.Core.AssociatedConcept;
@@ -33,21 +30,25 @@ import org.LexGrid.LexBIG.Exceptions.LBInvocationException;
 import org.LexGrid.LexBIG.Exceptions.LBParameterException;
 import org.LexGrid.LexBIG.Impl.function.LexBIGServiceTestCase;
 import org.LexGrid.LexBIG.Impl.function.TestUtil;
-import org.LexGrid.LexBIG.Impl.loaders.LexGridMultiLoaderImpl;
 import org.LexGrid.LexBIG.Impl.testUtility.ServiceHolder;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeGraph;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
-import org.LexGrid.LexBIG.LexBIGService.LexBIGServiceManager;
 import org.LexGrid.LexBIG.Utility.Constructors;
 import org.LexGrid.LexBIG.Utility.ConvenienceMethods;
 import org.LexGrid.LexBIG.Utility.LBConstants;
 import org.LexGrid.LexBIG.Utility.LBConstants.KnownTags;
+import org.LexGrid.LexBIG.Utility.OrderingTestRunner;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
-import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.lexevs.locator.LexEvsServiceLocator;
+import org.springframework.core.annotation.Order;
 
+import java.util.Arrays;
+
+@RunWith(OrderingTestRunner.class)
 public class TestProductionTags extends LexBIGServiceTestCase {
     final static String testID = "T1_HIS_01";
 
@@ -58,39 +59,6 @@ public class TestProductionTags extends LexBIGServiceTestCase {
 
     String updatedVersion = "1.1";
 
-/**
-     * 01 Load/Activate version 1.1 of Automobiles vocabulary
-     * 
-     * @throws InterruptedException
-     * @throws LBException
-     * 
-     */
-@Before
-public void testProductionTags01() throws InterruptedException, LBException {
-        // info("01 Load/Activate version 1.1 of Automobiles vocabulary (see
-        // TestUtil.loadLgXML() as
-        // reference)");
-
-        // silence some extraneous warnings from a logger here:
-        Logger temp = Logger.getLogger("org.LexGrid.emf.base.xml.LgXMLHandlerImpl");
-        temp.setLevel(Level.ERROR);
-
-        LexBIGServiceManager lbsm = ServiceHolder.instance().getLexBIGService().getServiceManager(null);
-
-        LexGridMultiLoaderImpl loader = (LexGridMultiLoaderImpl) lbsm.getLoader("LexGrid_Loader");
-
-        loader.load(new File("resources/testData/Automobiles2.xml").toURI(), true, true);
-
-        while (loader.getStatus().getEndTime() == null) {
-            Thread.sleep(500);
-        }
-
-        if (TestUtil.verifyScheme(AUTO_SCHEME, AUTO_URN, updatedVersion, CodingSchemeVersionStatus.INACTIVE))
-            assertTrue(TestUtil.activateScheme(AUTO_URN, updatedVersion));
-        assertTrue(TestUtil.verifyScheme(AUTO_SCHEME, AUTO_URN, updatedVersion, CodingSchemeVersionStatus.ACTIVE));
-
-    }
-
     /**
      * 02 Assign 'PRODUCTION' tag to 1.0 version; verify tag assignment
      * 
@@ -99,6 +67,8 @@ public void testProductionTags01() throws InterruptedException, LBException {
      * @throws LBParameterException
      * 
      */
+    @Test
+    @Order(2)
     public void testProductionTags02() throws LBParameterException, LBInvocationException, LBException {
         // info("02 Assign 'PRODUCTION' tag to 1.0 version; verify tag assignment ");
         CodingSchemeVersionOrTag tag = new CodingSchemeVersionOrTag();
@@ -124,6 +94,8 @@ public void testProductionTags01() throws InterruptedException, LBException {
      * @throws LBException
      * 
      */
+    @Test
+    @Order(3)
     public void testProductionTags03() throws LBException {
         // info("03 Perform concept lookup by coding scheme name/tag; verify
         // that 'Chrysler' is not included
@@ -147,6 +119,8 @@ public void testProductionTags01() throws InterruptedException, LBException {
      * @throws LBException
      * 
      */
+    @Test
+    @Order(4)
     public void testProductionTags04() throws LBException {
         // info("04 Perform concept lookup by coding scheme name only; verify
         // that 'Chrysler' is not included
@@ -169,6 +143,8 @@ public void testProductionTags01() throws InterruptedException, LBException {
      * @throws LBException
      * 
      */
+    @Test
+    @Order(5)
     public void testProductionTags05() throws LBException {
         // info("05 Perform relation lookup by coding scheme name/tag; verify
         // that 'Domestic Auto Makers' has
@@ -236,6 +212,8 @@ public void testProductionTags01() throws InterruptedException, LBException {
      * @throws LBException
      * 
      */
+    @Test
+    @Order(6)
     public void testProductionTags06() throws LBException {
         // info("06 Perform relation lookup by coding scheme name only; verify
         // that 'Domestic Auto Makers' has
@@ -278,6 +256,8 @@ public void testProductionTags01() throws InterruptedException, LBException {
      * @throws LBParameterException
      * 
      */
+    @Test
+    @Order(7)
     public void testProductionTags07() throws LBParameterException, LBInvocationException, LBException {
     	 AbsoluteCodingSchemeVersionReference ref1;
          ref1 = ConvenienceMethods.createAbsoluteCodingSchemeVersionReference(AUTO_URN, AUTO_VERSION);
@@ -303,6 +283,8 @@ public void testProductionTags01() throws InterruptedException, LBException {
      * @throws LBInvocationException
      * 
      */
+    @Test
+    @Order(8)
     public void testProductionTags08() throws LBInvocationException, LBException {
         // info("08 Perform concept lookup by coding scheme name/tag; verify that 'Chrysler' is included ");
         CodedNodeSet cns;
@@ -324,6 +306,8 @@ public void testProductionTags01() throws InterruptedException, LBException {
      * @throws LBException
      * 
      */
+    @Test
+    @Order(9)
     public void testProductionTags09() throws LBException {
         // info("09 Perform concept lookup by coding scheme name only; verify that 'Chrysler' is included ");
         // not providing a version number gets you the PRODUCTION (which can be
@@ -344,6 +328,8 @@ public void testProductionTags01() throws InterruptedException, LBException {
      * @throws LBException
      * 
      */
+    @Test
+    @Order(10)
     public void testProductionTags10() throws LBException {
         // info("10 Perform relation lookup by coding scheme name/tag; verify
         // that 'Domestic Auto Makers' has
@@ -388,6 +374,8 @@ public void testProductionTags01() throws InterruptedException, LBException {
      * @throws LBException
      * 
      */
+    @Test
+    @Order(11)
     public void testProductionTags11() throws LBException {
         // info("11 Perform relation lookup by coding scheme name only; verify
         // that 'Domestic Auto Makers' has
@@ -431,6 +419,8 @@ public void testProductionTags01() throws InterruptedException, LBException {
      * @throws LBParameterException
      * 
      */
+    @Test
+    @Order(12)
     public void testProductionTags12() throws LBParameterException, LBInvocationException, LBException {
         // info("12 Clear 'PRODUCTION' tag on 1.1 version by setting to empty
         // string; verify tag is cleared
@@ -456,6 +446,8 @@ public void testProductionTags01() throws InterruptedException, LBException {
      * exception
      * 
      */
+    @Test
+    @Order(13)
     public void testProductionTags13() {
         // info("13 Attempt to perform concept lookup without specifying a version; verify exception ");
         CodedNodeSet cns;
@@ -477,6 +469,8 @@ public void testProductionTags01() throws InterruptedException, LBException {
      * @throws LBParameterException
      * 
      */
+    @Test
+    @Order(14)
     public void testProductionTags14() throws LBParameterException, LBInvocationException, LBException {
         // info("14 Assign 'TEST' tag to 1.0 version; verify tag assignment ");
         CodingSchemeVersionOrTag tag = new CodingSchemeVersionOrTag();
@@ -492,7 +486,9 @@ public void testProductionTags01() throws InterruptedException, LBException {
 
     }
 
-    public void testProductionTags14b() throws LBException {
+    @Test
+    @Order(15)
+    public void testProductionTags15() throws LBException {
         // lets do a search on the 'TEST' coding scheme, make sure it doesn't
         // have chrysler
         CodedNodeSet cns;
@@ -516,7 +512,9 @@ public void testProductionTags01() throws InterruptedException, LBException {
      * @throws LBInvocationException
      * 
      */
-    public void testProductionTags15() throws LBInvocationException, LBException {
+    @Test
+    @Order(16)
+    public void testProductionTags16() throws LBInvocationException, LBException {
         // info("15 Deactivate/Remove version 1.1 (see deactivate/remove methods on TestUtil as reference)");
         if (TestUtil.verifyScheme(AUTO_SCHEME, AUTO_URN, updatedVersion, CodingSchemeVersionStatus.ACTIVE))
             assertTrue(TestUtil.deactivateScheme(AUTO_URN, updatedVersion));
@@ -526,4 +524,5 @@ public void testProductionTags01() throws InterruptedException, LBException {
         Logger temp = Logger.getLogger("org.LexGrid.emf.base.xml.LgXMLHandlerImpl");
         temp.setLevel(Level.DEBUG);
     }
+
 }

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/history/TestProductionTags.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/history/TestProductionTags.java
@@ -30,9 +30,11 @@ import org.LexGrid.LexBIG.Exceptions.LBInvocationException;
 import org.LexGrid.LexBIG.Exceptions.LBParameterException;
 import org.LexGrid.LexBIG.Impl.function.LexBIGServiceTestCase;
 import org.LexGrid.LexBIG.Impl.function.TestUtil;
+import org.LexGrid.LexBIG.Impl.loaders.LexGridMultiLoaderImpl;
 import org.LexGrid.LexBIG.Impl.testUtility.ServiceHolder;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeGraph;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
+import org.LexGrid.LexBIG.LexBIGService.LexBIGServiceManager;
 import org.LexGrid.LexBIG.Utility.Constructors;
 import org.LexGrid.LexBIG.Utility.ConvenienceMethods;
 import org.LexGrid.LexBIG.Utility.LBConstants;
@@ -46,6 +48,7 @@ import org.junit.runner.RunWith;
 import org.lexevs.locator.LexEvsServiceLocator;
 import org.springframework.core.annotation.Order;
 
+import java.io.File;
 import java.util.Arrays;
 
 @RunWith(OrderingTestRunner.class)
@@ -58,6 +61,34 @@ public class TestProductionTags extends LexBIGServiceTestCase {
     }
 
     String updatedVersion = "1.1";
+
+    @Test
+    @Order(2)
+    public void testProductionTags01() throws InterruptedException, LBException {
+        // info("01 Load/Activate version 1.1 of Automobiles vocabulary (see
+        // TestUtil.loadLgXML() as
+        // reference)");
+
+        // silence some extraneous warnings from a logger here:
+        Logger temp = Logger.getLogger("org.LexGrid.emf.base.xml.LgXMLHandlerImpl");
+        temp.setLevel(Level.ERROR);
+
+        LexBIGServiceManager lbsm = ServiceHolder.instance().getLexBIGService().getServiceManager(null);
+
+        LexGridMultiLoaderImpl loader = (LexGridMultiLoaderImpl) lbsm.getLoader("LexGrid_Loader");
+
+        loader.load(new File("resources/testData/Automobiles2.xml").toURI(), true, true);
+
+        while (loader.getStatus().getEndTime() == null) {
+            Thread.sleep(500);
+        }
+
+        if (TestUtil.verifyScheme(AUTO_SCHEME, AUTO_URN, updatedVersion, CodingSchemeVersionStatus.INACTIVE)) {
+            assertTrue(TestUtil.activateScheme(AUTO_URN, updatedVersion));
+        }
+
+        assertTrue(TestUtil.verifyScheme(AUTO_SCHEME, AUTO_URN, updatedVersion, CodingSchemeVersionStatus.ACTIVE));
+    }
 
     /**
      * 02 Assign 'PRODUCTION' tag to 1.0 version; verify tag assignment

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/testUtility/AllTestsNormalConfig.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/testUtility/AllTestsNormalConfig.java
@@ -363,7 +363,7 @@ public class AllTestsNormalConfig {
         mainSuite.addTest(codedNodeGraphSuite);
 
         TestSuite functionalTests = new TestSuite("Functional Tests");
-        functionalTests.addTestSuite(TestProductionTags.class);
+        functionalTests.addTest(orderedSuite(TestProductionTags.class));
         functionalTests.addTestSuite(TestApproximateStringMatch.class);
         functionalTests.addTestSuite(TestAttributePresenceMatch.class);
         functionalTests.addTestSuite(TestAttributeValueMatch.class);

--- a/lbTest/src/test/java/org/lexevs/dao/index/operation/DefaultLexEVSIndexOperationsCleanupIndexesTest.java
+++ b/lbTest/src/test/java/org/lexevs/dao/index/operation/DefaultLexEVSIndexOperationsCleanupIndexesTest.java
@@ -7,13 +7,13 @@ import org.LexGrid.LexBIG.Exceptions.LBException;
 import org.LexGrid.LexBIG.Exceptions.LBParameterException;
 import org.LexGrid.LexBIG.Impl.LexBIGServiceImpl;
 import org.LexGrid.LexBIG.Impl.dataAccess.CleanUpUtility;
+import org.LexGrid.LexBIG.Impl.function.TestUtil;
 import org.LexGrid.LexBIG.Impl.loaders.LexGridMultiLoaderImpl;
 import org.LexGrid.LexBIG.Impl.testUtility.ServiceHolder;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.LexBIGService.LexBIGService;
 import org.LexGrid.LexBIG.LexBIGService.LexBIGServiceManager;
 import org.LexGrid.LexBIG.Utility.Constructors;
-import org.LexGrid.LexBIG.Utility.ConvenienceMethods;
 import org.LexGrid.LexBIG.Utility.Iterators.ResolvedConceptReferencesIterator;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -42,6 +42,8 @@ public class DefaultLexEVSIndexOperationsCleanupIndexesTest {
 
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
+		TestUtil.removeAll();
+
 		LexBIGServiceManager lbsm = ServiceHolder.instance().getLexBIGService()
 				.getServiceManager(null);
 
@@ -92,16 +94,13 @@ public class DefaultLexEVSIndexOperationsCleanupIndexesTest {
 	public static void tearDownAfterClass() throws Exception {
 		LexBIGServiceManager lbsm = ServiceHolder.instance().getLexBIGService()
 				.getServiceManager(null);
-		
-		// deactivate
-		lbsm.deactivateCodingSchemeVersion(ConvenienceMethods.createAbsoluteCodingSchemeVersionReference(
-			references.get(1).getCodingSchemeURN(), references.get(1).getCodingSchemeVersion()),null);		
-		
-		lbsm.deactivateCodingSchemeVersion(ConvenienceMethods.createAbsoluteCodingSchemeVersionReference(
-			references.get(2).getCodingSchemeURN(), references.get(2).getCodingSchemeVersion()),null);		
-		
+
+		lbsm.deactivateCodingSchemeVersion(references.get(1), null);
 		lbsm.removeCodingSchemeVersion(references.get(1));
+
+		lbsm.deactivateCodingSchemeVersion(references.get(2), null);
 		lbsm.removeCodingSchemeVersion(references.get(2));
+
 		CleanUpUtility.removeAllUnusedDatabases();
 		assertEquals(0, CleanUpUtility.listUnusedDatabases().length);
 	}
@@ -117,7 +116,7 @@ public class DefaultLexEVSIndexOperationsCleanupIndexesTest {
 		ops.cleanUp(list, true);
 
 		// TODO: Check this
-		assertTrue(ops.getConcurrentMetaData().getCodingSchemeList().size() >= 2);
+		assertEquals(2, ops.getConcurrentMetaData().getCodingSchemeList().size());
 		
 		// Test the index is populated and valid (GermanMadeParts, version 1.0)
 		LexBIGService lbs = LexBIGServiceImpl.defaultInstance();

--- a/lbTest/src/test/java/org/lexevs/dao/index/operation/DefaultLexEVSIndexOperationsCreateIndexTest.java
+++ b/lbTest/src/test/java/org/lexevs/dao/index/operation/DefaultLexEVSIndexOperationsCreateIndexTest.java
@@ -1,18 +1,12 @@
 package org.lexevs.dao.index.operation;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.io.File;
-import java.util.List;
-
 import org.LexGrid.LexBIG.DataModel.Core.AbsoluteCodingSchemeVersionReference;
 import org.LexGrid.LexBIG.DataModel.Core.CodingSchemeVersionOrTag;
 import org.LexGrid.LexBIG.DataModel.InterfaceElements.types.ProcessState;
 import org.LexGrid.LexBIG.Exceptions.LBException;
 import org.LexGrid.LexBIG.Exceptions.LBParameterException;
 import org.LexGrid.LexBIG.Impl.LexBIGServiceImpl;
+import org.LexGrid.LexBIG.Impl.function.TestUtil;
 import org.LexGrid.LexBIG.Impl.loaders.LexGridMultiLoaderImpl;
 import org.LexGrid.LexBIG.Impl.testUtility.ServiceHolder;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
@@ -28,6 +22,13 @@ import org.lexevs.locator.LexEvsServiceLocator;
 import org.lexevs.registry.model.RegistryEntry;
 import org.lexevs.registry.service.Registry;
 
+import java.io.File;
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 public class DefaultLexEVSIndexOperationsCreateIndexTest {
 	static AbsoluteCodingSchemeVersionReference reference = new AbsoluteCodingSchemeVersionReference();
 
@@ -35,6 +36,8 @@ public class DefaultLexEVSIndexOperationsCreateIndexTest {
 	
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
+		TestUtil.removeAll();
+
 		lbsm = ServiceHolder.instance().getLexBIGService()
 				.getServiceManager(null);
 

--- a/lbTest/src/test/java/org/lexevs/dao/index/operation/DefaultLexEVSIndexOperationsCreateMultipleIndexesTest.java
+++ b/lbTest/src/test/java/org/lexevs/dao/index/operation/DefaultLexEVSIndexOperationsCreateMultipleIndexesTest.java
@@ -1,11 +1,5 @@
 package org.lexevs.dao.index.operation;
 
-import static org.junit.Assert.*;
-
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.LexGrid.LexBIG.DataModel.Core.AbsoluteCodingSchemeVersionReference;
 import org.LexGrid.LexBIG.DataModel.Core.CodingSchemeVersionOrTag;
 import org.LexGrid.LexBIG.DataModel.InterfaceElements.types.ProcessState;
@@ -17,6 +11,7 @@ import org.LexGrid.LexBIG.Impl.testUtility.ServiceHolder;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.LexBIGService.LexBIGService;
 import org.LexGrid.LexBIG.LexBIGService.LexBIGServiceManager;
+import org.LexGrid.LexBIG.Utility.Constructors;
 import org.LexGrid.LexBIG.Utility.ConvenienceMethods;
 import org.LexGrid.LexBIG.Utility.Iterators.ResolvedConceptReferencesIterator;
 import org.junit.AfterClass;
@@ -24,11 +19,21 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.lexevs.locator.LexEvsServiceLocator;
-import org.lexevs.registry.model.RegistryEntry;
-import org.lexevs.registry.service.Registry;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class DefaultLexEVSIndexOperationsCreateMultipleIndexesTest {
-	static List<AbsoluteCodingSchemeVersionReference> references = new ArrayList<AbsoluteCodingSchemeVersionReference>();
+	private static List<AbsoluteCodingSchemeVersionReference> references = Arrays.asList(
+			Constructors.createAbsoluteCodingSchemeVersionReference("urn:oid:11.11.0.1", "1.0"), // Automobiles 1.0
+			Constructors.createAbsoluteCodingSchemeVersionReference("urn:oid:11.11.0.2", "2.0"), // GMP
+			Constructors.createAbsoluteCodingSchemeVersionReference("urn:oid:11.11.0.1", "1.1") // Automobiles 1.1
+	);
 
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
@@ -66,14 +71,8 @@ public class DefaultLexEVSIndexOperationsCreateMultipleIndexesTest {
 		}
 		assertTrue(loader.getStatus().getState().equals(ProcessState.COMPLETED));
 		assertFalse(loader.getStatus().getErrorsLogged().booleanValue());
-		Registry registry = LexEvsServiceLocator.getInstance().getRegistry();
-		List<RegistryEntry> entries = registry.getAllRegistryEntries();
-		for(RegistryEntry re: entries){
-			AbsoluteCodingSchemeVersionReference ref = new AbsoluteCodingSchemeVersionReference();
-			ref.setCodingSchemeURN(re.getResourceUri());
-			ref.setCodingSchemeVersion(re.getResourceVersion());
-			references.add(ref);
-			
+
+		for(AbsoluteCodingSchemeVersionReference ref : references){
 			// activate
 			lbsm.activateCodingSchemeVersion(ConvenienceMethods.createAbsoluteCodingSchemeVersionReference(
 					ref.getCodingSchemeURN(), ref.getCodingSchemeVersion()));

--- a/lbTest/src/test/java/org/lexevs/dao/index/operation/DefaultLexEVSIndexOperationsCreateMultipleIndexesTest.java
+++ b/lbTest/src/test/java/org/lexevs/dao/index/operation/DefaultLexEVSIndexOperationsCreateMultipleIndexesTest.java
@@ -6,6 +6,7 @@ import org.LexGrid.LexBIG.DataModel.InterfaceElements.types.ProcessState;
 import org.LexGrid.LexBIG.Exceptions.LBException;
 import org.LexGrid.LexBIG.Exceptions.LBParameterException;
 import org.LexGrid.LexBIG.Impl.LexBIGServiceImpl;
+import org.LexGrid.LexBIG.Impl.function.TestUtil;
 import org.LexGrid.LexBIG.Impl.loaders.LexGridMultiLoaderImpl;
 import org.LexGrid.LexBIG.Impl.testUtility.ServiceHolder;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
@@ -37,6 +38,8 @@ public class DefaultLexEVSIndexOperationsCreateMultipleIndexesTest {
 
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
+		TestUtil.removeAll();
+
 		LexBIGServiceManager lbsm = ServiceHolder.instance().getLexBIGService()
 				.getServiceManager(null);
 

--- a/lbTest/src/test/java/org/lexevs/dao/index/operation/DefaultLexEVSIndexOperationsRemoveTest.java
+++ b/lbTest/src/test/java/org/lexevs/dao/index/operation/DefaultLexEVSIndexOperationsRemoveTest.java
@@ -8,6 +8,7 @@ import org.LexGrid.LexBIG.Exceptions.LBInvocationException;
 import org.LexGrid.LexBIG.Exceptions.LBParameterException;
 import org.LexGrid.LexBIG.Impl.LexBIGServiceImpl;
 import org.LexGrid.LexBIG.Impl.dataAccess.CleanUpUtility;
+import org.LexGrid.LexBIG.Impl.function.TestUtil;
 import org.LexGrid.LexBIG.Impl.loaders.LexGridMultiLoaderImpl;
 import org.LexGrid.LexBIG.Impl.testUtility.ServiceHolder;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
@@ -43,6 +44,7 @@ public class DefaultLexEVSIndexOperationsRemoveTest {
 	
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
+		TestUtil.removeAll();
 
 		LexBIGServiceManager lbsm = ServiceHolder.instance().getLexBIGService()
 				.getServiceManager(null);

--- a/lbTest/src/test/java/org/lexevs/dao/index/operation/DefaultLexEVSIndexOperationsWriteOverIndexTest.java
+++ b/lbTest/src/test/java/org/lexevs/dao/index/operation/DefaultLexEVSIndexOperationsWriteOverIndexTest.java
@@ -4,6 +4,7 @@ import org.LexGrid.LexBIG.DataModel.Core.AbsoluteCodingSchemeVersionReference;
 import org.LexGrid.LexBIG.DataModel.InterfaceElements.types.ProcessState;
 import org.LexGrid.LexBIG.Exceptions.LBException;
 import org.LexGrid.LexBIG.Impl.dataAccess.CleanUpUtility;
+import org.LexGrid.LexBIG.Impl.function.TestUtil;
 import org.LexGrid.LexBIG.Impl.loaders.LexGridMultiLoaderImpl;
 import org.LexGrid.LexBIG.Impl.testUtility.ServiceHolder;
 import org.LexGrid.LexBIG.LexBIGService.LexBIGServiceManager;
@@ -30,6 +31,8 @@ public class DefaultLexEVSIndexOperationsWriteOverIndexTest {
 
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
+		TestUtil.removeAll();
+
 		LexBIGServiceManager lbsm = ServiceHolder.instance().getLexBIGService()
 				.getServiceManager(null);
 

--- a/lbTest/src/test/java/org/lexevs/dao/index/operation/DefaultLexEVSIndexOperationsWriteOverIndexTest.java
+++ b/lbTest/src/test/java/org/lexevs/dao/index/operation/DefaultLexEVSIndexOperationsWriteOverIndexTest.java
@@ -1,35 +1,29 @@
 package org.lexevs.dao.index.operation;
 
-import static org.junit.Assert.*;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
-import org.LexGrid.LexBIG.DataModel.Collections.ResolvedConceptReferenceList;
 import org.LexGrid.LexBIG.DataModel.Core.AbsoluteCodingSchemeVersionReference;
 import org.LexGrid.LexBIG.DataModel.InterfaceElements.types.ProcessState;
 import org.LexGrid.LexBIG.Exceptions.LBException;
-import org.LexGrid.LexBIG.Exceptions.LBInvocationException;
-import org.LexGrid.LexBIG.Exceptions.LBParameterException;
 import org.LexGrid.LexBIG.Impl.dataAccess.CleanUpUtility;
 import org.LexGrid.LexBIG.Impl.loaders.LexGridMultiLoaderImpl;
 import org.LexGrid.LexBIG.Impl.testUtility.ServiceHolder;
-import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
-import org.LexGrid.LexBIG.LexBIGService.LexBIGService;
 import org.LexGrid.LexBIG.LexBIGService.LexBIGServiceManager;
-import org.LexGrid.LexBIG.Utility.Constructors;
-import org.LexGrid.LexBIG.Utility.Iterators.ResolvedConceptReferencesIterator;
 import org.LexGrid.LexBIG.admin.LoadLgXML;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.lexevs.locator.LexEvsServiceLocator;
 import org.lexevs.registry.model.RegistryEntry;
 import org.lexevs.registry.service.Registry;
 
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@Ignore
 public class DefaultLexEVSIndexOperationsWriteOverIndexTest {
 	static AbsoluteCodingSchemeVersionReference reference = new AbsoluteCodingSchemeVersionReference();
 	static String prefix;

--- a/lbTest/src/test/java/org/lexevs/dao/index/operation/SameSessionLoadandQueryTest.java
+++ b/lbTest/src/test/java/org/lexevs/dao/index/operation/SameSessionLoadandQueryTest.java
@@ -1,13 +1,5 @@
 package org.lexevs.dao.index.operation;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.LexGrid.LexBIG.DataModel.Core.AbsoluteCodingSchemeVersionReference;
 import org.LexGrid.LexBIG.DataModel.Core.CodingSchemeVersionOrTag;
 import org.LexGrid.LexBIG.DataModel.InterfaceElements.types.ProcessState;
@@ -19,18 +11,20 @@ import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.LexBIGService.LexBIGService;
 import org.LexGrid.LexBIG.LexBIGService.LexBIGServiceManager;
 import org.LexGrid.LexBIG.Utility.Constructors;
-import org.LexGrid.LexBIG.Utility.ConvenienceMethods;
 import org.LexGrid.LexBIG.Utility.Iterators.ResolvedConceptReferencesIterator;
 import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.lexevs.locator.LexEvsServiceLocator;
-import org.lexevs.registry.model.RegistryEntry;
-import org.lexevs.registry.service.Registry;
+
+import java.io.File;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class SameSessionLoadandQueryTest {
-	static List<AbsoluteCodingSchemeVersionReference> references = new ArrayList<AbsoluteCodingSchemeVersionReference>();
+
+	private static AbsoluteCodingSchemeVersionReference reference = Constructors.createAbsoluteCodingSchemeVersionReference("urn:oid:11.11.0.1", "1.0"); // Automobiles 1.0
 
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
@@ -48,32 +42,17 @@ public class SameSessionLoadandQueryTest {
 		}
 		
 		// Activate the coding scheme
-		lbsm.activateCodingSchemeVersion(ConvenienceMethods.createAbsoluteCodingSchemeVersionReference("urn:oid:11.11.0.1", "1.0"));
+		lbsm.activateCodingSchemeVersion(reference);
 		
 		assertTrue(loader.getStatus().getState().equals(ProcessState.COMPLETED));
 		assertFalse(loader.getStatus().getErrorsLogged().booleanValue());
-		Registry registry = LexEvsServiceLocator.getInstance().getRegistry();
-		List<RegistryEntry> entries = registry.getAllRegistryEntries();
-		for(RegistryEntry re: entries){
-			AbsoluteCodingSchemeVersionReference ref = new AbsoluteCodingSchemeVersionReference();
-			ref.setCodingSchemeURN(re.getResourceUri());
-			ref.setCodingSchemeVersion(re.getResourceVersion());
-			references.add(ref);
-		}
 	}
 
 	@AfterClass
 	public static void tearDownAfterClass() throws Exception {
 		LexBIGServiceManager lbsm = ServiceHolder.instance().getLexBIGService()
 				.getServiceManager(null);
-		for(AbsoluteCodingSchemeVersionReference acsv: references){
-			lbsm.removeCodingSchemeVersion(acsv);
-		}
-	}
-
-	@Before
-	public void setUp() throws Exception {
-		
+		lbsm.removeCodingSchemeVersion(reference);
 	}
 
 	@Test
@@ -87,8 +66,7 @@ public class SameSessionLoadandQueryTest {
 		CodedNodeSet set = lbs.getCodingSchemeConcepts("Automobiles", csvt);
 	
 		// deactivate the coding scheme
-		AbsoluteCodingSchemeVersionReference acsvr = Constructors.createAbsoluteCodingSchemeVersionReference("urn:oid:11.11.0.1", "1.0");
-		lbsm.deactivateCodingSchemeVersion(acsvr, null);
+		lbsm.deactivateCodingSchemeVersion(reference, null);
 		
 		ResolvedConceptReferencesIterator itr = set.resolve(null, null, null);
 		assertNotNull(itr.next());

--- a/lbTest/src/test/java/org/lexevs/dao/index/operation/SameSessionLoadandQueryTest.java
+++ b/lbTest/src/test/java/org/lexevs/dao/index/operation/SameSessionLoadandQueryTest.java
@@ -5,6 +5,7 @@ import org.LexGrid.LexBIG.DataModel.Core.CodingSchemeVersionOrTag;
 import org.LexGrid.LexBIG.DataModel.InterfaceElements.types.ProcessState;
 import org.LexGrid.LexBIG.Exceptions.LBException;
 import org.LexGrid.LexBIG.Impl.LexBIGServiceImpl;
+import org.LexGrid.LexBIG.Impl.function.TestUtil;
 import org.LexGrid.LexBIG.Impl.loaders.LexGridMultiLoaderImpl;
 import org.LexGrid.LexBIG.Impl.testUtility.ServiceHolder;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
@@ -28,6 +29,8 @@ public class SameSessionLoadandQueryTest {
 
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
+		TestUtil.removeAll();
+
 		LexBIGServiceManager lbsm = ServiceHolder.instance().getLexBIGService()
 				.getServiceManager(null);
 

--- a/lexevs-dao/src/main/java/org/lexevs/dao/index/operation/DefaultLexEvsIndexOperations.java
+++ b/lexevs-dao/src/main/java/org/lexevs/dao/index/operation/DefaultLexEvsIndexOperations.java
@@ -18,12 +18,6 @@
  */
 package org.lexevs.dao.index.operation;
 
-import java.io.File;
-import java.io.FileFilter;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.LexGrid.LexBIG.DataModel.Core.AbsoluteCodingSchemeVersionReference;
 import org.LexGrid.LexBIG.Exceptions.LBParameterException;
 import org.lexevs.dao.index.access.IndexDaoManager;
@@ -36,6 +30,12 @@ import org.lexevs.dao.indexer.utility.Utility;
 import org.lexevs.locator.LexEvsServiceLocator;
 import org.lexevs.logging.AbstractLoggingBean;
 import org.lexevs.system.model.LocalCodingScheme;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class DefaultLexEvsIndexOperations extends AbstractLoggingBean implements LexEvsIndexOperations {
 	
@@ -104,6 +104,23 @@ public class DefaultLexEvsIndexOperations extends AbstractLoggingBean implements
 					ref.setCodingSchemeVersion(metaData.getCodingSchemeVersion());
 				this.dropIndex(metaData.getCodingSchemeName(), ref);
 				}
+			}
+		}
+
+		// sync internal index list
+		for (CodingSchemeMetaData codingSchemeMetaData : this.concurrentMetaData.getCodingSchemeList()) {
+			boolean found = false;
+			for (AbsoluteCodingSchemeVersionReference ref : expectedCodingSchemes) {
+				if (codingSchemeMetaData.getCodingSchemeUri().equals(ref.getCodingSchemeURN())
+					&&
+						codingSchemeMetaData.getCodingSchemeVersion().equals(ref.getCodingSchemeVersion())) {
+					found = true;
+					break;
+				}
+			}
+
+			if(! found) {
+				this.concurrentMetaData.remove(codingSchemeMetaData);
 			}
 		}
 	}


### PR DESCRIPTION
Test org.lexevs.dao.index.operation.DefaultLexEVSIndexOperationsCleanupIndexesTest.testMultipleIndexCreation is still failing on the CI server, but I'm fairly certain that there is no ordering problem within the test itself. That issue may need to be explored further, independently.