### PR TITLE
LEXEVS-1847: Added a @RemoteApiSafeTest annotation.

### DIFF
--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/Extensions/GenericExtensions/MappingExtensionImplTest.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/Extensions/GenericExtensions/MappingExtensionImplTest.java
@@ -18,14 +18,6 @@
  */
 package org.LexGrid.LexBIG.Impl.Extensions.GenericExtensions;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import org.LexGrid.LexBIG.DataModel.Collections.AbsoluteCodingSchemeVersionReferenceList;
 import org.LexGrid.LexBIG.DataModel.Collections.NameAndValueList;
 import org.LexGrid.LexBIG.DataModel.Core.AssociatedConcept;
@@ -47,6 +39,14 @@ import org.LexGrid.LexBIG.LexBIGService.LexBIGService;
 import org.LexGrid.LexBIG.Utility.Constructors;
 import org.LexGrid.LexBIG.Utility.Iterators.ResolvedConceptReferencesIterator;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class MappingExtensionImplTest extends LexBIGServiceTestCase {
     final static String testID = "MappingExtensionImplTest";

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodegraph/CodingSchemeExtensionResolveTest.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodegraph/CodingSchemeExtensionResolveTest.java
@@ -22,12 +22,14 @@ import org.LexGrid.LexBIG.DataModel.Core.AssociatedConcept;
 import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeGraph;
 import org.LexGrid.LexBIG.Utility.Constructors;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
 /**
  * The Class CodingSchemeExtensionResolveTest.
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class CodingSchemeExtensionResolveTest extends BaseCodedNodeGraphTest {
 
    

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodegraph/CrossOntologyResolveTest.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodegraph/CrossOntologyResolveTest.java
@@ -23,12 +23,14 @@ import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
 import org.LexGrid.LexBIG.Impl.testUtility.DataTestUtils;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeGraph;
 import org.LexGrid.LexBIG.Utility.Constructors;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
 /**
  * The Class SortGraphTest.
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class CrossOntologyResolveTest extends BaseCodedNodeGraphTest {
 
     /**

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodegraph/FocusTest.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodegraph/FocusTest.java
@@ -22,12 +22,14 @@ import org.LexGrid.LexBIG.DataModel.Collections.ResolvedConceptReferenceList;
 import org.LexGrid.LexBIG.DataModel.Core.ConceptReference;
 import org.LexGrid.LexBIG.Exceptions.LBParameterException;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeGraph;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
 /**
  * The Class FocusTest.
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class FocusTest extends BaseCodedNodeGraphTest {
 
     /**

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodegraph/IntersectionTest.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodegraph/IntersectionTest.java
@@ -18,20 +18,22 @@
  */
 package org.LexGrid.LexBIG.Impl.function.codednodegraph;
 
-import java.util.Arrays;
-import java.util.List;
-
 import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
 import org.LexGrid.LexBIG.Impl.testUtility.DataTestUtils;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeGraph;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.Utility.Constructors;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
+
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * The Class IntersectionTest.
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class IntersectionTest extends BaseCodedNodeGraphTest {
 
     /**
@@ -44,18 +46,18 @@ public class IntersectionTest extends BaseCodedNodeGraphTest {
             lbs.getNodeGraph(AUTO_SCHEME, null, null);
         
         CodedNodeSet cns1 = lbs.getCodingSchemeConcepts(AUTO_SCHEME, null);
-        cns1.restrictToCodes(Constructors.createConceptReferenceList(new String[] {"005", "A0001", "Chevy"}));
+        cns1 = cns1.restrictToCodes(Constructors.createConceptReferenceList(new String[] {"005", "A0001", "Chevy"}));
  
         //005,GM,Ford,A,C0001,T0001,Batteries,Brakes,Tires
-        cngIntersect1.restrictToSourceCodes(cns1);
+        cngIntersect1 = cngIntersect1.restrictToSourceCodes(cns1);
 
         CodedNodeGraph cngIntersect2 = 
             lbs.getNodeGraph(AUTO_SCHEME, null, null);
         
         CodedNodeSet cns2 = lbs.getCodingSchemeConcepts(AUTO_SCHEME, null);
-        cns2.restrictToCodes(Constructors.createConceptReferenceList(new String[] {"GM","Ford","005"}));
-            
-        cngIntersect2.restrictToSourceCodes(cns2);
+        cns2 = cns2.restrictToCodes(Constructors.createConceptReferenceList(new String[] {"GM","Ford","005"}));
+
+        cngIntersect2 = cngIntersect2.restrictToSourceCodes(cns2);
  
         CodedNodeGraph cngIntersect = cngIntersect2.intersect(cngIntersect1);
         
@@ -84,17 +86,17 @@ public class IntersectionTest extends BaseCodedNodeGraphTest {
             lbs.getNodeGraph(AUTO_SCHEME, null, null);
         
         CodedNodeSet cns1 = lbs.getCodingSchemeConcepts(AUTO_SCHEME, null);
-        cns1.restrictToCodes(Constructors.createConceptReferenceList("Jaguar", AUTO_SCHEME));
- 
-        cngIntersect1.restrictToCodes(cns1);
+        cns1 = cns1.restrictToCodes(Constructors.createConceptReferenceList("Jaguar", AUTO_SCHEME));
+
+        cngIntersect1 = cngIntersect1.restrictToCodes(cns1);
         
         CodedNodeGraph cngIntersect2 = 
             lbs.getNodeGraph(AUTO_SCHEME, null, null);
         
         CodedNodeSet cns2 = lbs.getCodingSchemeConcepts(AUTO_SCHEME, null);
-        cns2.restrictToCodes(Constructors.createConceptReferenceList("Ford", AUTO_SCHEME));
-            
-        cngIntersect2.restrictToCodes(cns2);
+        cns2 = cns2.restrictToCodes(Constructors.createConceptReferenceList("Ford", AUTO_SCHEME));
+
+        cngIntersect2 = cngIntersect2.restrictToCodes(cns2);
         
         CodedNodeGraph cngIntersect = cngIntersect1.intersect(cngIntersect2);
         

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodegraph/ResolveToListTest.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodegraph/ResolveToListTest.java
@@ -20,12 +20,14 @@ package org.LexGrid.LexBIG.Impl.function.codednodegraph;
 
 import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
 import org.LexGrid.LexBIG.Utility.Constructors;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
 /**
  * The Class ResolveToListTest.
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class ResolveToListTest extends BaseCodedNodeGraphTest {
 
     /**

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodegraph/RestrictToAnonymousTest.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodegraph/RestrictToAnonymousTest.java
@@ -21,6 +21,7 @@ package org.LexGrid.LexBIG.Impl.function.codednodegraph;
 import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeGraph;
 import org.LexGrid.LexBIG.Utility.Constructors;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 import org.LexGrid.util.PrintUtility;
 
 /**
@@ -28,6 +29,7 @@ import org.LexGrid.util.PrintUtility;
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class RestrictToAnonymousTest extends BaseCodedNodeGraphTest {
 
     public void testRestrictToNonAnonymousForMappingScheme() throws Exception {

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodegraph/RestrictToAssociationsTest.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodegraph/RestrictToAssociationsTest.java
@@ -26,12 +26,14 @@ import org.LexGrid.LexBIG.Exceptions.LBInvocationException;
 import org.LexGrid.LexBIG.Exceptions.LBParameterException;
 import org.LexGrid.LexBIG.Impl.function.LexBIGServiceTestCase;
 import org.LexGrid.LexBIG.Utility.Constructors;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
 /**
  * The Class RestrictToAssociationsTest.
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class RestrictToAssociationsTest extends BaseCodedNodeGraphTest {
 
     /**
@@ -41,7 +43,7 @@ public class RestrictToAssociationsTest extends BaseCodedNodeGraphTest {
      * @throws LBParameterException the LB parameter exception
      */
     public void testOneAssociationNameNullQualifiers() throws LBInvocationException, LBParameterException{
-        cng.restrictToAssociations(Constructors.createNameAndValueList("uses"), 
+        cng = cng.restrictToAssociations(Constructors.createNameAndValueList("uses"), 
                 null);
         
         ResolvedConceptReference[] rcr = 
@@ -76,7 +78,7 @@ public class RestrictToAssociationsTest extends BaseCodedNodeGraphTest {
      */
     public void testOneAssociationNameNullQualifiersNoMatch() throws Exception{
 
-    	cng.restrictToAssociations(Constructors.createNameAndValueList("NOT_A_MATCH"), 
+    	cng = cng.restrictToAssociations(Constructors.createNameAndValueList("NOT_A_MATCH"), 
     			null);
     	ResolvedConceptReference[] rcr = 
     		cng.resolveAsList(Constructors.createConceptReference("A0001", LexBIGServiceTestCase.AUTO_SCHEME), 
@@ -101,7 +103,7 @@ public class RestrictToAssociationsTest extends BaseCodedNodeGraphTest {
      * @throws LBParameterException the LB parameter exception
      */
     public void testTwoAssociationNamesNullQualifiers() throws LBInvocationException, LBParameterException{
-        cng.restrictToAssociations(Constructors.createNameAndValueList(new String[]{"uses", "hasSubtype"}),
+        cng = cng.restrictToAssociations(Constructors.createNameAndValueList(new String[]{"uses", "hasSubtype"}),
                 null);
         
         ResolvedConceptReference[] rcr = 
@@ -152,7 +154,7 @@ public class RestrictToAssociationsTest extends BaseCodedNodeGraphTest {
      * @throws LBParameterException the LB parameter exception
      */
     public void testOneAssociationNameOneQualifierWithoutValue() throws LBInvocationException, LBParameterException{
-        cng.restrictToAssociations(Constructors.createNameAndValueList("hasSubtype"), 
+        cng = cng.restrictToAssociations(Constructors.createNameAndValueList("hasSubtype"), 
                 Constructors.createNameAndValueList("hasEngine"));
         
         ResolvedConceptReference[] rcr = 
@@ -190,7 +192,7 @@ public class RestrictToAssociationsTest extends BaseCodedNodeGraphTest {
      * @throws LBParameterException the LB parameter exception
      */
     public void testOneAssociationNameOneQualifierWithValue() throws LBInvocationException, LBParameterException{
-        cng.restrictToAssociations(Constructors.createNameAndValueList("hasSubtype"), 
+        cng = cng.restrictToAssociations(Constructors.createNameAndValueList("hasSubtype"), 
                 Constructors.createNameAndValueList("hasEngine", "true"));
         
         ResolvedConceptReference[] rcr = 
@@ -228,7 +230,7 @@ public class RestrictToAssociationsTest extends BaseCodedNodeGraphTest {
      * @throws LBParameterException the LB parameter exception
      */
     public void testOneAssociationNameOneQualifierWithWrongValue() throws LBInvocationException, LBParameterException{
-        cng.restrictToAssociations(Constructors.createNameAndValueList("hasSubtype"), 
+        cng = cng.restrictToAssociations(Constructors.createNameAndValueList("hasSubtype"), 
                 Constructors.createNameAndValueList("hasEngine", "false"));
 
         ResolvedConceptReference[] rcr = 
@@ -248,7 +250,7 @@ public class RestrictToAssociationsTest extends BaseCodedNodeGraphTest {
     }
     
     public void testOneAssociationNameOneQualifierWithValueResolveAllQuals() throws LBInvocationException, LBParameterException{
-        cng.restrictToAssociations(Constructors.createNameAndValueList("hasSubtype"), 
+        cng = cng.restrictToAssociations(Constructors.createNameAndValueList("hasSubtype"), 
                 Constructors.createNameAndValueList("since", "1998"));
         
         ResolvedConceptReference[] rcr = 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodegraph/RestrictToDirectionalNamesTest.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodegraph/RestrictToDirectionalNamesTest.java
@@ -25,12 +25,14 @@ import org.LexGrid.LexBIG.Exceptions.LBInvocationException;
 import org.LexGrid.LexBIG.Exceptions.LBParameterException;
 import org.LexGrid.LexBIG.Impl.function.LexBIGServiceTestCase;
 import org.LexGrid.LexBIG.Utility.Constructors;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
 /**
  * The Class RestrictToDirectionalNamesTest.
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class RestrictToDirectionalNamesTest extends BaseCodedNodeGraphTest {
 
     /**
@@ -81,7 +83,7 @@ public class RestrictToDirectionalNamesTest extends BaseCodedNodeGraphTest {
      */
     public void testOneDirectionalNameNullQualifiersNoMatch() {
         try {
-			cng.restrictToDirectionalNames(Constructors.createNameAndValueList("NOT_A_MATCH"), 
+            cng = cng.restrictToDirectionalNames(Constructors.createNameAndValueList("NOT_A_MATCH"),
 			        null);
 		} catch (LBInvocationException e) {
 			fail();
@@ -150,11 +152,11 @@ public class RestrictToDirectionalNamesTest extends BaseCodedNodeGraphTest {
      * @throws LBParameterException the LB parameter exception
      */
     public void testOneDirectionalNameOneQualifierWithoutValue() throws LBInvocationException, LBParameterException{
-        cng.restrictToDirectionalNames(Constructors.createNameAndValueList("hasSubtype"), 
+        cng = cng.restrictToDirectionalNames(Constructors.createNameAndValueList("hasSubtype"),
                 Constructors.createNameAndValueList("hasEngine"));
         
-        ResolvedConceptReference[] rcr = 
-            cng.resolveAsList(Constructors.createConceptReference("A0001", LexBIGServiceTestCase.AUTO_SCHEME), 
+        ResolvedConceptReference[] rcr =
+            cng.resolveAsList(Constructors.createConceptReference("A0001", LexBIGServiceTestCase.AUTO_SCHEME),
                     true, 
                     false, 
                     -1, 
@@ -188,7 +190,7 @@ public class RestrictToDirectionalNamesTest extends BaseCodedNodeGraphTest {
      * @throws LBParameterException the LB parameter exception
      */
     public void testOneDirectionalNameOneQualifierWithValue() throws LBInvocationException, LBParameterException{
-        cng.restrictToDirectionalNames(Constructors.createNameAndValueList("hasSubtype"), 
+        cng = cng.restrictToDirectionalNames(Constructors.createNameAndValueList("hasSubtype"),
                 Constructors.createNameAndValueList("hasEngine", "true"));
         
         ResolvedConceptReference[] rcr = 
@@ -226,7 +228,7 @@ public class RestrictToDirectionalNamesTest extends BaseCodedNodeGraphTest {
      * @throws LBParameterException the LB parameter exception
      */
     public void testOneDirectionalNameOneQualifierWithWrongValue() throws LBInvocationException, LBParameterException{
-        cng.restrictToDirectionalNames(Constructors.createNameAndValueList("hasSubtype"), 
+        cng = cng.restrictToDirectionalNames(Constructors.createNameAndValueList("hasSubtype"),
                 Constructors.createNameAndValueList("hasEngine", "false"));
 
         ResolvedConceptReference[] rcr = 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodegraph/RestrictToSourceCodesTest.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodegraph/RestrictToSourceCodesTest.java
@@ -22,6 +22,7 @@ import org.LexGrid.LexBIG.DataModel.Core.AssociatedConcept;
 import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.Utility.Constructors;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 import org.junit.Test;
 
 /**
@@ -29,6 +30,7 @@ import org.junit.Test;
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class RestrictToSourceCodesTest extends BaseCodedNodeGraphTest {
 
     /**
@@ -41,7 +43,7 @@ public class RestrictToSourceCodesTest extends BaseCodedNodeGraphTest {
         CodedNodeSet cns = lbs.getCodingSchemeConcepts(AUTO_SCHEME, null);
         cns.restrictToCodes(Constructors.createConceptReferenceList("005", AUTO_SCHEME));
  
-        cng.restrictToSourceCodes(cns);
+        cng = cng.restrictToSourceCodes(cns);
         
         ResolvedConceptReference[] rcr = 
             cng.resolveAsList(null, 
@@ -65,7 +67,7 @@ public class RestrictToSourceCodesTest extends BaseCodedNodeGraphTest {
         CodedNodeSet cns = lbs.getCodingSchemeConcepts(AUTO_SCHEME, null);
         cns.restrictToCodes(Constructors.createConceptReferenceList("005", AUTO_SCHEME));
  
-        cng.restrictToSourceCodes(cns);
+        cng = cng.restrictToSourceCodes(cns);
         
         ResolvedConceptReference[] rcr = 
             cng.resolveAsList(null, 
@@ -103,7 +105,7 @@ public class RestrictToSourceCodesTest extends BaseCodedNodeGraphTest {
         CodedNodeSet cns = lbs.getCodingSchemeConcepts(AUTO_SCHEME, null);
         cns.restrictToCodes(Constructors.createConceptReferenceList("005", AUTO_SCHEME));
  
-        cng.restrictToSourceCodes(cns);
+        cng = cng.restrictToSourceCodes(cns);
         
         ResolvedConceptReference[] rcr = 
             cng.resolveAsList(null, 
@@ -137,7 +139,7 @@ public class RestrictToSourceCodesTest extends BaseCodedNodeGraphTest {
         CodedNodeSet cns = lbs.getCodingSchemeConcepts(AUTO_SCHEME, null);
         cns.restrictToCodes(Constructors.createConceptReferenceList(new String[]{"Ford", "A0001"}));
  
-        cng.restrictToSourceCodes(cns);
+        cng = cng.restrictToSourceCodes(cns);
         
         ResolvedConceptReference[] rcr = 
             cng.resolveAsList(null, 
@@ -166,7 +168,7 @@ public class RestrictToSourceCodesTest extends BaseCodedNodeGraphTest {
         CodedNodeSet cns = lbs.getCodingSchemeConcepts(AUTO_SCHEME, null);
         cns.restrictToCodes(Constructors.createConceptReferenceList(new String[]{"NO_MATCH"}));
  
-        cng.restrictToSourceCodes(cns);
+        cng = cng.restrictToSourceCodes(cns);
         
         ResolvedConceptReference[] rcr = 
             cng.resolveAsList(null, 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodegraph/RestrictToTargetCodesTest.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodegraph/RestrictToTargetCodesTest.java
@@ -21,12 +21,14 @@ package org.LexGrid.LexBIG.Impl.function.codednodegraph;
 import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.Utility.Constructors;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
 /**
  * The Class RestrictToTargetCodesTest.
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class RestrictToTargetCodesTest extends BaseCodedNodeGraphTest {
 
     /**
@@ -37,9 +39,9 @@ public class RestrictToTargetCodesTest extends BaseCodedNodeGraphTest {
     public void testRestrictToTargetCodes() throws Exception {
         
         CodedNodeSet cns = lbs.getCodingSchemeConcepts(AUTO_SCHEME, null);
-        cns.restrictToCodes(Constructors.createConceptReferenceList("Ford", AUTO_SCHEME));
- 
-        cng.restrictToTargetCodes(cns);
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList("Ford", AUTO_SCHEME));
+
+        cng = cng.restrictToTargetCodes(cns);
         
         ResolvedConceptReference[] rcr = 
             cng.resolveAsList(null, 
@@ -67,9 +69,9 @@ public class RestrictToTargetCodesTest extends BaseCodedNodeGraphTest {
     public void testRestrictToTargetCodesTwoCodes() throws Exception {
         
         CodedNodeSet cns = lbs.getCodingSchemeConcepts(AUTO_SCHEME, null);
-        cns.restrictToCodes(Constructors.createConceptReferenceList(new String[]{"Ford", "T0001"}));
- 
-        cng.restrictToTargetCodes(cns);
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList(new String[]{"Ford", "T0001"}));
+
+        cng = cng.restrictToTargetCodes(cns);
         
         ResolvedConceptReference[] rcr = 
             cng.resolveAsList(null, 
@@ -96,9 +98,9 @@ public class RestrictToTargetCodesTest extends BaseCodedNodeGraphTest {
     public void testRestrictToTargetCodesNoMatch() throws Exception {
         
         CodedNodeSet cns = lbs.getCodingSchemeConcepts(AUTO_SCHEME, null);
-        cns.restrictToCodes(Constructors.createConceptReferenceList(new String[]{"NO_MATCH"}));
- 
-        cng.restrictToTargetCodes(cns);
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList(new String[]{"NO_MATCH"}));
+
+        cng = cng.restrictToTargetCodes(cns);
         
         ResolvedConceptReference[] rcr = 
             cng.resolveAsList(null, 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodegraph/RootsTest.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodegraph/RootsTest.java
@@ -22,12 +22,14 @@ import org.LexGrid.LexBIG.DataModel.Collections.ResolvedConceptReferenceList;
 import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
 import org.LexGrid.LexBIG.Impl.testUtility.DataTestUtils;
 import org.LexGrid.LexBIG.Utility.Constructors;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
 /**
  * The Class RootsTest.
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class RootsTest extends BaseCodedNodeGraphTest {
 
     /**

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodegraph/SearchByRelationshipTest.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodegraph/SearchByRelationshipTest.java
@@ -18,19 +18,20 @@
  */
 package org.LexGrid.LexBIG.Impl.function.codednodegraph;
 
-import java.util.Arrays;
-
 import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
 import org.LexGrid.LexBIG.Impl.testUtility.DataTestUtils;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet.SearchDesignationOption;
-import org.LexGrid.util.PrintUtility;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
+
+import java.util.Arrays;
 
 /**
  * The Class SearchByRelationshipTest.
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class SearchByRelationshipTest extends BaseCodedNodeGraphTest {
 
 	//get all sub codes of codes that contain 'car'

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodegraph/SortGraphTest.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodegraph/SortGraphTest.java
@@ -22,12 +22,14 @@ import org.LexGrid.LexBIG.DataModel.Core.AssociatedConcept;
 import org.LexGrid.LexBIG.DataModel.Core.Association;
 import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
 import org.LexGrid.LexBIG.Utility.Constructors;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
 /**
  * The Class SortGraphTest.
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class SortGraphTest extends BaseCodedNodeGraphTest {
 
     /**

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodegraph/ToNodeListTest.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodegraph/ToNodeListTest.java
@@ -18,15 +18,10 @@
  */
 package org.LexGrid.LexBIG.Impl.function.codednodegraph;
 
-import org.LexGrid.LexBIG.DataModel.Collections.AssociationList;
-import org.LexGrid.LexBIG.DataModel.Collections.ConceptReferenceList;
 import org.LexGrid.LexBIG.DataModel.Core.ConceptReference;
 import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
-import org.LexGrid.LexBIG.Impl.CodedNodeSetImpl;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.Utility.Constructors;
-import org.LexGrid.commonTypes.EntityDescription;
-import org.lexevs.dao.database.ibatis.codednodegraph.model.EntityReferencingAssociatedConcept;
 
 /**
  * The Class ToNodeListTest.

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodegraph/UnionTest.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodegraph/UnionTest.java
@@ -18,24 +18,22 @@
  */
 package org.LexGrid.LexBIG.Impl.function.codednodegraph;
 
-import java.util.Arrays;
-
 import org.LexGrid.LexBIG.DataModel.Collections.ResolvedConceptReferenceList;
-import org.LexGrid.LexBIG.DataModel.Core.AssociatedConcept;
-import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
-import org.LexGrid.LexBIG.Impl.LexBIGServiceImpl;
 import org.LexGrid.LexBIG.Impl.testUtility.DataTestUtils;
-import org.LexGrid.LexBIG.LexBIGService.CodedNodeGraph;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet.SearchDesignationOption;
 import org.LexGrid.LexBIG.Utility.Constructors;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 import org.LexGrid.util.PrintUtility;
+
+import java.util.Arrays;
 
 /**
  * The Class UnionTest.
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class UnionTest extends BaseCodedNodeGraphTest {
 
     /**
@@ -45,23 +43,23 @@ public class UnionTest extends BaseCodedNodeGraphTest {
      */
     public void testMultipleToNodeListUnionsWithPropertyRestriction() throws Exception {
     	CodedNodeSet cns1 = 
-			LexBIGServiceImpl.defaultInstance().getNodeGraph(AUTO_SCHEME, null, null).toNodeList(
+			this.lbs.getNodeGraph(AUTO_SCHEME, null, null).toNodeList(
 					Constructors.createConceptReference("A0001", AUTO_SCHEME), true, false, 0, -1);
 		
 		CodedNodeSet cns2 = 
-			LexBIGServiceImpl.defaultInstance().getNodeGraph(AUTO_SCHEME, null, null).toNodeList(
+			this.lbs.getNodeGraph(AUTO_SCHEME, null, null).toNodeList(
 					Constructors.createConceptReference("T0001", AUTO_SCHEME), true, false, 0, -1);
 		
 		CodedNodeSet cns3 = 
-			LexBIGServiceImpl.defaultInstance().getNodeGraph(AUTO_SCHEME, null, null).toNodeList(
+			this.lbs.getNodeGraph(AUTO_SCHEME, null, null).toNodeList(
 					Constructors.createConceptReference("C0001", AUTO_SCHEME), true, false, 0, -1);
 		
 		CodedNodeSet cns4 = 
-			LexBIGServiceImpl.defaultInstance().getNodeGraph(AUTO_SCHEME, null, null).toNodeList(
+			this.lbs.getNodeGraph(AUTO_SCHEME, null, null).toNodeList(
 					Constructors.createConceptReference("Ford", AUTO_SCHEME), true, false, 0, -1);
 		
 		CodedNodeSet cns5 = 
-			LexBIGServiceImpl.defaultInstance().getNodeGraph(AUTO_SCHEME, null, null).toNodeList(
+			this.lbs.getNodeGraph(AUTO_SCHEME, null, null).toNodeList(
 					null, true, false, -1, -1);
 		
 		cns5 = cns5.restrictToMatchingDesignations("General", SearchDesignationOption.ALL, "LuceneQuery", null);
@@ -85,23 +83,23 @@ public class UnionTest extends BaseCodedNodeGraphTest {
     
     public void testMultipleToNodeListUnionsWithOverallPropertyRestriction() throws Exception {
     	CodedNodeSet cns1 = 
-			LexBIGServiceImpl.defaultInstance().getNodeGraph(AUTO_SCHEME, null, null).toNodeList(
+			this.lbs.getNodeGraph(AUTO_SCHEME, null, null).toNodeList(
 					Constructors.createConceptReference("A0001", AUTO_SCHEME), true, false, 0, -1);
 		
 		CodedNodeSet cns2 = 
-			LexBIGServiceImpl.defaultInstance().getNodeGraph(AUTO_SCHEME, null, null).toNodeList(
+			this.lbs.getNodeGraph(AUTO_SCHEME, null, null).toNodeList(
 					Constructors.createConceptReference("T0001", AUTO_SCHEME), true, false, 0, -1);
 		
 		CodedNodeSet cns3 = 
-			LexBIGServiceImpl.defaultInstance().getNodeGraph(AUTO_SCHEME, null, null).toNodeList(
+			this.lbs.getNodeGraph(AUTO_SCHEME, null, null).toNodeList(
 					Constructors.createConceptReference("C0001", AUTO_SCHEME), true, false, 0, -1);
 		
 		CodedNodeSet cns4 = 
-			LexBIGServiceImpl.defaultInstance().getNodeGraph(AUTO_SCHEME, null, null).toNodeList(
+			this.lbs.getNodeGraph(AUTO_SCHEME, null, null).toNodeList(
 					Constructors.createConceptReference("Ford", AUTO_SCHEME), true, false, 0, -1);
 		
 		CodedNodeSet cns5 = 
-			LexBIGServiceImpl.defaultInstance().getNodeGraph(AUTO_SCHEME, null, null).toNodeList(
+			this.lbs.getNodeGraph(AUTO_SCHEME, null, null).toNodeList(
 					null, true, false, -1, -1);
 		
 		CodedNodeSet cns6 = cns1.union(cns2).union(cns3).union(cns4).union(cns5);

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodeset/CodedNodeSetOperationsTest.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodeset/CodedNodeSetOperationsTest.java
@@ -56,26 +56,26 @@ public class CodedNodeSetOperationsTest extends BaseCodedNodeSetTest {
         super.setUp();
         try {
             CodedNodeSet unionedCodedNodeSetPart1 = lbs.getCodingSchemeConcepts(AUTO_SCHEME, null);
-            unionedCodedNodeSetPart1.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "005", "Chevy" }, "Automobiles"));
+            unionedCodedNodeSetPart1 = unionedCodedNodeSetPart1.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "005", "Chevy" }, "Automobiles"));
             
             CodedNodeSet unionedCodedNodeSetPart2 = lbs.getCodingSchemeConcepts(AUTO_SCHEME, null);
-            unionedCodedNodeSetPart2.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "GM" }, "Automobiles"));
+            unionedCodedNodeSetPart2 = unionedCodedNodeSetPart2.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "GM" }, "Automobiles"));
             
             unionedCodedNodeSet = unionedCodedNodeSetPart1.union(unionedCodedNodeSetPart2);
             
             CodedNodeSet intersectedCodedNodeSetPart1 = lbs.getCodingSchemeConcepts(AUTO_SCHEME, null);
-            intersectedCodedNodeSetPart1.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "005", "Chevy" }, "Automobiles"));
+            intersectedCodedNodeSetPart1 = intersectedCodedNodeSetPart1.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "005", "Chevy" }, "Automobiles"));
             
             CodedNodeSet intersectedCodedNodeSetPart2 = lbs.getCodingSchemeConcepts(AUTO_SCHEME, null);
-            intersectedCodedNodeSetPart2.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "Chevy", "GM" }, "Automobiles"));
+            intersectedCodedNodeSetPart2 = intersectedCodedNodeSetPart2.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "Chevy", "GM" }, "Automobiles"));
             
             intersectedCodedNodeSet = intersectedCodedNodeSetPart1.intersect(intersectedCodedNodeSetPart2);
             
             CodedNodeSet differencedCodedNodeSetPart1 = lbs.getCodingSchemeConcepts(AUTO_SCHEME, null);
-            differencedCodedNodeSetPart1.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "005", "Chevy" }, "Automobiles"));
+            differencedCodedNodeSetPart1 = differencedCodedNodeSetPart1.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "005", "Chevy" }, "Automobiles"));
             
             CodedNodeSet differencedCodedNodeSetPart2 = lbs.getCodingSchemeConcepts(AUTO_SCHEME, null);
-            differencedCodedNodeSetPart2.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "Chevy", "GM" }, "Automobiles"));
+            differencedCodedNodeSetPart2 = differencedCodedNodeSetPart2.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "Chevy", "GM" }, "Automobiles"));
             
             differencedCodedNodeSet = differencedCodedNodeSetPart1.difference(differencedCodedNodeSetPart2);
         } catch (Exception e) {
@@ -90,8 +90,8 @@ public class CodedNodeSetOperationsTest extends BaseCodedNodeSetTest {
    * @throws Exception the exception
    */
   public void testIntersectAUnion() throws Exception {
-        
-        cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "005", "GM" }, "Automobiles"));
+
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "005", "GM" }, "Automobiles"));
 
         CodedNodeSet result = cns.intersect(unionedCodedNodeSet);
 
@@ -108,8 +108,8 @@ public class CodedNodeSetOperationsTest extends BaseCodedNodeSetTest {
      * @throws Exception the exception
      */
     public void testUnionAnIntersection() throws Exception {
-        
-        cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "005", "Chevy" }, "Automobiles"));
+
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "005", "Chevy" }, "Automobiles"));
 
         CodedNodeSet result = cns.union(intersectedCodedNodeSet);
 
@@ -127,7 +127,7 @@ public class CodedNodeSetOperationsTest extends BaseCodedNodeSetTest {
   */
  public void testIntersectADifference() throws Exception {
         
-        cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "005", "Chevy" }, "Automobiles"));
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "005", "Chevy" }, "Automobiles"));
 
         CodedNodeSet result = cns.intersect(differencedCodedNodeSet);
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodeset/CodedNodeSetOperationsTest.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodeset/CodedNodeSetOperationsTest.java
@@ -21,12 +21,14 @@ package org.LexGrid.LexBIG.Impl.function.codednodeset;
 import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.Utility.Constructors;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
 /**
  * The Class CodedNodeSetOperationsTest.
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class CodedNodeSetOperationsTest extends BaseCodedNodeSetTest {
     
     /** The unioned coded node set. */

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodeset/DifferenceTest.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodeset/DifferenceTest.java
@@ -18,23 +18,25 @@
  */
 package org.LexGrid.LexBIG.Impl.function.codednodeset;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
-
 import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
 import org.LexGrid.LexBIG.Exceptions.LBException;
 import org.LexGrid.LexBIG.Impl.function.LexBIGServiceTestCase;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.Utility.Constructors;
 import org.LexGrid.LexBIG.Utility.Iterators.ResolvedConceptReferencesIterator;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 import org.junit.Ignore;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * The Class DifferenceTest.
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class DifferenceTest extends BaseCodedNodeSetTest {
     
     /** The cns2. */
@@ -71,10 +73,10 @@ public class DifferenceTest extends BaseCodedNodeSetTest {
     @Ignore
     public void testDifference() throws LBException {
 
-        cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "005", "Chevy", "Ford", "A0001" },
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "005", "Chevy", "Ford", "A0001" },
                 "Automobiles"));
 
-        cns2.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "Ford", "005" }, "Automobiles"));
+        cns2 = cns2.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "Ford", "005" }, "Automobiles"));
 
         CodedNodeSet difference = cns.difference(cns2);
 
@@ -92,10 +94,10 @@ public class DifferenceTest extends BaseCodedNodeSetTest {
      */
     public void testDifferenceCorrectSetTheoryExample() throws LBException {
 
-        cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "005", "Chevy" },
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "005", "Chevy" },
                 "Automobiles"));
 
-        cns2.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "005", "A0001" }, "Automobiles"));
+        cns2 = cns2.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "005", "A0001" }, "Automobiles"));
 
         CodedNodeSet difference = cns.difference(cns2);
 
@@ -112,10 +114,10 @@ public class DifferenceTest extends BaseCodedNodeSetTest {
      */
     public void testDifferenceCorrectSetTheoryExampleOtherWay() throws LBException {
 
-        cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "005", "Chevy" },
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "005", "Chevy" },
                 "Automobiles"));
 
-        cns2.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "005", "A0001" }, "Automobiles"));
+        cns2 = cns2.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "005", "A0001" }, "Automobiles"));
 
         CodedNodeSet difference =  cns2.difference(cns);
 
@@ -132,10 +134,10 @@ public class DifferenceTest extends BaseCodedNodeSetTest {
      */
     public void testDifferenceWithAddedRestriction() throws LBException {
 
-        cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "005", "Chevy", "Ford", "A0001" },
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "005", "Chevy", "Ford", "A0001" },
                 "Automobiles"));
 
-        cns2.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "Ford", "005" }, "Automobiles"));
+        cns2 = cns2.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "Ford", "005" }, "Automobiles"));
 
         CodedNodeSet cns3 = cns.difference(cns2);
         

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodeset/ExtensionCodedNodeSetTest.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodeset/ExtensionCodedNodeSetTest.java
@@ -19,12 +19,14 @@
 package org.LexGrid.LexBIG.Impl.function.codednodeset;
 
 import org.LexGrid.LexBIG.Utility.Constructors;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
 /**
  * The Class ExtensionCodedNodeSetTest.
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class ExtensionCodedNodeSetTest extends BaseCodedNodeSetTest {
     
     

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodeset/IntersectionTest.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodeset/IntersectionTest.java
@@ -24,6 +24,7 @@ import org.LexGrid.LexBIG.Exceptions.LBException;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet.SearchDesignationOption;
 import org.LexGrid.LexBIG.Utility.Constructors;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 import org.LexGrid.util.PrintUtility;
 
 /**
@@ -31,6 +32,7 @@ import org.LexGrid.util.PrintUtility;
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class IntersectionTest extends BaseCodedNodeSetTest {
     
     /** The cns2. */
@@ -68,9 +70,9 @@ public class IntersectionTest extends BaseCodedNodeSetTest {
      */
     public void testIntersection() throws LBException {
 
-        cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "005", "Chevy" }, "Automobiles"));
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "005", "Chevy" }, "Automobiles"));
 
-        cns2.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "Ford", "005" }, "Automobiles"));
+        cns2 = cns2.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "Ford", "005" }, "Automobiles"));
 
         CodedNodeSet intersect = cns.intersect(cns2);
 
@@ -195,9 +197,9 @@ public class IntersectionTest extends BaseCodedNodeSetTest {
      */
     public void testIntersectionWithAddedRestriction() throws LBException {
 
-        cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "005", "Chevy", "Ford" }, "Automobiles"));
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "005", "Chevy", "Ford" }, "Automobiles"));
 
-        cns2.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "Ford", "005" }, "Automobiles"));
+        cns2 = cns2.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "Ford", "005" }, "Automobiles"));
 
         CodedNodeSet cns3 = cns.intersect(cns2);
         

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodeset/IsCodeInSetTest.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodeset/IsCodeInSetTest.java
@@ -22,12 +22,14 @@ import org.LexGrid.LexBIG.Exceptions.LBInvocationException;
 import org.LexGrid.LexBIG.Exceptions.LBParameterException;
 import org.LexGrid.LexBIG.Impl.function.LexBIGServiceTestCase;
 import org.LexGrid.LexBIG.Utility.Constructors;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
 /**
  * The Class IsCodeInSetTest.
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class IsCodeInSetTest extends BaseCodedNodeSetTest {
     
     /* (non-Javadoc)
@@ -69,7 +71,7 @@ public class IsCodeInSetTest extends BaseCodedNodeSetTest {
     * @throws LBParameterException the LB parameter exception
     */
    public void testIsCodeInSetWithRestriction() throws LBInvocationException, LBParameterException{
-       cns.restrictToCodes(Constructors.createConceptReferenceList("A0001"));
+       cns = cns.restrictToCodes(Constructors.createConceptReferenceList("A0001"));
        assertTrue(
                cns.isCodeInSet(
                        Constructors.createConceptReference("A0001", LexBIGServiceTestCase.AUTO_SCHEME )));
@@ -82,7 +84,7 @@ public class IsCodeInSetTest extends BaseCodedNodeSetTest {
     * @throws LBParameterException the LB parameter exception
     */
    public void testIsCodeNotInSetWithRestriction() throws LBInvocationException, LBParameterException{
-       cns.restrictToCodes(Constructors.createConceptReferenceList("T0001"));
+       cns = cns.restrictToCodes(Constructors.createConceptReferenceList("T0001"));
        assertFalse(
                cns.isCodeInSet(
                        Constructors.createConceptReference("A0001", LexBIGServiceTestCase.AUTO_SCHEME )));

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodeset/MultipeRestrictionsTest.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodeset/MultipeRestrictionsTest.java
@@ -25,7 +25,9 @@ import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet.ActiveOption;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet.PropertyType;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet.SearchDesignationOption;
 import org.LexGrid.LexBIG.Utility.Constructors;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
+@RemoteApiSafeTest
 public class MultipeRestrictionsTest extends BaseCodedNodeSetTest {
 
     @Override
@@ -34,8 +36,8 @@ public class MultipeRestrictionsTest extends BaseCodedNodeSetTest {
     }
 
     public void testRestrictDesignationAndHasPropertyType() throws LBException{
-        cns.restrictToMatchingDesignations("automobile", SearchDesignationOption.ALL, "contains", null);
-        cns.restrictToProperties(
+        cns = cns.restrictToMatchingDesignations("automobile", SearchDesignationOption.ALL, "contains", null);
+        cns = cns.restrictToProperties(
         		null, 
         		new PropertyType[]{PropertyType.DEFINITION}, 
         		null, 
@@ -53,8 +55,8 @@ public class MultipeRestrictionsTest extends BaseCodedNodeSetTest {
     }
     
     public void testRestrictDesignationAndDefinition() throws LBException{
-        cns.restrictToMatchingDesignations("automobile", SearchDesignationOption.ALL, "exactMatch", null);
-        cns.restrictToMatchingProperties(null, 
+        cns = cns.restrictToMatchingDesignations("automobile", SearchDesignationOption.ALL, "exactMatch", null);
+        cns = cns.restrictToMatchingProperties(null, 
         		new PropertyType[]{PropertyType.DEFINITION}, 
         		"An automobile", 
         		"exactMatch", 
@@ -71,8 +73,8 @@ public class MultipeRestrictionsTest extends BaseCodedNodeSetTest {
     }
     
     public void testRestrictDesignationAndWrongDefinition() throws LBException{
-        cns.restrictToMatchingDesignations("automobile", SearchDesignationOption.ALL, "contains", null);
-        cns.restrictToMatchingProperties(null, 
+        cns = cns.restrictToMatchingDesignations("automobile", SearchDesignationOption.ALL, "contains", null);
+        cns = cns.restrictToMatchingProperties(null, 
         		new PropertyType[]{PropertyType.DEFINITION}, 
         		"An automobileWRONG", 
         		"exactMatch", 
@@ -85,8 +87,8 @@ public class MultipeRestrictionsTest extends BaseCodedNodeSetTest {
     }
     
     public void testRestrictDesignationAndSource() throws LBException{
-        cns.restrictToMatchingDesignations("Domestic Auto Makers", SearchDesignationOption.ALL, "contains", null);
-        cns.restrictToProperties(
+        cns = cns.restrictToMatchingDesignations("Domestic Auto Makers", SearchDesignationOption.ALL, "contains", null);
+        cns = cns.restrictToProperties(
         		null, 
         		new PropertyType[]{PropertyType.PRESENTATION}, 
         		Constructors.createLocalNameList("lexgrid.org"), 
@@ -104,14 +106,14 @@ public class MultipeRestrictionsTest extends BaseCodedNodeSetTest {
     }
      
     public void testRestrictDesignationAndSourceAndActive() throws LBException{
-        cns.restrictToMatchingDesignations("Domestic Auto Makers", SearchDesignationOption.ALL, "contains", null);
-        cns.restrictToProperties(
+        cns = cns.restrictToMatchingDesignations("Domestic Auto Makers", SearchDesignationOption.ALL, "contains", null);
+        cns = cns.restrictToProperties(
         		null, 
         		new PropertyType[]{PropertyType.PRESENTATION}, 
         		Constructors.createLocalNameList("lexgrid.org"), 
         		null, 
         		null);
-        cns.restrictToStatus(ActiveOption.ACTIVE_ONLY, null);
+        cns = cns.restrictToStatus(ActiveOption.ACTIVE_ONLY, null);
         
         ResolvedConceptReferenceList rcrl = cns.resolveToList(null, null, null, -1);
         
@@ -124,15 +126,15 @@ public class MultipeRestrictionsTest extends BaseCodedNodeSetTest {
     }
     
     public void testRestrictDesignationAndSourceAndActiveAndWrongPresentation() throws LBException{
-        cns.restrictToMatchingDesignations("Domestic Auto Makers", SearchDesignationOption.ALL, "contains", null);
-        cns.restrictToProperties(
+        cns = cns.restrictToMatchingDesignations("Domestic Auto Makers", SearchDesignationOption.ALL, "contains", null);
+        cns = cns.restrictToProperties(
         		null, 
         		new PropertyType[]{PropertyType.PRESENTATION}, 
         		Constructors.createLocalNameList("lexgrid.org"), 
         		null, 
         		null);
-        cns.restrictToStatus(ActiveOption.ACTIVE_ONLY, null);
-        cns.restrictToMatchingDesignations("WRONG__DONT_MATCH_ANYTHING", SearchDesignationOption.ALL, "contains", null);
+        cns = cns.restrictToStatus(ActiveOption.ACTIVE_ONLY, null);
+        cns = cns.restrictToMatchingDesignations("WRONG__DONT_MATCH_ANYTHING", SearchDesignationOption.ALL, "contains", null);
         
         
         ResolvedConceptReferenceList rcrl = cns.resolveToList(null, null, null, -1);
@@ -142,16 +144,16 @@ public class MultipeRestrictionsTest extends BaseCodedNodeSetTest {
     }
     
     public void testRestrictDesignationAndSourceAndActiveAndCode() throws LBException{
-        cns.restrictToMatchingDesignations("Domestic Auto Makers", SearchDesignationOption.ALL, "contains", null);
-        cns.restrictToProperties(
+        cns = cns.restrictToMatchingDesignations("Domestic Auto Makers", SearchDesignationOption.ALL, "contains", null);
+        cns = cns.restrictToProperties(
         		null, 
         		new PropertyType[]{PropertyType.PRESENTATION}, 
         		Constructors.createLocalNameList("lexgrid.org"), 
         		null, 
         		null);
-        cns.restrictToStatus(ActiveOption.ACTIVE_ONLY, null);
+        cns = cns.restrictToStatus(ActiveOption.ACTIVE_ONLY, null);
         
-        cns.restrictToCodes(Constructors.createConceptReferenceList("005"));
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList("005"));
         
         ResolvedConceptReferenceList rcrl = cns.resolveToList(null, null, null, -1);
         
@@ -164,16 +166,16 @@ public class MultipeRestrictionsTest extends BaseCodedNodeSetTest {
     }
     
     public void testRestrictDesignationAndSourceAndActiveAndWrongCode() throws LBException{
-        cns.restrictToMatchingDesignations("Domestic Auto Makers", SearchDesignationOption.ALL, "contains", null);
-        cns.restrictToProperties(
+        cns = cns.restrictToMatchingDesignations("Domestic Auto Makers", SearchDesignationOption.ALL, "contains", null);
+        cns = cns.restrictToProperties(
         		null, 
         		new PropertyType[]{PropertyType.PRESENTATION}, 
         		Constructors.createLocalNameList("lexgrid.org"), 
         		null, 
         		null);
-        cns.restrictToStatus(ActiveOption.ACTIVE_ONLY, null);
+        cns = cns.restrictToStatus(ActiveOption.ACTIVE_ONLY, null);
         
-        cns.restrictToCodes(Constructors.createConceptReferenceList("WRONG_CODE"));
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList("WRONG_CODE"));
         
         ResolvedConceptReferenceList rcrl = cns.resolveToList(null, null, null, -1);
         

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodeset/ResolveTest.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodeset/ResolveTest.java
@@ -248,7 +248,7 @@ public class ResolveTest extends BaseCodedNodeSetTest {
      * @throws Exception the exception
      */
     public void testResolvePropertyNamesPresentation() throws Exception {
-        cns.restrictToCodes(Constructors.createConceptReferenceList("A0001"));
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList("A0001"));
         ResolvedConceptReferencesIterator itr = cns.resolve(null, null, Constructors.createLocalNameList("textualPresentation"), null, true);  
         
         ResolvedConceptReference ref = itr.next();
@@ -267,7 +267,7 @@ public class ResolveTest extends BaseCodedNodeSetTest {
      * @throws LBException the LB exception
      */
     public void testResolvePropertyNamesDefinition() throws LBException{
-        cns.restrictToCodes(Constructors.createConceptReferenceList("A0001"));
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList("A0001"));
         ResolvedConceptReferencesIterator itr = cns.resolve(null, null, Constructors.createLocalNameList("definition"), null, true);     
         
         ResolvedConceptReference ref = itr.next();
@@ -287,7 +287,7 @@ public class ResolveTest extends BaseCodedNodeSetTest {
      * @throws LBException the LB exception
      */
     public void testResolvePropertyTypesPresentation() throws LBException{
-        cns.restrictToCodes(Constructors.createConceptReferenceList("A0001"));
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList("A0001"));
         ResolvedConceptReferencesIterator itr = cns.resolve(null, null, null, new PropertyType[]{PropertyType.PRESENTATION}, true);
 
         ResolvedConceptReference ref = itr.next();
@@ -307,7 +307,7 @@ public class ResolveTest extends BaseCodedNodeSetTest {
      * @throws LBException the LB exception
      */
     public void testResolvePropertyTypesDefinition() throws LBException{
-        cns.restrictToCodes(Constructors.createConceptReferenceList("A0001"));
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList("A0001"));
         ResolvedConceptReferencesIterator itr = cns.resolve(null, null, null, new PropertyType[]{PropertyType.DEFINITION}, true);
 
         ResolvedConceptReference ref = itr.next();

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodeset/ResolveToListTest.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodeset/ResolveToListTest.java
@@ -28,12 +28,14 @@ import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet.PropertyType;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet.SearchDesignationOption;
 import org.LexGrid.LexBIG.Utility.Constructors;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
 /**
  * The Class ResolveToListTest.
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class ResolveToListTest extends BaseCodedNodeSetTest {
     
     /**
@@ -147,8 +149,8 @@ public class ResolveToListTest extends BaseCodedNodeSetTest {
         CodedNodeSet cns2 = lbs.getCodingSchemeConcepts(PARTS_SCHEME, null);
         
         CodedNodeSet union = cns.union(cns2);
-        
-        union.restrictToMatchingDesignations("(rims^5 OR automobile OR truck^4 OR piston )", SearchDesignationOption.ALL, "LuceneQuery", null);
+
+        union = union.restrictToMatchingDesignations("(rims^5 OR automobile OR truck^4 OR piston )", SearchDesignationOption.ALL, "LuceneQuery", null);
 
         ResolvedConceptReference[] refs = union.resolveToList(
                 Constructors.createSortOptionList(new String[]{"matchToQuery"}), null, null, -1).getResolvedConceptReference();
@@ -162,8 +164,8 @@ public class ResolveToListTest extends BaseCodedNodeSetTest {
          CodedNodeSet cns2 = lbs.getCodingSchemeConcepts(PARTS_SCHEME, null);
          
          CodedNodeSet union = cns2.union(cns);
-         
-         union.restrictToMatchingDesignations("( automobile OR truck^4 OR piston OR rims^5 )", SearchDesignationOption.ALL, "LuceneQuery", null);
+
+         union = union.restrictToMatchingDesignations("( automobile OR truck^4 OR piston OR rims^5 )", SearchDesignationOption.ALL, "LuceneQuery", null);
 
          ResolvedConceptReference[] refs = union.resolveToList(
                  Constructors.createSortOptionList(new String[]{"matchToQuery"}), null, null, -1).getResolvedConceptReference();
@@ -212,7 +214,7 @@ public class ResolveToListTest extends BaseCodedNodeSetTest {
      * @throws LBException the LB exception
      */
     public void testResolvePropertyNamesPresentation() throws LBException{
-        cns.restrictToCodes(Constructors.createConceptReferenceList("A0001"));
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList("A0001"));
         ResolvedConceptReferenceList rcrl = cns.resolveToList(null, null, Constructors.createLocalNameList("textualPresentation"), null, -1);
        
         assertTrue(rcrl.getResolvedConceptReference().length == 1);  
@@ -232,7 +234,7 @@ public class ResolveToListTest extends BaseCodedNodeSetTest {
      * @throws LBException the LB exception
      */
     public void testResolvePropertyNamesDefinition() throws LBException{
-        cns.restrictToCodes(Constructors.createConceptReferenceList("A0001"));
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList("A0001"));
         ResolvedConceptReferenceList rcrl = cns.resolveToList(null, null, Constructors.createLocalNameList("definition"), null, -1);
 
         assertTrue(rcrl.getResolvedConceptReference().length == 1);  
@@ -252,7 +254,7 @@ public class ResolveToListTest extends BaseCodedNodeSetTest {
      * @throws LBException the LB exception
      */
     public void testResolvePropertyTypesPresentation() throws LBException{
-        cns.restrictToCodes(Constructors.createConceptReferenceList("A0001"));
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList("A0001"));
         ResolvedConceptReferenceList rcrl = cns.resolveToList(null, null, null, new PropertyType[]{PropertyType.PRESENTATION}, -1);
 
         assertTrue(rcrl.getResolvedConceptReference().length == 1);  
@@ -272,7 +274,7 @@ public class ResolveToListTest extends BaseCodedNodeSetTest {
      * @throws LBException the LB exception
      */
     public void testResolvePropertyTypesDefinition() throws LBException{
-        cns.restrictToCodes(Constructors.createConceptReferenceList("A0001"));
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList("A0001"));
         ResolvedConceptReferenceList rcrl = cns.resolveToList(null, null, null, new PropertyType[]{PropertyType.DEFINITION}, -1);
 
         assertTrue(rcrl.getResolvedConceptReference().length == 1);  

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodeset/RestrictToMatchingDesignationsTest.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodeset/RestrictToMatchingDesignationsTest.java
@@ -23,7 +23,9 @@ import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
 import org.LexGrid.LexBIG.Exceptions.LBException;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet.SearchDesignationOption;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
+@RemoteApiSafeTest
 public class RestrictToMatchingDesignationsTest extends BaseCodedNodeSetTest {
 
     @Override
@@ -33,7 +35,7 @@ public class RestrictToMatchingDesignationsTest extends BaseCodedNodeSetTest {
 
     public void testRestrictToMatchingDesignationsNodeSet() throws LBException{
     	CodedNodeSet cns = lbs.getNodeSet(AUTO_SCHEME, null, null);
-        cns.restrictToMatchingDesignations("General Motors", SearchDesignationOption.ALL, "contains", null);
+        cns = cns.restrictToMatchingDesignations("General Motors", SearchDesignationOption.ALL, "contains", null);
         
         ResolvedConceptReferenceList rcrl = cns.resolveToList(null, null, null, -1);
 
@@ -45,7 +47,7 @@ public class RestrictToMatchingDesignationsTest extends BaseCodedNodeSetTest {
     }
      
     public void testRestrictToMatchingDesignationsALL() throws LBException{
-        cns.restrictToMatchingDesignations("Domestic", SearchDesignationOption.ALL, "contains", null);
+        cns = cns.restrictToMatchingDesignations("Domestic", SearchDesignationOption.ALL, "contains", null);
         
         ResolvedConceptReferenceList rcrl = cns.resolveToList(null, null, null, -1);
 
@@ -57,7 +59,7 @@ public class RestrictToMatchingDesignationsTest extends BaseCodedNodeSetTest {
     }
     
     public void testRestrictToMatchingDesignationsPreferredOnlyMatch() throws LBException{
-        cns.restrictToMatchingDesignations("Domestic", SearchDesignationOption.PREFERRED_ONLY, "contains", null);
+        cns = cns.restrictToMatchingDesignations("Domestic", SearchDesignationOption.PREFERRED_ONLY, "contains", null);
         
         ResolvedConceptReferenceList rcrl = cns.resolveToList(null, null, null, -1);
 
@@ -69,7 +71,7 @@ public class RestrictToMatchingDesignationsTest extends BaseCodedNodeSetTest {
     }
     
     public void testRestrictToMatchingDesignationsPreferredOnlyNoMatch() throws LBException{
-        cns.restrictToMatchingDesignations("American", SearchDesignationOption.PREFERRED_ONLY, "contains", null);
+        cns = cns.restrictToMatchingDesignations("American", SearchDesignationOption.PREFERRED_ONLY, "contains", null);
         
         ResolvedConceptReferenceList rcrl = cns.resolveToList(null, null, null, -1);
 
@@ -77,7 +79,7 @@ public class RestrictToMatchingDesignationsTest extends BaseCodedNodeSetTest {
     }
     
     public void testRestrictToMatchingDesignationsNonPreferredOnlyMatch() throws LBException{
-        cns.restrictToMatchingDesignations("American", SearchDesignationOption.NON_PREFERRED_ONLY, "contains", null);
+        cns = cns.restrictToMatchingDesignations("American", SearchDesignationOption.NON_PREFERRED_ONLY, "contains", null);
         
         ResolvedConceptReferenceList rcrl = cns.resolveToList(null, null, null, -1);
 
@@ -89,7 +91,7 @@ public class RestrictToMatchingDesignationsTest extends BaseCodedNodeSetTest {
     }
     
     public void testRestrictToMatchingDesignationsNonPreferredOnlyNoMatch() throws LBException{
-        cns.restrictToMatchingDesignations("Domestic", SearchDesignationOption.NON_PREFERRED_ONLY, "contains", null);
+        cns = cns.restrictToMatchingDesignations("Domestic", SearchDesignationOption.NON_PREFERRED_ONLY, "contains", null);
         
         ResolvedConceptReferenceList rcrl = cns.resolveToList(null, null, null, -1);
 
@@ -97,7 +99,7 @@ public class RestrictToMatchingDesignationsTest extends BaseCodedNodeSetTest {
     }
     
     public void testRestrictToMatchingDesignationsLanguage() throws LBException{
-        cns.restrictToMatchingDesignations("Truck", SearchDesignationOption.ALL, "contains", "en");
+        cns = cns.restrictToMatchingDesignations("Truck", SearchDesignationOption.ALL, "contains", "en");
         
         ResolvedConceptReferenceList rcrl = cns.resolveToList(null, null, null, -1);
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodeset/RestrictToMatchingPropertiesTest.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodeset/RestrictToMatchingPropertiesTest.java
@@ -25,7 +25,9 @@ import org.LexGrid.LexBIG.Exceptions.LBInvocationException;
 import org.LexGrid.LexBIG.Exceptions.LBParameterException;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet.PropertyType;
 import org.LexGrid.LexBIG.Utility.Constructors;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
+@RemoteApiSafeTest
 public class RestrictToMatchingPropertiesTest extends BaseCodedNodeSetTest {
 
     @Override
@@ -36,7 +38,7 @@ public class RestrictToMatchingPropertiesTest extends BaseCodedNodeSetTest {
     public void testRestrictToMatchingPropertiesError() throws LBInvocationException {
 
         try {
-            cns.restrictToMatchingProperties(null, null, "Domestic", "contains", null);
+            cns = cns.restrictToMatchingProperties(null, null, "Domestic", "contains", null);
             ResolvedConceptReferenceList rcrl = cns.resolveToList(null, null, null, -1);
         } catch (LBParameterException e) {
             //this is good - pass the test.
@@ -48,7 +50,7 @@ public class RestrictToMatchingPropertiesTest extends BaseCodedNodeSetTest {
     }
     
     public void testRestrictToMatchingPropertiesPropertyNameMatch() throws LBException{
-        cns.restrictToMatchingProperties(Constructors.createLocalNameList("definition"), null, "an automobile", "contains", null);
+        cns = cns.restrictToMatchingProperties(Constructors.createLocalNameList("definition"), null, "an automobile", "contains", null);
         
         ResolvedConceptReferenceList rcrl = cns.resolveToList(null, null, null, -1);
 
@@ -60,7 +62,7 @@ public class RestrictToMatchingPropertiesTest extends BaseCodedNodeSetTest {
     }
     
     public void testRestrictToMatchingPropertiesPropertyNameNoMatch() throws LBException{
-        cns.restrictToMatchingProperties(Constructors.createLocalNameList("textualPresentation"), null, "An", "startsWith", null);
+        cns = cns.restrictToMatchingProperties(Constructors.createLocalNameList("textualPresentation"), null, "An", "startsWith", null);
         
         ResolvedConceptReferenceList rcrl = cns.resolveToList(null, null, null, -1);
 
@@ -68,7 +70,7 @@ public class RestrictToMatchingPropertiesTest extends BaseCodedNodeSetTest {
     }
     
     public void testRestrictToMatchingPropertiesPropertyTypeMatch() throws LBException{
-        cns.restrictToMatchingProperties(null, new PropertyType[]{PropertyType.DEFINITION}, "An", "startsWith", null);
+        cns = cns.restrictToMatchingProperties(null, new PropertyType[]{PropertyType.DEFINITION}, "An", "startsWith", null);
         
         ResolvedConceptReferenceList rcrl = cns.resolveToList(null, null, null, -1);
 
@@ -80,7 +82,7 @@ public class RestrictToMatchingPropertiesTest extends BaseCodedNodeSetTest {
     }
     
     public void testRestrictToMatchingPropertiesPropertyTypeNoMatch() throws LBException{
-        cns.restrictToMatchingProperties(null, new PropertyType[]{PropertyType.PRESENTATION}, "An", "startsWith", null);
+        cns = cns.restrictToMatchingProperties(null, new PropertyType[]{PropertyType.PRESENTATION}, "An", "startsWith", null);
           
         ResolvedConceptReferenceList rcrl = cns.resolveToList(null, null, null, -1);
 
@@ -88,7 +90,7 @@ public class RestrictToMatchingPropertiesTest extends BaseCodedNodeSetTest {
     }
     
     public void testRestrictToMatchingPropertiesPropertyGenericProperty() throws LBException{
-        cns.restrictToMatchingProperties(null, new PropertyType[]{PropertyType.GENERIC}, "A Generic Property", "exactMatch", null);
+        cns = cns.restrictToMatchingProperties(null, new PropertyType[]{PropertyType.GENERIC}, "A Generic Property", "exactMatch", null);
           
         ResolvedConceptReferenceList rcrl = cns.resolveToList(null, null, null, -1);
 
@@ -102,7 +104,7 @@ public class RestrictToMatchingPropertiesTest extends BaseCodedNodeSetTest {
     public void testRestrictToMatchingPropertiesPropertySearchAllProperties() throws LBException{
     	PropertyType[] types = new PropertyType[]{PropertyType.GENERIC, PropertyType.COMMENT, PropertyType.DEFINITION, PropertyType.PRESENTATION};
     	
-        cns.restrictToMatchingProperties(null, types, "A Generic Property", "exactMatch", null);
+        cns = cns.restrictToMatchingProperties(null, types, "A Generic Property", "exactMatch", null);
           
         ResolvedConceptReferenceList rcrl = cns.resolveToList(null, null, null, -1);
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodeset/RestrictToPropertiesTest.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodeset/RestrictToPropertiesTest.java
@@ -22,7 +22,9 @@ import org.LexGrid.LexBIG.DataModel.Collections.ResolvedConceptReferenceList;
 import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
 import org.LexGrid.LexBIG.Exceptions.LBException;
 import org.LexGrid.LexBIG.Utility.Constructors;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
+@RemoteApiSafeTest
 public class RestrictToPropertiesTest extends BaseCodedNodeSetTest {
 
     @Override
@@ -31,8 +33,8 @@ public class RestrictToPropertiesTest extends BaseCodedNodeSetTest {
     }
 
     public void testRestrictToProperty() throws LBException{
-        cns.restrictToCodes(Constructors.createConceptReferenceList("A0001"));
-        cns.restrictToProperties(Constructors.createLocalNameList("textualPresentation"), null);
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList("A0001"));
+        cns = cns.restrictToProperties(Constructors.createLocalNameList("textualPresentation"), null);
         
         ResolvedConceptReferenceList rcrl = cns.resolveToList(null, null, null, -1);
 
@@ -44,8 +46,8 @@ public class RestrictToPropertiesTest extends BaseCodedNodeSetTest {
     }
     
     public void testRestrictToPropertyDefinition() throws LBException{
-        cns.restrictToCodes(Constructors.createConceptReferenceList("A0001"));
-        cns.restrictToProperties(Constructors.createLocalNameList("definition"), null);
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList("A0001"));
+        cns = cns.restrictToProperties(Constructors.createLocalNameList("definition"), null);
         
         ResolvedConceptReferenceList rcrl = cns.resolveToList(null, null, null, -1);
 
@@ -57,8 +59,8 @@ public class RestrictToPropertiesTest extends BaseCodedNodeSetTest {
     }
     
     public void testRestrictToPropertyTwo() throws LBException{
-        cns.restrictToCodes(Constructors.createConceptReferenceList("A0001"));
-        cns.restrictToProperties(Constructors.createLocalNameList(new String[]{"definition", "textualPresentation"}), null);
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList("A0001"));
+        cns = cns.restrictToProperties(Constructors.createLocalNameList(new String[]{"definition", "textualPresentation"}), null);
         
         ResolvedConceptReferenceList rcrl = cns.resolveToList(null, null, null, -1);
 
@@ -70,9 +72,9 @@ public class RestrictToPropertiesTest extends BaseCodedNodeSetTest {
     }
     
     public void testRestrictToPropertyTwoSeperate() throws LBException{
-        cns.restrictToCodes(Constructors.createConceptReferenceList("A0001"));
-        cns.restrictToProperties(Constructors.createLocalNameList(new String[]{"definition"}), null);
-        cns.restrictToProperties(Constructors.createLocalNameList(new String[]{"textualPresentation"}), null);
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList("A0001"));
+        cns = cns.restrictToProperties(Constructors.createLocalNameList(new String[]{"definition"}), null);
+        cns = cns.restrictToProperties(Constructors.createLocalNameList(new String[]{"textualPresentation"}), null);
         
         ResolvedConceptReferenceList rcrl = cns.resolveToList(null, null, null, -1);
 
@@ -84,8 +86,8 @@ public class RestrictToPropertiesTest extends BaseCodedNodeSetTest {
     }
     
     public void testRestrictToWrongProperty() throws LBException{
-        cns.restrictToCodes(Constructors.createConceptReferenceList("73"));
-        cns.restrictToProperties(Constructors.createLocalNameList("definition"), null);
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList("73"));
+        cns = cns.restrictToProperties(Constructors.createLocalNameList("definition"), null);
         
         ResolvedConceptReferenceList rcrl = cns.resolveToList(null, null, null, -1);
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodeset/UnionTest.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/codednodeset/UnionTest.java
@@ -20,20 +20,18 @@ package org.LexGrid.LexBIG.Impl.function.codednodeset;
 
 import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
 import org.LexGrid.LexBIG.Exceptions.LBException;
-import org.LexGrid.LexBIG.Exceptions.LBInvocationException;
-import org.LexGrid.LexBIG.Exceptions.LBParameterException;
-import org.LexGrid.LexBIG.Impl.LexBIGServiceImpl;
 import org.LexGrid.LexBIG.Impl.function.LexBIGServiceTestCase;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet.SearchDesignationOption;
 import org.LexGrid.LexBIG.Utility.Constructors;
-import org.LexGrid.util.PrintUtility;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
 /**
  * The Class UnionTest.
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class UnionTest extends BaseCodedNodeSetTest {
     
     /** The cns2. */
@@ -71,9 +69,9 @@ public class UnionTest extends BaseCodedNodeSetTest {
      */
     public void testUnion() throws LBException {
         
-        cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "005" }, LexBIGServiceTestCase.AUTO_SCHEME));
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "005" }, LexBIGServiceTestCase.AUTO_SCHEME));
 
-        cns2.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "Ford" }, LexBIGServiceTestCase.AUTO_SCHEME));
+        cns2 = cns2.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "Ford" }, LexBIGServiceTestCase.AUTO_SCHEME));
 
         CodedNodeSet cnsUnion = cns.union(cns2);
 
@@ -91,13 +89,13 @@ public class UnionTest extends BaseCodedNodeSetTest {
      */
     public void testUnionWithAddedRestriction() throws LBException {
         
-        cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "005" }, LexBIGServiceTestCase.AUTO_SCHEME));
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "005" }, LexBIGServiceTestCase.AUTO_SCHEME));
 
-        cns2.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "Ford" }, LexBIGServiceTestCase.AUTO_SCHEME));
+        cns2 = cns2.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "Ford" }, LexBIGServiceTestCase.AUTO_SCHEME));
 
         CodedNodeSet cns3 = cns.union(cns2);
         
-        cns3.restrictToCodes(Constructors.createConceptReferenceList("005"));
+        cns3 = cns3.restrictToCodes(Constructors.createConceptReferenceList("005"));
 
         ResolvedConceptReference[] rcr = cns3.resolveToList(null, null, null, 50).getResolvedConceptReference();
 
@@ -112,7 +110,7 @@ public class UnionTest extends BaseCodedNodeSetTest {
      */
     public void testUnionToSelf() throws LBException {
 
-        cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "005" }, LexBIGServiceTestCase.AUTO_SCHEME));
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "005" }, LexBIGServiceTestCase.AUTO_SCHEME));
 
         CodedNodeSet union = cns.union(cns);
 
@@ -129,10 +127,10 @@ public class UnionTest extends BaseCodedNodeSetTest {
      */
     public void testUnionCrossCodingScheme() throws LBException {
 
-        cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "005" }, LexBIGServiceTestCase.AUTO_SCHEME));
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "005" }, LexBIGServiceTestCase.AUTO_SCHEME));
 
         CodedNodeSet gmCns = lbs.getCodingSchemeConcepts(LexBIGServiceTestCase.PARTS_SCHEME, null);
-        gmCns.restrictToCodes(Constructors.createConceptReferenceList("P0001"));
+        gmCns = gmCns.restrictToCodes(Constructors.createConceptReferenceList("P0001"));
         
         CodedNodeSet union = cns.union(gmCns);
 
@@ -150,11 +148,11 @@ public class UnionTest extends BaseCodedNodeSetTest {
      */
     public void testUnionToAUnion() throws LBException {
 
-        cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "005" }, LexBIGServiceTestCase.AUTO_SCHEME));
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "005" }, LexBIGServiceTestCase.AUTO_SCHEME));
         
-        cns2.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "Ford" }, LexBIGServiceTestCase.AUTO_SCHEME));
+        cns2 = cns2.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "Ford" }, LexBIGServiceTestCase.AUTO_SCHEME));
         
-        cns3.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "GM" }, LexBIGServiceTestCase.AUTO_SCHEME));
+        cns3 = cns3.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "GM" }, LexBIGServiceTestCase.AUTO_SCHEME));
 
         CodedNodeSet union = cns.union(cns2);
         
@@ -175,11 +173,11 @@ public class UnionTest extends BaseCodedNodeSetTest {
      */
     public void testUnionWithAUnion() throws LBException {
 
-        cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "005" }, LexBIGServiceTestCase.AUTO_SCHEME));
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "005" }, LexBIGServiceTestCase.AUTO_SCHEME));
         
-        cns2.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "Ford" }, LexBIGServiceTestCase.AUTO_SCHEME));
+        cns2 = cns2.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "Ford" }, LexBIGServiceTestCase.AUTO_SCHEME));
         
-        cns3.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "GM" }, LexBIGServiceTestCase.AUTO_SCHEME));
+        cns3 = cns3.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "GM" }, LexBIGServiceTestCase.AUTO_SCHEME));
 
         CodedNodeSet union = cns.union(cns2);
         

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/mapping/MappingToNodeListTest.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/mapping/MappingToNodeListTest.java
@@ -18,21 +18,23 @@
  */
 package org.LexGrid.LexBIG.Impl.function.mapping;
 
-import java.util.HashSet;
-import java.util.Set;
-
 import org.LexGrid.LexBIG.Impl.function.LexBIGServiceTestCase;
 import org.LexGrid.LexBIG.Impl.testUtility.ServiceHolder;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeGraph;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.LexBIGService.LexBIGService;
 import org.LexGrid.LexBIG.Utility.Iterators.ResolvedConceptReferencesIterator;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
+
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * The Class MappingTest.
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class MappingToNodeListTest extends LexBIGServiceTestCase {
 
 	@Override

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestApproximateStringMatch.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestApproximateStringMatch.java
@@ -39,7 +39,7 @@ public class TestApproximateStringMatch extends LexBIGServiceTestCase {
 
         CodedNodeSet cns = ServiceHolder.instance().getLexBIGService().getCodingSchemeConcepts(THES_SCHEME, null);
 
-        cns.restrictToMatchingDesignations("heaart base", SearchDesignationOption.ALL, "DoubleMetaphoneLuceneQuery",
+        cns = cns.restrictToMatchingDesignations("heaart base", SearchDesignationOption.ALL, "DoubleMetaphoneLuceneQuery",
                 null);
 
         ResolvedConceptReference[] rcr = cns.resolveToList(null, null, null, 0).getResolvedConceptReference();

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestAttributePresenceMatch.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestAttributePresenceMatch.java
@@ -26,7 +26,9 @@ import org.LexGrid.LexBIG.Exceptions.LBParameterException;
 import org.LexGrid.LexBIG.Impl.function.LexBIGServiceTestCase;
 import org.LexGrid.LexBIG.Impl.testUtility.ServiceHolder;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
+@RemoteApiSafeTest
 public class TestAttributePresenceMatch extends LexBIGServiceTestCase {
     final static String testID = "T1_FNC_14";
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestChildIndicator.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestChildIndicator.java
@@ -26,7 +26,9 @@ import org.LexGrid.LexBIG.Impl.function.LexBIGServiceTestCase;
 import org.LexGrid.LexBIG.Impl.testUtility.ServiceHolder;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeGraph;
 import org.LexGrid.LexBIG.Utility.Constructors;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
+@RemoteApiSafeTest
 public class TestChildIndicator extends LexBIGServiceTestCase {
     final static String testID = "T1_CHILD_INDICATOR";
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestCodingSchemesWithSupportedAssociation.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestCodingSchemesWithSupportedAssociation.java
@@ -24,9 +24,11 @@ import org.LexGrid.LexBIG.Exceptions.LBException;
 import org.LexGrid.LexBIG.Impl.function.LexBIGServiceTestCase;
 import org.LexGrid.LexBIG.Impl.testUtility.ServiceHolder;
 import org.LexGrid.LexBIG.Utility.ConvenienceMethods;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
 //LexBIG Test ID: TEST_FNQRY_CSRNDR_FOR_SUPPASSOC TestCodingSchemesWithSupportedAssociation
 
+@RemoteApiSafeTest
 public class TestCodingSchemesWithSupportedAssociation extends LexBIGServiceTestCase {
     final static String testID = "TEST_FNQRY_CSRNDR_FOR_SUPPASSOC";
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestContentExtraction.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestContentExtraction.java
@@ -26,7 +26,9 @@ import org.LexGrid.LexBIG.Impl.function.LexBIGServiceTestCase;
 import org.LexGrid.LexBIG.Impl.testUtility.ServiceHolder;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.Utility.Iterators.ResolvedConceptReferencesIterator;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
+@RemoteApiSafeTest
 public class TestContentExtraction extends LexBIGServiceTestCase {
     final static String testID = "T1_FNC_01";
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestContentExtraction.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestContentExtraction.java
@@ -26,9 +26,7 @@ import org.LexGrid.LexBIG.Impl.function.LexBIGServiceTestCase;
 import org.LexGrid.LexBIG.Impl.testUtility.ServiceHolder;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.Utility.Iterators.ResolvedConceptReferencesIterator;
-import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
-@RemoteApiSafeTest
 public class TestContentExtraction extends LexBIGServiceTestCase {
     final static String testID = "T1_FNC_01";
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestDescribeSearchTechniques.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestDescribeSearchTechniques.java
@@ -23,7 +23,9 @@ package org.LexGrid.LexBIG.Impl.function.query;
 import org.LexGrid.LexBIG.DataModel.InterfaceElements.ModuleDescription;
 import org.LexGrid.LexBIG.Impl.function.LexBIGServiceTestCase;
 import org.LexGrid.LexBIG.Impl.testUtility.ServiceHolder;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
+@RemoteApiSafeTest
 public class TestDescribeSearchTechniques extends LexBIGServiceTestCase {
     final static String testID = "T1_FNC_26";
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestDescribeSupportedSearchCriteria.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestDescribeSupportedSearchCriteria.java
@@ -23,11 +23,12 @@ package org.LexGrid.LexBIG.Impl.function.query;
 import org.LexGrid.LexBIG.DataModel.Collections.CodingSchemeRenderingList;
 import org.LexGrid.LexBIG.DataModel.Core.CodingSchemeSummary;
 import org.LexGrid.LexBIG.DataModel.InterfaceElements.CodingSchemeRendering;
-import org.LexGrid.LexBIG.DataModel.InterfaceElements.RenderingDetail;
 import org.LexGrid.LexBIG.Exceptions.LBException;
 import org.LexGrid.LexBIG.Impl.function.LexBIGServiceTestCase;
 import org.LexGrid.LexBIG.Impl.testUtility.ServiceHolder;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
+@RemoteApiSafeTest
 public class TestDescribeSupportedSearchCriteria extends LexBIGServiceTestCase {
     final static String testID = "T1_FNC_27";
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestEnumerateAllConcepts.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestEnumerateAllConcepts.java
@@ -26,7 +26,9 @@ import org.LexGrid.LexBIG.Exceptions.LBException;
 import org.LexGrid.LexBIG.Impl.function.LexBIGServiceTestCase;
 import org.LexGrid.LexBIG.Impl.testUtility.ServiceHolder;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
+@RemoteApiSafeTest
 public class TestEnumerateAllConcepts extends LexBIGServiceTestCase {
     final static String testID = "T1_FNC_28";
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestEnumerateAssociationNames.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestEnumerateAssociationNames.java
@@ -20,14 +20,16 @@ package org.LexGrid.LexBIG.Impl.function.query;
 
 // LexBIG Test ID: T1_FNC_31	TestEnumerateRelationships
 
-import java.util.Arrays;
-import java.util.List;
-
 import org.LexGrid.LexBIG.Exceptions.LBException;
 import org.LexGrid.LexBIG.Impl.function.LexBIGServiceTestCase;
 import org.LexGrid.LexBIG.Impl.testUtility.ServiceHolder;
 import org.LexGrid.LexBIG.Utility.ConvenienceMethods;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
+import java.util.Arrays;
+import java.util.List;
+
+@RemoteApiSafeTest
 public class TestEnumerateAssociationNames extends LexBIGServiceTestCase {
     final static String testID = "TEST_FNQRY_ASSOCIATIONNAME_FOR_CODINGSCHEME";
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestEnumerateProperties.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestEnumerateProperties.java
@@ -27,6 +27,7 @@ import org.LexGrid.LexBIG.Exceptions.LBException;
 import org.LexGrid.LexBIG.Impl.function.LexBIGServiceTestCase;
 import org.LexGrid.LexBIG.Impl.testUtility.ServiceHolder;
 import org.LexGrid.LexBIG.Utility.ConvenienceMethods;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 import org.LexGrid.commonTypes.Property;
 import org.LexGrid.concepts.Entity;
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestEnumerateRelationships.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestEnumerateRelationships.java
@@ -20,8 +20,6 @@ package org.LexGrid.LexBIG.Impl.function.query;
 
 // LexBIG Test ID: T1_FNC_31	TestEnumerateRelationships
 
-import java.util.List;
-
 import org.LexGrid.LexBIG.DataModel.Core.ConceptReference;
 import org.LexGrid.LexBIG.Exceptions.LBException;
 import org.LexGrid.LexBIG.Impl.function.LexBIGServiceTestCase;
@@ -29,7 +27,11 @@ import org.LexGrid.LexBIG.Impl.testUtility.ServiceHolder;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeGraph;
 import org.LexGrid.LexBIG.LexBIGService.LexBIGService;
 import org.LexGrid.LexBIG.Utility.ConvenienceMethods;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
+import java.util.List;
+
+@RemoteApiSafeTest
 public class TestEnumerateRelationships extends LexBIGServiceTestCase {
     final static String testID = "T1_FNC_31";
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestEnumerateSourceConceptsforRelationandTarget.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestEnumerateSourceConceptsforRelationandTarget.java
@@ -45,7 +45,7 @@ public class TestEnumerateSourceConceptsforRelationandTarget extends LexBIGServi
 
         ConvenienceMethods cm = new ConvenienceMethods(ServiceHolder.instance().getLexBIGService());
 
-        cng.restrictToTargetCodes(cm.createCodedNodeSet(new String[] { "Membranous_Labyrinth" }, THES_SCHEME, null));
+        cng = cng.restrictToTargetCodes(cm.createCodedNodeSet(new String[] { "Membranous_Labyrinth" }, THES_SCHEME, null));
 
         ResolvedConceptReference[] rcr = cng.resolveAsList(Constructors.createConceptReference("Membranous_Labyrinth", THES_SCHEME),
                 false, true, 1, 1, null, null, null, 0).getResolvedConceptReference();

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestGenerateDAG.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestGenerateDAG.java
@@ -29,7 +29,9 @@ import org.LexGrid.LexBIG.Impl.testUtility.ServiceHolder;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeGraph;
 import org.LexGrid.LexBIG.LexBIGService.LexBIGService;
 import org.LexGrid.LexBIG.Utility.Constructors;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
+@RemoteApiSafeTest
 public class TestGenerateDAG extends LexBIGServiceTestCase {
     final static String testID = "T1_FNC_04";
 
@@ -41,8 +43,8 @@ public class TestGenerateDAG extends LexBIGServiceTestCase {
     public void testT1_FNC_04() throws LBException {
         LexBIGService lbs = ServiceHolder.instance().getLexBIGService();
         CodedNodeGraph cng = lbs.getNodeGraph(AUTO_SCHEME, null, "relations");
-        
-        cng.restrictToAssociations(Constructors.createNameAndValueList("hasSubtype"), null);
+
+        cng = cng.restrictToAssociations(Constructors.createNameAndValueList("hasSubtype"), null);
 
         ResolvedConceptReference[] rcr = cng.resolveAsList(Constructors.createConceptReference("Ford", AUTO_SCHEME),
                 true, true, 10, -1, null, null, null, 0).getResolvedConceptReference();

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestHierarchyAPI.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestHierarchyAPI.java
@@ -18,8 +18,6 @@
  */
 package org.LexGrid.LexBIG.Impl.function.query;
 
-import java.util.Iterator;
-
 import org.LexGrid.LexBIG.DataModel.Collections.AssociationList;
 import org.LexGrid.LexBIG.DataModel.Collections.ConceptReferenceList;
 import org.LexGrid.LexBIG.DataModel.Collections.ResolvedConceptReferenceList;
@@ -35,6 +33,8 @@ import org.LexGrid.LexBIG.LexBIGService.LexBIGService;
 import org.LexGrid.LexBIG.Utility.Constructors;
 import org.LexGrid.LexBIG.Utility.ConvenienceMethods;
 import org.lexevs.dao.database.service.codednodegraph.model.CountConceptReference;
+
+import java.util.Iterator;
 
 /**
  * This testcase checks that the hierarchy api works as desired.

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestLexicalMatchingTechniques.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestLexicalMatchingTechniques.java
@@ -39,7 +39,7 @@ public class TestLexicalMatchingTechniques extends LexBIGServiceTestCase {
 
         CodedNodeSet cns = ServiceHolder.instance().getLexBIGService().getCodingSchemeConcepts(THES_SCHEME, null);
 
-        cns.restrictToMatchingDesignations("heaart", SearchDesignationOption.ALL, "DoubleMetaphoneLuceneQuery", null);
+        cns = cns.restrictToMatchingDesignations("heaart", SearchDesignationOption.ALL, "DoubleMetaphoneLuceneQuery", null);
 
         ResolvedConceptReference[] rcr = cns.resolveToList(null, null, null, 0).getResolvedConceptReference();
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestLimitReturnedValues.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestLimitReturnedValues.java
@@ -26,7 +26,9 @@ import org.LexGrid.LexBIG.Impl.function.LexBIGServiceTestCase;
 import org.LexGrid.LexBIG.Impl.testUtility.ServiceHolder;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet.SearchDesignationOption;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
+@RemoteApiSafeTest
 public class TestLimitReturnedValues extends LexBIGServiceTestCase {
     final static String testID = "T1_FNC_43";
 
@@ -39,7 +41,7 @@ public class TestLimitReturnedValues extends LexBIGServiceTestCase {
 
         CodedNodeSet cns = ServiceHolder.instance().getLexBIGService().getCodingSchemeConcepts(THES_SCHEME, null);
 
-        cns.restrictToMatchingDesignations("heaart", SearchDesignationOption.ALL, "DoubleMetaphoneLuceneQuery", null);
+        cns = cns.restrictToMatchingDesignations("heaart", SearchDesignationOption.ALL, "DoubleMetaphoneLuceneQuery", null);
 
         ResolvedConceptReference[] rcr = cns.resolveToList(null, null, null, 1).getResolvedConceptReference();
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestLimitReturnedValues.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestLimitReturnedValues.java
@@ -26,9 +26,7 @@ import org.LexGrid.LexBIG.Impl.function.LexBIGServiceTestCase;
 import org.LexGrid.LexBIG.Impl.testUtility.ServiceHolder;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet.SearchDesignationOption;
-import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
-@RemoteApiSafeTest
 public class TestLimitReturnedValues extends LexBIGServiceTestCase {
     final static String testID = "T1_FNC_43";
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestMRRANK.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestMRRANK.java
@@ -56,7 +56,7 @@ public class TestMRRANK extends LexBIGServiceTestCase {
         cr.setCodingSchemeName(META_SCHEME);
         cr.setConceptCode("C0000005");
         crl.addConceptReference(cr);
-        cns.restrictToCodes(crl);
+        cns = cns.restrictToCodes(crl);
 
         ResolvedConceptReference[] rcr = cns.resolveToList(null, null, null, 0).getResolvedConceptReference();
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestMapAttributestoTypes.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestMapAttributestoTypes.java
@@ -23,9 +23,11 @@ package org.LexGrid.LexBIG.Impl.function.query;
 import org.LexGrid.LexBIG.Exceptions.LBException;
 import org.LexGrid.LexBIG.Impl.function.LexBIGServiceTestCase;
 import org.LexGrid.LexBIG.Impl.testUtility.ServiceHolder;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 import org.LexGrid.codingSchemes.CodingScheme;
 import org.LexGrid.naming.SupportedProperty;
 
+@RemoteApiSafeTest
 public class TestMapAttributestoTypes extends LexBIGServiceTestCase {
     final static String testID = "T1_FNC_32";
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestMapSynonymtoPreferredNames.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestMapSynonymtoPreferredNames.java
@@ -39,7 +39,7 @@ public class TestMapSynonymtoPreferredNames extends LexBIGServiceTestCase {
     public void testT1_FNC_38() throws LBException {
 
         CodedNodeSet cns = ServiceHolder.instance().getLexBIGService().getCodingSchemeConcepts(THES_SCHEME, null);
-        cns.restrictToMatchingDesignations("skeleton", SearchDesignationOption.ALL, "exactMatch", null);
+        cns = cns.restrictToMatchingDesignations("skeleton", SearchDesignationOption.ALL, "exactMatch", null);
 
         ResolvedConceptReference[] rcr = cns.resolveToList(null, Constructors.createLocalNameList("Display_Name"),
                 null, 0).getResolvedConceptReference();

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestOWLLoaderPreferences.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestOWLLoaderPreferences.java
@@ -58,7 +58,7 @@ public class TestOWLLoaderPreferences extends LexBIGServiceTestCase {
         cr.setCodingSchemeName(CAMERA_SCHEME_MANIFEST_URN);
         cr.setConceptCode("BUCKS");
         crl.addConceptReference(cr);
-        cns.restrictToCodes(crl);
+        cns = cns.restrictToCodes(crl);
 
         ResolvedConceptReference[] rcr = cns.resolveToList(null, null, null, 0).getResolvedConceptReference();
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestOtherMatchingTechniques.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestOtherMatchingTechniques.java
@@ -39,7 +39,7 @@ public class TestOtherMatchingTechniques extends LexBIGServiceTestCase {
 
         CodedNodeSet cns = ServiceHolder.instance().getLexBIGService().getCodingSchemeConcepts(THES_SCHEME, null);
 
-        cns.restrictToMatchingDesignations("base heart", null, "LuceneQuery", null);
+        cns = cns.restrictToMatchingDesignations("base heart", null, "LuceneQuery", null);
 
         ResolvedConceptReference[] rcr = cns.resolveToList(null, null, null, 0).getResolvedConceptReference();
 
@@ -61,7 +61,7 @@ public class TestOtherMatchingTechniques extends LexBIGServiceTestCase {
         // present.
         CodedNodeSet cns = ServiceHolder.instance().getLexBIGService().getCodingSchemeConcepts("AI/RHEUM, 1993", null);
 
-        cns.restrictToMatchingDesignations("ecchymosis", null, "LuceneQuery", null);
+        cns = cns.restrictToMatchingDesignations("ecchymosis", null, "LuceneQuery", null);
 
         ResolvedConceptReference[] rcr = cns.resolveToList(null, null, null, 0).getResolvedConceptReference();
 
@@ -79,7 +79,7 @@ public class TestOtherMatchingTechniques extends LexBIGServiceTestCase {
     public void testRegExp() throws LBException {
         CodedNodeSet cns = ServiceHolder.instance().getLexBIGService().getCodingSchemeConcepts(AUTO_SCHEME, null);
 
-        cns.restrictToMatchingDesignations(".*lds", null, "RegExp", null);
+        cns = cns.restrictToMatchingDesignations(".*lds", null, "RegExp", null);
 
         ResolvedConceptReference[] rcr = cns.resolveToList(null, null, null, 0).getResolvedConceptReference();
 
@@ -94,7 +94,7 @@ public class TestOtherMatchingTechniques extends LexBIGServiceTestCase {
         // non preferred should have 1 hit.
         CodedNodeSet cns = ServiceHolder.instance().getLexBIGService().getCodingSchemeConcepts(AUTO_SCHEME, null);
 
-        cns.restrictToMatchingDesignations("\"American Car\"", SearchDesignationOption.NON_PREFERRED_ONLY,
+        cns = cns.restrictToMatchingDesignations("\"American Car\"", SearchDesignationOption.NON_PREFERRED_ONLY,
                 "LuceneQuery", null);
         ResolvedConceptReference[] rcr = cns.resolveToList(null, null, null, 0).getResolvedConceptReference();
 
@@ -103,21 +103,21 @@ public class TestOtherMatchingTechniques extends LexBIGServiceTestCase {
 
         // preferred should have 0 hits.
         cns = ServiceHolder.instance().getLexBIGService().getCodingSchemeConcepts(AUTO_SCHEME, null);
-        cns.restrictToMatchingDesignations("\"American Car\"", SearchDesignationOption.PREFERRED_ONLY, "LuceneQuery",
+        cns = cns.restrictToMatchingDesignations("\"American Car\"", SearchDesignationOption.PREFERRED_ONLY, "LuceneQuery",
                 null);
         rcr = cns.resolveToList(null, null, null, 0).getResolvedConceptReference();
         assertTrue(rcr.length == 0);
 
         // Any should have 1 hit.
         cns = ServiceHolder.instance().getLexBIGService().getCodingSchemeConcepts(AUTO_SCHEME, null);
-        cns.restrictToMatchingDesignations("\"American Car\"", SearchDesignationOption.ALL, "LuceneQuery", null);
+        cns = cns.restrictToMatchingDesignations("\"American Car\"", SearchDesignationOption.ALL, "LuceneQuery", null);
         rcr = cns.resolveToList(null, null, null, 0).getResolvedConceptReference();
         assertTrue(rcr.length == 1);
         assertTrue(rcr[0].getConceptCode().equals("005"));
 
         // null should have 1 hit.
         cns = ServiceHolder.instance().getLexBIGService().getCodingSchemeConcepts(AUTO_SCHEME, null);
-        cns.restrictToMatchingDesignations("\"American Car\"", null, "LuceneQuery", null);
+        cns = cns.restrictToMatchingDesignations("\"American Car\"", null, "LuceneQuery", null);
         rcr = cns.resolveToList(null, null, null, 0).getResolvedConceptReference();
         assertTrue(rcr.length == 1);
         assertTrue(rcr[0].getConceptCode().equals("005"));
@@ -126,27 +126,27 @@ public class TestOtherMatchingTechniques extends LexBIGServiceTestCase {
         // should not.
         // preferred should have 1 hits.
         cns = ServiceHolder.instance().getLexBIGService().getCodingSchemeConcepts(AUTO_SCHEME, null);
-        cns.restrictToMatchingDesignations("\"General Motors\"", SearchDesignationOption.PREFERRED_ONLY, "LuceneQuery",
+        cns = cns.restrictToMatchingDesignations("\"General Motors\"", SearchDesignationOption.PREFERRED_ONLY, "LuceneQuery",
                 null);
         rcr = cns.resolveToList(null, null, null, 0).getResolvedConceptReference();
         assertTrue(rcr.length == 1);
 
         // non-preferred should have 0 hits.
         cns = ServiceHolder.instance().getLexBIGService().getCodingSchemeConcepts(AUTO_SCHEME, null);
-        cns.restrictToMatchingDesignations("\"General Motors\"", SearchDesignationOption.NON_PREFERRED_ONLY,
+        cns = cns.restrictToMatchingDesignations("\"General Motors\"", SearchDesignationOption.NON_PREFERRED_ONLY,
                 "LuceneQuery", null);
         rcr = cns.resolveToList(null, null, null, 0).getResolvedConceptReference();
         assertTrue(rcr.length == 0);
 
         // all should have 1 hits.
         cns = ServiceHolder.instance().getLexBIGService().getCodingSchemeConcepts(AUTO_SCHEME, null);
-        cns.restrictToMatchingDesignations("\"General Motors\"", SearchDesignationOption.ALL, "LuceneQuery", null);
+        cns = cns.restrictToMatchingDesignations("\"General Motors\"", SearchDesignationOption.ALL, "LuceneQuery", null);
         rcr = cns.resolveToList(null, null, null, 0).getResolvedConceptReference();
         assertTrue(rcr.length == 1);
 
         // and so should null
         cns = ServiceHolder.instance().getLexBIGService().getCodingSchemeConcepts(AUTO_SCHEME, null);
-        cns.restrictToMatchingDesignations("\"General Motors\"", null, "LuceneQuery", null);
+        cns = cns.restrictToMatchingDesignations("\"General Motors\"", null, "LuceneQuery", null);
         rcr = cns.resolveToList(null, null, null, 0).getResolvedConceptReference();
         assertTrue(rcr.length == 1);
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestQuerybyRelationshipDomain.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestQuerybyRelationshipDomain.java
@@ -47,8 +47,8 @@ public class TestQuerybyRelationshipDomain extends LexBIGServiceTestCase {
         ConvenienceMethods cm = new ConvenienceMethods(ServiceHolder.instance().getLexBIGService());
 
         CodedNodeGraph cng = ServiceHolder.instance().getLexBIGService().getNodeGraph(THES_SCHEME, null, null);
-        cng.restrictToAssociations(Constructors.createNameAndValueList("domain"), null);
-        cng.restrictToTargetCodes(cm.createCodedNodeSet(new String[] { domainCode }, THES_SCHEME, null));
+        cng = cng.restrictToAssociations(Constructors.createNameAndValueList("domain"), null);
+        cng = cng.restrictToTargetCodes(cm.createCodedNodeSet(new String[] { domainCode }, THES_SCHEME, null));
 
         assertTrue(cng.isCodeInGraph(Constructors.createConceptReference(domainCode, THES_SCHEME)).booleanValue());
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestRetrieveConceptandAttributesbyCode.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestRetrieveConceptandAttributesbyCode.java
@@ -38,7 +38,7 @@ public class TestRetrieveConceptandAttributesbyCode extends LexBIGServiceTestCas
     public void testT1_FNC_34() throws LBException {
 
         CodedNodeSet cns = ServiceHolder.instance().getLexBIGService().getCodingSchemeConcepts(THES_SCHEME, null);
-        cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "Vallecula" }, THES_SCHEME));
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "Vallecula" }, THES_SCHEME));
 
         ResolvedConceptReference[] rcr = cns.resolveToList(null, Constructors.createLocalNameList("Semantic_Type"),
                 null, 0).getResolvedConceptReference();
@@ -49,7 +49,7 @@ public class TestRetrieveConceptandAttributesbyCode extends LexBIGServiceTestCas
         assertTrue(rcr[0].getEntity().getProperty()[0].getPropertyName().equals("Semantic_Type"));
 
         cns = ServiceHolder.instance().getLexBIGService().getCodingSchemeConcepts(THES_SCHEME, null);
-        cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "invalidCode" }, THES_SCHEME));
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "invalidCode" }, THES_SCHEME));
 
         rcr = cns.resolveToList(null, Constructors.createLocalNameList("Semantic_Type"), null, 0)
                 .getResolvedConceptReference();

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestRetrieveConceptandAttributesbyPreferredName.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestRetrieveConceptandAttributesbyPreferredName.java
@@ -26,8 +26,8 @@ import org.LexGrid.LexBIG.Extensions.Generic.LexBIGServiceConvenienceMethods;
 import org.LexGrid.LexBIG.Impl.function.LexBIGServiceTestCase;
 import org.LexGrid.LexBIG.Impl.testUtility.ServiceHolder;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
-import org.LexGrid.LexBIG.LexBIGService.LexBIGService;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet.SearchDesignationOption;
+import org.LexGrid.LexBIG.LexBIGService.LexBIGService;
 import org.LexGrid.LexBIG.Utility.Constructors;
 
 public class TestRetrieveConceptandAttributesbyPreferredName extends LexBIGServiceTestCase {
@@ -42,7 +42,7 @@ public class TestRetrieveConceptandAttributesbyPreferredName extends LexBIGServi
         LexBIGService lbsvc = ServiceHolder.instance().getLexBIGService();
         
         CodedNodeSet cns = lbsvc.getCodingSchemeConcepts(THES_SCHEME, null);
-        cns.restrictToMatchingDesignations("Vallecula", SearchDesignationOption.PREFERRED_ONLY, "exactMatch", null);
+        cns = cns.restrictToMatchingDesignations("Vallecula", SearchDesignationOption.PREFERRED_ONLY, "exactMatch", null);
 
         ResolvedConceptReference[] rcr = cns.resolveToList(null, Constructors.createLocalNameList("Semantic_Type"),
                 null, 0).getResolvedConceptReference();

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestRetrieveMostRecentVersionofConcept.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestRetrieveMostRecentVersionofConcept.java
@@ -41,7 +41,7 @@ public class TestRetrieveMostRecentVersionofConcept extends LexBIGServiceTestCas
         // good version)
 
         CodedNodeSet cns = ServiceHolder.instance().getLexBIGService().getCodingSchemeConcepts(THES_SCHEME, null);
-        cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "External_Lip" }, THES_SCHEME));
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "External_Lip" }, THES_SCHEME));
 
         assertTrue(cns.resolveToList(null, null, null, 0).getResolvedConceptReference().length == 1);
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestRetrieveRelationsforConcept.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestRetrieveRelationsforConcept.java
@@ -39,7 +39,7 @@ public class TestRetrieveRelationsforConcept extends LexBIGServiceTestCase {
     public void testT1_FNC_40() throws LBException {
 
         CodedNodeSet cns = ServiceHolder.instance().getLexBIGService().getCodingSchemeConcepts(THES_SCHEME, null);
-        cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "External_Lip" }, THES_SCHEME));
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "External_Lip" }, THES_SCHEME));
 
         CodedNodeGraph cng = ServiceHolder.instance().getLexBIGService().getNodeGraph(THES_SCHEME, null, "roles");
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestSameCodeDifferentNamespace.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestSameCodeDifferentNamespace.java
@@ -23,6 +23,7 @@ import org.LexGrid.LexBIG.Exceptions.LBInvocationException;
 import org.LexGrid.LexBIG.Exceptions.LBParameterException;
 import org.LexGrid.LexBIG.Impl.function.codednodeset.BaseCodedNodeSetTest;
 import org.LexGrid.LexBIG.Utility.Constructors;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 import org.LexGrid.commonTypes.Property;
 import org.LexGrid.concepts.Entity;
 import org.LexGrid.concepts.Presentation;
@@ -32,6 +33,7 @@ import org.LexGrid.concepts.Presentation;
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class TestSameCodeDifferentNamespace extends BaseCodedNodeSetTest{
 
     /**
@@ -53,7 +55,7 @@ public class TestSameCodeDifferentNamespace extends BaseCodedNodeSetTest{
      * @throws LBParameterException the LB parameter exception
      */
     public void testRestrictToCodesNoNamespaceSize() throws LBInvocationException, LBParameterException{
-        cns.restrictToCodes(Constructors.createConceptReferenceList("DifferentNamespaceConcept"));
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList("DifferentNamespaceConcept"));
         
         ResolvedConceptReference[] refs = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
         
@@ -67,7 +69,7 @@ public class TestSameCodeDifferentNamespace extends BaseCodedNodeSetTest{
      * @throws LBParameterException the LB parameter exception
      */
     public void testRestrictToCodesNoNamespaceIfNamespaceIsCorrect() throws LBInvocationException, LBParameterException{
-        cns.restrictToCodes(Constructors.createConceptReferenceList("DifferentNamespaceConcept"));
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList("DifferentNamespaceConcept"));
         
         ResolvedConceptReference[] refs = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
         
@@ -82,7 +84,7 @@ public class TestSameCodeDifferentNamespace extends BaseCodedNodeSetTest{
      * @throws LBParameterException the LB parameter exception
      */
     public void testRestrictToCodesNoNamespaceIfPropertiesCountAreCorrect() throws LBInvocationException, LBParameterException{
-        cns.restrictToCodes(Constructors.createConceptReferenceList("DifferentNamespaceConcept"));
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList("DifferentNamespaceConcept"));
         
         ResolvedConceptReference[] refs = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
         
@@ -113,7 +115,7 @@ public class TestSameCodeDifferentNamespace extends BaseCodedNodeSetTest{
      * @throws LBParameterException the LB parameter exception
      */
     public void testRestrictToCodesNoNamespaceIfPropertiesTypesAreCorrect() throws LBInvocationException, LBParameterException{
-        cns.restrictToCodes(Constructors.createConceptReferenceList("DifferentNamespaceConcept"));
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList("DifferentNamespaceConcept"));
         
         ResolvedConceptReference[] refs = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
         
@@ -148,7 +150,7 @@ public class TestSameCodeDifferentNamespace extends BaseCodedNodeSetTest{
      * @throws LBParameterException the LB parameter exception
      */
     public void testRestrictToCodesNoNamespaceIfPropertiesValuesAreCorrect() throws LBInvocationException, LBParameterException{
-        cns.restrictToCodes(Constructors.createConceptReferenceList("DifferentNamespaceConcept"));
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList("DifferentNamespaceConcept"));
         
         ResolvedConceptReference[] refs = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
         
@@ -183,7 +185,7 @@ public class TestSameCodeDifferentNamespace extends BaseCodedNodeSetTest{
      * @throws LBParameterException the LB parameter exception
      */
     public void testRestrictToCodesWithNamespace1() throws LBInvocationException, LBParameterException{
-        cns.restrictToCodes(Constructors.createConceptReferenceList("DifferentNamespaceConcept", 
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList("DifferentNamespaceConcept",
                 AUTO_SCHEME, AUTO_SCHEME));
         
         ResolvedConceptReference[] refs = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
@@ -200,7 +202,7 @@ public class TestSameCodeDifferentNamespace extends BaseCodedNodeSetTest{
      * @throws LBParameterException the LB parameter exception
      */
     public void testRestrictToCodesWithNamespace2() throws LBInvocationException, LBParameterException{
-        cns.restrictToCodes(Constructors.createConceptReferenceList("DifferentNamespaceConcept", 
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList("DifferentNamespaceConcept",
                 "TestForSameCodeNamespace", AUTO_SCHEME));
         
         ResolvedConceptReference[] refs = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestSearchbyStatus.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestSearchbyStatus.java
@@ -25,7 +25,9 @@ import org.LexGrid.LexBIG.Exceptions.LBException;
 import org.LexGrid.LexBIG.Impl.function.LexBIGServiceTestCase;
 import org.LexGrid.LexBIG.Impl.testUtility.ServiceHolder;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
+@RemoteApiSafeTest
 public class TestSearchbyStatus extends LexBIGServiceTestCase {
     final static String testID = "T1_FNC_16";
 
@@ -38,7 +40,7 @@ public class TestSearchbyStatus extends LexBIGServiceTestCase {
 
         CodedNodeSet cns = ServiceHolder.instance().getLexBIGService().getCodingSchemeConcepts(AUTO_SCHEME, null);
 
-        cns.restrictToStatus(null, new String[] { "Retired" });
+        cns = cns.restrictToStatus(null, new String[] { "Retired" });
         ResolvedConceptReference[] rcr = cns.resolveToList(null, null, null, 0).getResolvedConceptReference();
 
         assertTrue(rcr.length == 1);

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestSpecifyReturnOrder.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestSpecifyReturnOrder.java
@@ -27,7 +27,9 @@ import org.LexGrid.LexBIG.Impl.testUtility.ServiceHolder;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.LexBIGService.LexBIGService;
 import org.LexGrid.LexBIG.Utility.Constructors;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
+@RemoteApiSafeTest
 public class TestSpecifyReturnOrder extends LexBIGServiceTestCase {
     final static String testID = "T1_FNC_22";
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestSubsetExtraction.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestSubsetExtraction.java
@@ -37,7 +37,7 @@ public class TestSubsetExtraction extends LexBIGServiceTestCase {
     public void testT1_FNC_02() throws LBException {
 
         CodedNodeSet cns = ServiceHolder.instance().getLexBIGService().getCodingSchemeConcepts(THES_SCHEME, null);
-        cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "Vallecula", "Palate", "Hard_Palate" },
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "Vallecula", "Palate", "Hard_Palate" },
                 THES_SCHEME));
 
         // this test is really lacking... but here is how you subset. You can

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestTransitiveClosure.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestTransitiveClosure.java
@@ -26,6 +26,7 @@ import org.LexGrid.LexBIG.LexBIGService.CodedNodeGraph;
 import org.LexGrid.LexBIG.LexBIGService.LexBIGService;
 import org.LexGrid.LexBIG.Utility.Constructors;
 import org.LexGrid.LexBIG.Utility.ConvenienceMethods;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
 /**
  * This testcase checks that the transitive api works as desired.
@@ -33,6 +34,7 @@ import org.LexGrid.LexBIG.Utility.ConvenienceMethods;
  * @author Pradip Kanjamala
  * 
  */
+@RemoteApiSafeTest
 public class TestTransitiveClosure extends LexBIGServiceTestCase {
 
     final static String testID = "T1_FNC_150";

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestVersioningandAuthorityEnumeration.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestVersioningandAuthorityEnumeration.java
@@ -24,8 +24,10 @@ import org.LexGrid.LexBIG.Exceptions.LBException;
 import org.LexGrid.LexBIG.Impl.function.LexBIGServiceTestCase;
 import org.LexGrid.LexBIG.Impl.testUtility.ServiceHolder;
 import org.LexGrid.LexBIG.Utility.ConvenienceMethods;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 import org.LexGrid.codingSchemes.CodingScheme;
 
+@RemoteApiSafeTest
 public class TestVersioningandAuthorityEnumeration extends LexBIGServiceTestCase {
     final static String testID = "T1_FNC_33";
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestforCurrentOrObsoleteConcept.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestforCurrentOrObsoleteConcept.java
@@ -41,21 +41,21 @@ public class TestforCurrentOrObsoleteConcept extends LexBIGServiceTestCase {
     public void testT1_FNC_23() throws LBException {
 
         CodedNodeSet cns = ServiceHolder.instance().getLexBIGService().getCodingSchemeConcepts(AUTO_SCHEME, null, true);
-        cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "73" }, AUTO_SCHEME));
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "73" }, AUTO_SCHEME));
         ResolvedConceptReference[] rcr = cns.resolveToList(null, null, null, 0).getResolvedConceptReference();
 
         // 73 is inactive - so this should be 0.
         assertTrue(rcr.length == 0);
 
         cns = ServiceHolder.instance().getLexBIGService().getCodingSchemeConcepts(AUTO_SCHEME, null, false);
-        cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "73" }, AUTO_SCHEME));
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "73" }, AUTO_SCHEME));
         rcr = cns.resolveToList(null, null, null, 0).getResolvedConceptReference();
 
         // 73 is inactive - so this should be 1.
         assertTrue(rcr.length == 1);
 
         cns = ServiceHolder.instance().getLexBIGService().getCodingSchemeConcepts(AUTO_SCHEME, null, false);
-        cns.restrictToMatchingDesignations("olds", SearchDesignationOption.ALL, "startsWith", null);
+        cns = cns.restrictToMatchingDesignations("olds", SearchDesignationOption.ALL, "startsWith", null);
         rcr = cns.resolveToList(null, null, null, 0).getResolvedConceptReference();
 
         assertTrue(rcr.length == 1);
@@ -69,16 +69,16 @@ public class TestforCurrentOrObsoleteConcept extends LexBIGServiceTestCase {
         // same as above, but this time, using the new methods (that aren't
         // deprecated)
         CodedNodeSet cns = ServiceHolder.instance().getLexBIGService().getCodingSchemeConcepts(AUTO_SCHEME, null);
-        cns.restrictToStatus(ActiveOption.ACTIVE_ONLY, null);
-        cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "73" }, AUTO_SCHEME));
+        cns = cns.restrictToStatus(ActiveOption.ACTIVE_ONLY, null);
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "73" }, AUTO_SCHEME));
         ResolvedConceptReference[] rcr = cns.resolveToList(null, null, null, 0).getResolvedConceptReference();
 
         // 73 is inactive - so this should be 0.
         assertTrue(rcr.length == 0);
 
         cns = ServiceHolder.instance().getLexBIGService().getCodingSchemeConcepts(AUTO_SCHEME, null);
-        cns.restrictToStatus(ActiveOption.ALL, null);
-        cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "73" }, AUTO_SCHEME));
+        cns = cns.restrictToStatus(ActiveOption.ALL, null);
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "73" }, AUTO_SCHEME));
         rcr = cns.resolveToList(null, null, null, 0).getResolvedConceptReference();
 
         // 73 is inactive - so this should be 1.
@@ -86,7 +86,7 @@ public class TestforCurrentOrObsoleteConcept extends LexBIGServiceTestCase {
 
         // same test again - no status restriction
         cns = ServiceHolder.instance().getLexBIGService().getCodingSchemeConcepts(AUTO_SCHEME, null);
-        cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "73" }, AUTO_SCHEME));
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] { "73" }, AUTO_SCHEME));
         rcr = cns.resolveToList(null, null, null, 0).getResolvedConceptReference();
 
         // 73 is inactive - so this should be 1.
@@ -94,8 +94,8 @@ public class TestforCurrentOrObsoleteConcept extends LexBIGServiceTestCase {
 
         // add a status restriction
         cns = ServiceHolder.instance().getLexBIGService().getCodingSchemeConcepts(AUTO_SCHEME, null);
-        cns.restrictToMatchingDesignations("olds", SearchDesignationOption.ALL, "startsWith", null);
-        cns.restrictToStatus(ActiveOption.INACTIVE_ONLY, new String[] { "Retired" });
+        cns = cns.restrictToMatchingDesignations("olds", SearchDesignationOption.ALL, "startsWith", null);
+        cns = cns.restrictToStatus(ActiveOption.INACTIVE_ONLY, new String[] { "Retired" });
         rcr = cns.resolveToList(null, null, null, 0).getResolvedConceptReference();
         assertTrue(rcr.length == 1);
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestContains.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestContains.java
@@ -21,12 +21,14 @@ package org.LexGrid.LexBIG.Impl.function.query.lucene.searchAlgorithms;
 import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet.SearchDesignationOption;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
 /**
  * The Class TestContains.
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class TestContains extends BaseSearchAlgorithmTest {
 
     /** The algorithm. */
@@ -53,7 +55,7 @@ public class TestContains extends BaseSearchAlgorithmTest {
      */
     public void testContains() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("automob", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("automob", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -69,7 +71,7 @@ public class TestContains extends BaseSearchAlgorithmTest {
      */
     public void testContainsWithNonNormalizedSearch() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("Automob", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("Automob", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -85,7 +87,7 @@ public class TestContains extends BaseSearchAlgorithmTest {
      */
     public void testContainsTwoTerms() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("General Motors", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("General Motors", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -101,7 +103,7 @@ public class TestContains extends BaseSearchAlgorithmTest {
      */
     public void testContainsTwoTermsIncompleteTerms() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("Gener Moto", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("Gener Moto", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -117,7 +119,7 @@ public class TestContains extends BaseSearchAlgorithmTest {
      */
     public void testContainsANDTerms() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("car truck", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("car truck", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestContainsLiteralContains.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestContainsLiteralContains.java
@@ -21,12 +21,14 @@ package org.LexGrid.LexBIG.Impl.function.query.lucene.searchAlgorithms;
 import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet.SearchDesignationOption;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
 /**
  * The Class TestContainsLiteralContains.
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class TestContainsLiteralContains extends BaseSearchAlgorithmTest{
 
     /** The algorithm. */
@@ -42,7 +44,7 @@ public class TestContainsLiteralContains extends BaseSearchAlgorithmTest{
      */
     public void testContains() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("automob", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("automob", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -58,7 +60,7 @@ public class TestContainsLiteralContains extends BaseSearchAlgorithmTest{
      */
     public void testContainsWithNonNormalizedSearch() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("Automob", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("Automob", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -74,7 +76,7 @@ public class TestContainsLiteralContains extends BaseSearchAlgorithmTest{
      */
     public void testContainsTwoTerms() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("General Motors", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("General Motors", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -90,7 +92,7 @@ public class TestContainsLiteralContains extends BaseSearchAlgorithmTest{
      */
     public void testContainsTwoTermsIncompleteTerms() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("Gener Moto", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("Gener Moto", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -106,7 +108,7 @@ public class TestContainsLiteralContains extends BaseSearchAlgorithmTest{
      */
     public void testContainsANDTerms() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("car truck", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("car truck", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestDoubleMetaphone.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestDoubleMetaphone.java
@@ -21,12 +21,14 @@ package org.LexGrid.LexBIG.Impl.function.query.lucene.searchAlgorithms;
 import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet.SearchDesignationOption;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
 /**
  * The Class TestDoubleMetaphone.
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class TestDoubleMetaphone extends BaseSearchAlgorithmTest {
 
     /** The algorithm. */
@@ -53,7 +55,7 @@ public class TestDoubleMetaphone extends BaseSearchAlgorithmTest {
      */
     public void testDoubleMetaphone() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("Automobeel", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("Automobeel", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -69,7 +71,7 @@ public class TestDoubleMetaphone extends BaseSearchAlgorithmTest {
      */
     public void testDoubleMetaphoneCaseInsensitive() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("automobeel", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("automobeel", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -85,7 +87,7 @@ public class TestDoubleMetaphone extends BaseSearchAlgorithmTest {
      */
     public void testDoubleMetaphoneANDTerms() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("kar truk", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("kar truk", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestExactMatch.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestExactMatch.java
@@ -21,12 +21,14 @@ package org.LexGrid.LexBIG.Impl.function.query.lucene.searchAlgorithms;
 import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet.SearchDesignationOption;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
 /**
  * The Class TestExactMatch.
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class TestExactMatch extends BaseSearchAlgorithmTest {
 
     /** The algorithm. */
@@ -53,7 +55,7 @@ public class TestExactMatch extends BaseSearchAlgorithmTest {
      */
     public void testExactMatch() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("Automobile", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("Automobile", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -69,7 +71,7 @@ public class TestExactMatch extends BaseSearchAlgorithmTest {
      */
     public void testExactMatchMultipleTokens() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("General Motors", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("General Motors", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -85,7 +87,7 @@ public class TestExactMatch extends BaseSearchAlgorithmTest {
      */
     public void testExactMatchWrongCase() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("automobile", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("automobile", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -101,7 +103,7 @@ public class TestExactMatch extends BaseSearchAlgorithmTest {
      */
     public void testLiteralExactMatch() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("a^s sp*cial co{nce]pt", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("a^s sp*cial co{nce]pt", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -117,7 +119,7 @@ public class TestExactMatch extends BaseSearchAlgorithmTest {
      */
     public void testLiteralExactMatchDifferentCode() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("Car (with special) charaters!", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("Car (with special) charaters!", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -133,7 +135,7 @@ public class TestExactMatch extends BaseSearchAlgorithmTest {
      */
     public void testLiteralExactMatchWrongCase() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("A^s sp*cial Co{nce]Pt", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("A^s sp*cial Co{nce]Pt", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -149,7 +151,7 @@ public class TestExactMatch extends BaseSearchAlgorithmTest {
      */
     public void testLiteralExactMatchNotExact() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("a^s sp*cial", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("a^s sp*cial", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -163,7 +165,7 @@ public class TestExactMatch extends BaseSearchAlgorithmTest {
      */
     public void testLiteralExactMatchWrongSpecialCharacter() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("a^s sp^cial co{nce]pt", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("a^s sp^cial co{nce]pt", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestLeadingAndTrailingWildcard.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestLeadingAndTrailingWildcard.java
@@ -22,12 +22,14 @@ import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet.SearchDesignationOption;
 import org.LexGrid.LexBIG.Utility.Constructors;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
 /**
  * The Class TestLeadingAndTrailingWildcard.
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class TestLeadingAndTrailingWildcard extends BaseSearchAlgorithmTest {
 
     /** The algorithm. */
@@ -54,7 +56,7 @@ public class TestLeadingAndTrailingWildcard extends BaseSearchAlgorithmTest {
      */
     public void testLeadingAndTrailingWildcard() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("chevy", SearchDesignationOption.ALL, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("chevy", SearchDesignationOption.ALL, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -70,7 +72,7 @@ public class TestLeadingAndTrailingWildcard extends BaseSearchAlgorithmTest {
      */
     public void testLeadingAndTrailingWildcardLeading() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("hevy", SearchDesignationOption.ALL, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("hevy", SearchDesignationOption.ALL, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -86,7 +88,7 @@ public class TestLeadingAndTrailingWildcard extends BaseSearchAlgorithmTest {
      */
     public void testLeadingAndTrailingWildcardTrailing() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("chev", SearchDesignationOption.ALL, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("chev", SearchDesignationOption.ALL, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -102,7 +104,7 @@ public class TestLeadingAndTrailingWildcard extends BaseSearchAlgorithmTest {
      */
     public void testLeadingAndTrailingWildcardBoth() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("hev", SearchDesignationOption.ALL, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("hev", SearchDesignationOption.ALL, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -118,7 +120,7 @@ public class TestLeadingAndTrailingWildcard extends BaseSearchAlgorithmTest {
      */
     public void testLeadingAndTrailingWildcardNoMatch() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("NO_MATCH_FOR_TESTING", SearchDesignationOption.ALL, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("NO_MATCH_FOR_TESTING", SearchDesignationOption.ALL, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -132,7 +134,7 @@ public class TestLeadingAndTrailingWildcard extends BaseSearchAlgorithmTest {
      */
     public void testLeadingAndTrailingWildcardCaseInsensitive() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("HEV", SearchDesignationOption.ALL, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("HEV", SearchDesignationOption.ALL, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -148,7 +150,7 @@ public class TestLeadingAndTrailingWildcard extends BaseSearchAlgorithmTest {
      */
     public void testLeadingAndTrailingWildcardManyTokens() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("onc o esti aph uild n onc w o elatio", SearchDesignationOption.ALL, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("onc o esti aph uild n onc w o elatio", SearchDesignationOption.ALL, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -164,7 +166,7 @@ public class TestLeadingAndTrailingWildcard extends BaseSearchAlgorithmTest {
      */
     public void testLeadingAndTrailingWildcardManyTokensCaseInsensitive() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("oNc O eStI APH uild n OnC w O eLAtiO", SearchDesignationOption.ALL, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("oNc O eStI APH uild n OnC w O eLAtiO", SearchDesignationOption.ALL, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -175,8 +177,8 @@ public class TestLeadingAndTrailingWildcard extends BaseSearchAlgorithmTest {
     
     public void testLeadingAndTrailingWildcardScoring() throws Exception {
    	 CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("auto", SearchDesignationOption.ALL, algorithm, null);
-        cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] {"005", "A0001"}));
+        cns = cns.restrictToMatchingDesignations("auto", SearchDesignationOption.ALL, algorithm, null);
+        cns = cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] {"005", "A0001"}));
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestLiteral.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestLiteral.java
@@ -21,12 +21,14 @@ package org.LexGrid.LexBIG.Impl.function.query.lucene.searchAlgorithms;
 import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet.SearchDesignationOption;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
 /**
  * The Class TestLiteral.
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class TestLiteral extends BaseSearchAlgorithmTest {
 
     /** The algorithm. */
@@ -53,7 +55,7 @@ public class TestLiteral extends BaseSearchAlgorithmTest {
      */
     public void testLiteral() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("a^s", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("a^s", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -69,7 +71,7 @@ public class TestLiteral extends BaseSearchAlgorithmTest {
      */
     public void testLiteralTwoTerms() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("a^s co{nce]pt", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("a^s co{nce]pt", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -85,7 +87,7 @@ public class TestLiteral extends BaseSearchAlgorithmTest {
      */
     public void testLiteralCaseInsensitive() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("sp*cial", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("sp*cial", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -101,7 +103,7 @@ public class TestLiteral extends BaseSearchAlgorithmTest {
      */
     public void testStartsWithNoMatch() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("NO_MATCH_FOR_TESTING", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("NO_MATCH_FOR_TESTING", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestLiteralContains.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestLiteralContains.java
@@ -21,12 +21,14 @@ package org.LexGrid.LexBIG.Impl.function.query.lucene.searchAlgorithms;
 import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet.SearchDesignationOption;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
 /**
  * The Class TestLiteralContains.
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class TestLiteralContains extends BaseSearchAlgorithmTest {
 
     /** The algorithm. */
@@ -53,7 +55,7 @@ public class TestLiteralContains extends BaseSearchAlgorithmTest {
      */
     public void testLiteralContains() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("a^s sp*cial co{nce]pt", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("a^s sp*cial co{nce]pt", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -69,7 +71,7 @@ public class TestLiteralContains extends BaseSearchAlgorithmTest {
      */
     public void testLiteralContainsFirstTerm() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("a^s", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("a^s", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -85,7 +87,7 @@ public class TestLiteralContains extends BaseSearchAlgorithmTest {
      */
     public void testLiteralContainsLastTerm() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("co{nce]pt", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("co{nce]pt", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -101,7 +103,7 @@ public class TestLiteralContains extends BaseSearchAlgorithmTest {
      */
     public void testLiteralContainsMiddleTerm() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("sp*cial", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("sp*cial", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -117,7 +119,7 @@ public class TestLiteralContains extends BaseSearchAlgorithmTest {
      */
     public void testLiteralContainsPartialTerm() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("sp*cia", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("sp*cia", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -133,7 +135,7 @@ public class TestLiteralContains extends BaseSearchAlgorithmTest {
      */
     public void testLiteralContainsPartialTerms() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("a^ sp*cia", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("a^ sp*cia", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -149,7 +151,7 @@ public class TestLiteralContains extends BaseSearchAlgorithmTest {
      */
     public void testLiteralContainsANDTerms() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("a^s truck", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("a^s truck", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestLiteralLiteralContains.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestLiteralLiteralContains.java
@@ -18,11 +18,14 @@
  */
 package org.LexGrid.LexBIG.Impl.function.query.lucene.searchAlgorithms;
 
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
+
 /**
  * The Class TestLiteralLiteralContains.
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class TestLiteralLiteralContains extends TestLiteral {
 
     /** The algorithm. */

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestLiteralSpellingErrorTolerantSubString.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestLiteralSpellingErrorTolerantSubString.java
@@ -18,11 +18,14 @@
  */
 package org.LexGrid.LexBIG.Impl.function.query.lucene.searchAlgorithms;
 
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
+
 /**
  * The Class TestWeightedDoubleMetaphone.
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class TestLiteralSpellingErrorTolerantSubString extends TestLiteral {
 
     /** The algorithm. */

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestLiteralSubString.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestLiteralSubString.java
@@ -21,12 +21,14 @@ package org.LexGrid.LexBIG.Impl.function.query.lucene.searchAlgorithms;
 import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet.SearchDesignationOption;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
 /**
  * The Class TestSubString.
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class TestLiteralSubString extends BaseSearchAlgorithmTest {
 
     /** The algorithm. */
@@ -53,7 +55,7 @@ public class TestLiteralSubString extends BaseSearchAlgorithmTest {
      */
     public void testLiteralSubString() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("a^s", SearchDesignationOption.ALL, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("a^s", SearchDesignationOption.ALL, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -69,7 +71,7 @@ public class TestLiteralSubString extends BaseSearchAlgorithmTest {
      */
     public void testLiteralSubStringInvalidSpecialCharacter() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("sp!cial", SearchDesignationOption.ALL, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("sp!cial", SearchDesignationOption.ALL, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -83,7 +85,7 @@ public class TestLiteralSubString extends BaseSearchAlgorithmTest {
      */
     public void testLiteralSubStringInvalidSpecialCharacterCaseInsensitive() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("Sp!ciAL", SearchDesignationOption.ALL, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("Sp!ciAL", SearchDesignationOption.ALL, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -97,7 +99,7 @@ public class TestLiteralSubString extends BaseSearchAlgorithmTest {
      */
     public void testLiteralSubStringTwoTerm() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("a^s sp*cial", SearchDesignationOption.ALL, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("a^s sp*cial", SearchDesignationOption.ALL, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -113,7 +115,7 @@ public class TestLiteralSubString extends BaseSearchAlgorithmTest {
      */
     public void testLiteralSubStringAllTerms() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("a^s sp*cial co{nce]pt", SearchDesignationOption.ALL, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("a^s sp*cial co{nce]pt", SearchDesignationOption.ALL, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -129,7 +131,7 @@ public class TestLiteralSubString extends BaseSearchAlgorithmTest {
      */
     public void testLiteralSubStringInvalidDistance() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("a^s co{nce]pt", SearchDesignationOption.ALL, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("a^s co{nce]pt", SearchDesignationOption.ALL, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -143,7 +145,7 @@ public class TestLiteralSubString extends BaseSearchAlgorithmTest {
      */
     public void testLiteralSubStringInvalidOrder() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("co{nce]pt sp*cial ", SearchDesignationOption.ALL, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("co{nce]pt sp*cial ", SearchDesignationOption.ALL, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -158,7 +160,7 @@ public class TestLiteralSubString extends BaseSearchAlgorithmTest {
      */
     public void testLiteralSubStringLeadingWildcard() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("^s sp*cial co{nce]pt", SearchDesignationOption.ALL, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("^s sp*cial co{nce]pt", SearchDesignationOption.ALL, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -174,7 +176,7 @@ public class TestLiteralSubString extends BaseSearchAlgorithmTest {
      */
     public void testLiteralSubStringTrailingWildcard() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("a^s sp*cial co{nce]p", SearchDesignationOption.ALL, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("a^s sp*cial co{nce]p", SearchDesignationOption.ALL, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -190,7 +192,7 @@ public class TestLiteralSubString extends BaseSearchAlgorithmTest {
      */
     public void testLiteralSubStringLeadingAndTrailingWildcard() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("^s sp*cial co{nce]p", SearchDesignationOption.ALL, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("^s sp*cial co{nce]p", SearchDesignationOption.ALL, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -206,7 +208,7 @@ public class TestLiteralSubString extends BaseSearchAlgorithmTest {
      */
     public void testLiteralSubStringNoMatch() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("NO_MATCH_FOR_TESTING", SearchDesignationOption.ALL, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("NO_MATCH_FOR_TESTING", SearchDesignationOption.ALL, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -220,7 +222,7 @@ public class TestLiteralSubString extends BaseSearchAlgorithmTest {
      */
     public void testLiteralSubStringCaseInsensitive() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("A^s Sp*cial CO{nce]pt", SearchDesignationOption.ALL, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("A^s Sp*cial CO{nce]pt", SearchDesignationOption.ALL, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestPhrase.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestPhrase.java
@@ -21,12 +21,14 @@ package org.LexGrid.LexBIG.Impl.function.query.lucene.searchAlgorithms;
 import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet.SearchDesignationOption;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
 /**
  * The Class TestSubString.
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class TestPhrase extends BaseSearchAlgorithmTest {
 
     /** The algorithm. */
@@ -53,7 +55,7 @@ public class TestPhrase extends BaseSearchAlgorithmTest {
      */
     public void testPhrase() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("for testing Graph Building", SearchDesignationOption.ALL, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("for testing Graph Building", SearchDesignationOption.ALL, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -69,7 +71,7 @@ public class TestPhrase extends BaseSearchAlgorithmTest {
      */
     public void testPhraseNoMatch() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("Graph Concepts", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("Graph Concepts", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -83,7 +85,7 @@ public class TestPhrase extends BaseSearchAlgorithmTest {
      */
     public void testPhraseCaseInsensitive() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("graph building on concepts", SearchDesignationOption.ALL, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("graph building on concepts", SearchDesignationOption.ALL, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestPlainLuceneQuery.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestPlainLuceneQuery.java
@@ -7,6 +7,7 @@ import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet.AnonymousOption;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet.SearchDesignationOption;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -14,6 +15,7 @@ import org.junit.Test;
  * @author m029206
  *
  */
+@RemoteApiSafeTest
 public class TestPlainLuceneQuery extends BaseSearchAlgorithmTest {
 	
 	String algorithm = "LuceneQuery";
@@ -29,7 +31,7 @@ public class TestPlainLuceneQuery extends BaseSearchAlgorithmTest {
 	@Test
 	public void testMinimalParams() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-		cns.restrictToAnonymous(AnonymousOption.NON_ANONYMOUS_ONLY);
+		cns = cns.restrictToAnonymous(AnonymousOption.NON_ANONYMOUS_ONLY);
         ResolvedConceptReference[] rcrl = null;
         try{
         rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
@@ -45,7 +47,7 @@ public class TestPlainLuceneQuery extends BaseSearchAlgorithmTest {
 	@Test
 	public void testLuceneQuery() throws Exception{
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-		cns.restrictToMatchingDesignations("Car", SearchDesignationOption.ALL, this.getAlgorithm(), null);
+		cns = cns.restrictToMatchingDesignations("Car", SearchDesignationOption.ALL, this.getAlgorithm(), null);
         ResolvedConceptReference[] rcrl = null;
         try{
         rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestRegExp.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestRegExp.java
@@ -21,12 +21,14 @@ package org.LexGrid.LexBIG.Impl.function.query.lucene.searchAlgorithms;
 import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet.SearchDesignationOption;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
 /**
  * The Class TestRegExp.
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class TestRegExp extends BaseSearchAlgorithmTest {
 
     /** The algorithm. */
@@ -53,7 +55,7 @@ public class TestRegExp extends BaseSearchAlgorithmTest {
      */
     public void testRegExp() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("automobi.*", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("automobi.*", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -69,7 +71,7 @@ public class TestRegExp extends BaseSearchAlgorithmTest {
      */
     public void testRegExpLeadingWildcard() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations(".*utomobile", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
+        cns = cns.restrictToMatchingDesignations(".*utomobile", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -85,7 +87,7 @@ public class TestRegExp extends BaseSearchAlgorithmTest {
      */
     public void testRegExpMiddleWildcard() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("aut.*ile", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("aut.*ile", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -101,7 +103,7 @@ public class TestRegExp extends BaseSearchAlgorithmTest {
       */
      public void testRegExpBrackets() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("au[s-u]omobile", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("au[s-u]omobile", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -117,7 +119,7 @@ public class TestRegExp extends BaseSearchAlgorithmTest {
       */
      public void testRegExpBracketsNoMatch() throws Exception {
          CodedNodeSet cns = super.getAutosCodedNodeSet();
-         cns.restrictToMatchingDesignations("au[c-f]omobile", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
+         cns = cns.restrictToMatchingDesignations("au[c-f]omobile", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
 
          ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -131,7 +133,7 @@ public class TestRegExp extends BaseSearchAlgorithmTest {
       */
      public void testRegExpComplex() throws Exception {
          CodedNodeSet cns = super.getAutosCodedNodeSet();
-         cns.restrictToMatchingDesignations("a[^z]t*o(m|o)*bi.*e$", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
+         cns = cns.restrictToMatchingDesignations("a[^z]t*o(m|o)*bi.*e$", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
 
          ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -147,7 +149,7 @@ public class TestRegExp extends BaseSearchAlgorithmTest {
       */
      public void testRegExpComplexNoMatch() throws Exception {
          CodedNodeSet cns = super.getAutosCodedNodeSet();
-         cns.restrictToMatchingDesignations("a[s]o(o|l)*bi.*e$", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
+         cns = cns.restrictToMatchingDesignations("a[s]o(o|l)*bi.*e$", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
 
          ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestSearchByPreferred.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestSearchByPreferred.java
@@ -21,12 +21,14 @@ package org.LexGrid.LexBIG.Impl.function.query.lucene.searchAlgorithms;
 import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet.SearchDesignationOption;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
 /**
  * The Class TestSearchByPreferred.
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class TestSearchByPreferred extends BaseSearchAlgorithmTest {
 
     /** The algorithm. */
@@ -53,7 +55,7 @@ public class TestSearchByPreferred extends BaseSearchAlgorithmTest {
      */
     public void testSearchByPreferredMatch() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("Domestic Auto Makers", SearchDesignationOption.PREFERRED_ONLY, algorithm,
+        cns = cns.restrictToMatchingDesignations("Domestic Auto Makers", SearchDesignationOption.PREFERRED_ONLY, algorithm,
                 null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
@@ -70,7 +72,7 @@ public class TestSearchByPreferred extends BaseSearchAlgorithmTest {
      */
     public void testSearchByPreferredNoMatch() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("American Car Companies", SearchDesignationOption.PREFERRED_ONLY, algorithm,
+        cns = cns.restrictToMatchingDesignations("American Car Companies", SearchDesignationOption.PREFERRED_ONLY, algorithm,
                 null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
@@ -85,7 +87,7 @@ public class TestSearchByPreferred extends BaseSearchAlgorithmTest {
      */
     public void testSearchByNonPreferredMatch() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("American Car Companies", SearchDesignationOption.NON_PREFERRED_ONLY,
+        cns = cns.restrictToMatchingDesignations("American Car Companies", SearchDesignationOption.NON_PREFERRED_ONLY,
                 algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
@@ -102,7 +104,7 @@ public class TestSearchByPreferred extends BaseSearchAlgorithmTest {
      */
     public void testSearchByNonPreferredNoMatch() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("Domestic Auto Makers", SearchDesignationOption.NON_PREFERRED_ONLY,
+        cns = cns.restrictToMatchingDesignations("Domestic Auto Makers", SearchDesignationOption.NON_PREFERRED_ONLY,
                 algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
@@ -117,7 +119,7 @@ public class TestSearchByPreferred extends BaseSearchAlgorithmTest {
      */
     public void testSearchByAllWithPreferred() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("Domestic Auto Makers", SearchDesignationOption.ALL, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("Domestic Auto Makers", SearchDesignationOption.ALL, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -133,7 +135,7 @@ public class TestSearchByPreferred extends BaseSearchAlgorithmTest {
      */
     public void testSearchByAllWithNonPreferred() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("American Car Companies", SearchDesignationOption.ALL, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("American Car Companies", SearchDesignationOption.ALL, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestSpellingErrorTolerantSubString.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestSpellingErrorTolerantSubString.java
@@ -18,20 +18,22 @@
  */
 package org.LexGrid.LexBIG.Impl.function.query.lucene.searchAlgorithms;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
 import org.LexGrid.LexBIG.Exceptions.LBException;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet.SearchDesignationOption;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * The Class TestWeightedDoubleMetaphone.
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class TestSpellingErrorTolerantSubString extends BaseSearchAlgorithmTest {
 
     /** The algorithm. */
@@ -55,7 +57,7 @@ public class TestSpellingErrorTolerantSubString extends BaseSearchAlgorithmTest 
      */
     public void testSpellingErrorTolerantSubString() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("car", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("car", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -72,7 +74,7 @@ public class TestSpellingErrorTolerantSubString extends BaseSearchAlgorithmTest 
      */
     public void testSpellingErrorTolerantSubStringFirstResult() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("car", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("car", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -88,7 +90,7 @@ public class TestSpellingErrorTolerantSubString extends BaseSearchAlgorithmTest 
      */
     public void testSpellingErrorTolerantSubStringDifferentMetaphoneValue() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("kar", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("kar", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -105,7 +107,7 @@ public class TestSpellingErrorTolerantSubString extends BaseSearchAlgorithmTest 
      */
     public void testSpellingErrorTolerantSubStringDifferentMetaphoneValueFirstResult() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("kar", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("kar", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -121,7 +123,7 @@ public class TestSpellingErrorTolerantSubString extends BaseSearchAlgorithmTest 
      */
     public void testSpellingErrorTolerantSubStringTwoTokens() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("General Motors", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("General Motors", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -137,7 +139,7 @@ public class TestSpellingErrorTolerantSubString extends BaseSearchAlgorithmTest 
      */
     public void testSpellingErrorTolerantSubStringThreeTokensCorrectSpelling() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("Ford Motor Company", SearchDesignationOption.ALL, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("Ford Motor Company", SearchDesignationOption.ALL, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -153,7 +155,7 @@ public class TestSpellingErrorTolerantSubString extends BaseSearchAlgorithmTest 
      */
     public void testSpellingErrorTolerantSubStringThreeTokensDifferentOrder() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("Motor Ford Company", SearchDesignationOption.ALL, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("Motor Ford Company", SearchDesignationOption.ALL, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -167,7 +169,7 @@ public class TestSpellingErrorTolerantSubString extends BaseSearchAlgorithmTest 
      */
     public void testSpellingErrorTolerantSubStringThreeTokensTooMuchDistance() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("Ford Company", SearchDesignationOption.ALL, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("Ford Company", SearchDesignationOption.ALL, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -181,7 +183,7 @@ public class TestSpellingErrorTolerantSubString extends BaseSearchAlgorithmTest 
      */
     public void testSpellingErrorTolerantSubStringThreeTokensSpellingErrorTolerant() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("testyng sam kode", SearchDesignationOption.ALL, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("testyng sam kode", SearchDesignationOption.ALL, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -206,7 +208,7 @@ public class TestSpellingErrorTolerantSubString extends BaseSearchAlgorithmTest 
      */
     public void testSpellingErrorTolerantSubStringSpecialCharacters() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("Kar (with special) charaters!", SearchDesignationOption.ALL, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("Kar (with special) charaters!", SearchDesignationOption.ALL, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -225,7 +227,7 @@ public class TestSpellingErrorTolerantSubString extends BaseSearchAlgorithmTest 
      */
     public void testSpellingErrorTolerantSubStringWrongSpecialCharacters() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("Kar (with special) charaters^", SearchDesignationOption.ALL, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("Kar (with special) charaters^", SearchDesignationOption.ALL, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -239,7 +241,7 @@ public class TestSpellingErrorTolerantSubString extends BaseSearchAlgorithmTest 
     @Test
     public void testBoostOne() throws LBException{
     	CodedNodeSet cns = lbs.getCodingSchemeConcepts(BOOST_SCHEME, null);
-    	cns.restrictToMatchingDesignations("maintenance", SearchDesignationOption.ALL, algorithm, null);
+    	cns = cns.restrictToMatchingDesignations("maintenance", SearchDesignationOption.ALL, algorithm, null);
     	 ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
     	 assertTrue("Length: " + rcrl.length, rcrl.length > 0);
     	 assertTrue(rcrl[0].getEntity().getEntityCode().equals("111"));
@@ -247,7 +249,7 @@ public class TestSpellingErrorTolerantSubString extends BaseSearchAlgorithmTest 
     @Test
     public void testBoostTwo() throws LBException{
     	CodedNodeSet cns = lbs.getCodingSchemeConcepts(BOOST_SCHEME, null);
-    	cns.restrictToMatchingDesignations("mayntenance", SearchDesignationOption.ALL, algorithm, null);
+    	cns = cns.restrictToMatchingDesignations("mayntenance", SearchDesignationOption.ALL, algorithm, null);
     	 ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
     	 assertTrue("Length: " + rcrl.length, rcrl.length > 0);
     	 assertTrue(rcrl[0].getEntity().getEntityCode().equals("22"));
@@ -255,7 +257,7 @@ public class TestSpellingErrorTolerantSubString extends BaseSearchAlgorithmTest 
     @Test
     public void testBoostThree() throws LBException{
     	CodedNodeSet cns = lbs.getCodingSchemeConcepts(BOOST_SCHEME, null);
-    	cns.restrictToMatchingDesignations("maintinance", SearchDesignationOption.ALL, algorithm, null);
+    	cns = cns.restrictToMatchingDesignations("maintinance", SearchDesignationOption.ALL, algorithm, null);
     	 ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
     	 assertTrue("Length: " + rcrl.length, rcrl.length > 0);
     	 assertTrue(rcrl[0].getEntity().getEntityCode().equals("33"));
@@ -263,7 +265,7 @@ public class TestSpellingErrorTolerantSubString extends BaseSearchAlgorithmTest 
     @Test
     public void testBoostFive() throws LBException{
     	CodedNodeSet cns = lbs.getCodingSchemeConcepts(BOOST_SCHEME, null);
-    	cns.restrictToMatchingDesignations("maintenanse", SearchDesignationOption.ALL, algorithm, null);
+    	cns = cns.restrictToMatchingDesignations("maintenanse", SearchDesignationOption.ALL, algorithm, null);
     	 ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
     	 assertTrue("Length: " + rcrl.length, rcrl.length > 0);
     	 assertTrue(rcrl[0].getEntity().getEntityCode().equals("55"));

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestStartsWith.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestStartsWith.java
@@ -21,12 +21,14 @@ package org.LexGrid.LexBIG.Impl.function.query.lucene.searchAlgorithms;
 import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet.SearchDesignationOption;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
 /**
  * The Class TestStartsWith.
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class TestStartsWith extends BaseSearchAlgorithmTest {
 
     /** The algorithm. */
@@ -53,7 +55,7 @@ public class TestStartsWith extends BaseSearchAlgorithmTest {
      */
     public void testStartsWith() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("Automob", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("Automob", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -69,7 +71,7 @@ public class TestStartsWith extends BaseSearchAlgorithmTest {
      */
     public void testStartsWithANDTerms() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("car truck", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("car truck", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -83,7 +85,7 @@ public class TestStartsWith extends BaseSearchAlgorithmTest {
      */
     public void testStartsWithNoMatch() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("Makers", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("Makers", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -97,7 +99,7 @@ public class TestStartsWith extends BaseSearchAlgorithmTest {
      */
     public void testStartsWithCaseInsensitive() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("automob", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("automob", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -114,7 +116,7 @@ public class TestStartsWith extends BaseSearchAlgorithmTest {
      */
     public void testStartsWithSpecialCharacters() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("Car (with special) charaters!", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("Car (with special) charaters!", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -130,7 +132,7 @@ public class TestStartsWith extends BaseSearchAlgorithmTest {
      */
     public void testStartsWithOneSpecialCharacter() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("Car (", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("Car (", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -147,7 +149,7 @@ public class TestStartsWith extends BaseSearchAlgorithmTest {
      */
     public void testStartsWithOneSpecialCharacterDoesntStartWith() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("(with special) charaters!", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("(with special) charaters!", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -161,7 +163,7 @@ public class TestStartsWith extends BaseSearchAlgorithmTest {
      */
     public void testStartsWithNoMatchSpecialCharacters() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("Car {", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("Car {", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -175,7 +177,7 @@ public class TestStartsWith extends BaseSearchAlgorithmTest {
      */
     public void testStartsWithCaseInsensitiveSpecialCharacters() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("CaR (wiTh SpecIal) cHaraters!", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("CaR (wiTh SpecIal) cHaraters!", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestStemming.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestStemming.java
@@ -21,12 +21,14 @@ package org.LexGrid.LexBIG.Impl.function.query.lucene.searchAlgorithms;
 import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet.SearchDesignationOption;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
 /**
  * The Class TestStemming.
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class TestStemming extends BaseSearchAlgorithmTest {
 
     /** The algorithm. */
@@ -53,7 +55,7 @@ public class TestStemming extends BaseSearchAlgorithmTest {
      */
     public void testStemmedLuceneQueryMatch() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("Automobiles", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("Automobiles", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -71,7 +73,7 @@ public class TestStemming extends BaseSearchAlgorithmTest {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
 
         // Note 'Automobiled'... cool word huh?
-        cns.restrictToMatchingDesignations("Automobiled", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("Automobiled", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -87,7 +89,7 @@ public class TestStemming extends BaseSearchAlgorithmTest {
      */
     public void testStemmedLuceneQueryCaseInsensitive() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("automobiles", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("automobiles", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestSubString.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestSubString.java
@@ -22,12 +22,14 @@ import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet.SearchDesignationOption;
 import org.LexGrid.LexBIG.Utility.Constructors;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
 /**
  * The Class TestSubString.
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class TestSubString extends BaseSearchAlgorithmTest {
 
     /** The algorithm. */
@@ -54,7 +56,7 @@ public class TestSubString extends BaseSearchAlgorithmTest {
      */
     public void testSubString() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("graph", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("graph", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -70,7 +72,7 @@ public class TestSubString extends BaseSearchAlgorithmTest {
      */
     public void testSubStringTwoTerm() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("graph building", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("graph building", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -86,7 +88,7 @@ public class TestSubString extends BaseSearchAlgorithmTest {
      */
     public void testSubStringThreeTerms() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("graph building on", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("graph building on", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -102,7 +104,7 @@ public class TestSubString extends BaseSearchAlgorithmTest {
      */
     public void testSubStringAllTerms() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("A concept for testing Graph Building on Concepts with no relations", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("A concept for testing Graph Building on Concepts with no relations", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -118,7 +120,7 @@ public class TestSubString extends BaseSearchAlgorithmTest {
      */
     public void testSubStringInvalidDistance() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("concept testing", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("concept testing", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -132,7 +134,7 @@ public class TestSubString extends BaseSearchAlgorithmTest {
      */
     public void testSubStringInvalidOrder() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("graph testing", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("graph testing", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -147,7 +149,7 @@ public class TestSubString extends BaseSearchAlgorithmTest {
      */
     public void testSubStringLeadingWildcard() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("ncept for testing graph", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("ncept for testing graph", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -163,7 +165,7 @@ public class TestSubString extends BaseSearchAlgorithmTest {
      */
     public void testSubStringTrailingWildcard() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("concept for testing gra", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("concept for testing gra", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -179,7 +181,7 @@ public class TestSubString extends BaseSearchAlgorithmTest {
      */
     public void testSubStringLeadingAndTrailingWildcard() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("ncept for testing gr", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("ncept for testing gr", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -190,8 +192,8 @@ public class TestSubString extends BaseSearchAlgorithmTest {
     
     public void testSubStringExactMatchScoring() throws Exception {
     	 CodedNodeSet cns = super.getAutosCodedNodeSet();
-         cns.restrictToMatchingDesignations("auto", SearchDesignationOption.ALL, getAlgorithm(), null);
-         cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] {"005", "A0001"}));
+         cns = cns.restrictToMatchingDesignations("auto", SearchDesignationOption.ALL, getAlgorithm(), null);
+         cns = cns.restrictToCodes(Constructors.createConceptReferenceList(new String[] {"005", "A0001"}));
 
          ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -210,7 +212,7 @@ public class TestSubString extends BaseSearchAlgorithmTest {
      */
     public void testSubStringNoMatch() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("NO_MATCH_FOR_TESTING", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("NO_MATCH_FOR_TESTING", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -224,7 +226,7 @@ public class TestSubString extends BaseSearchAlgorithmTest {
      */
     public void testSubStringCaseInsensitive() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("GraPH BuIlDing ON ConcEPTS With", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("GraPH BuIlDing ON ConcEPTS With", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestSubStringLiteralSubString.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestSubStringLiteralSubString.java
@@ -18,11 +18,14 @@
  */
 package org.LexGrid.LexBIG.Impl.function.query.lucene.searchAlgorithms;
 
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
+
 /**
  * The Class TestSubStringLiteralSubString.
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class TestSubStringLiteralSubString extends TestSubString {
 
     /** The algorithm. */

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestSubStringNonLeadingWildcardLiteralSubString.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestSubStringNonLeadingWildcardLiteralSubString.java
@@ -21,12 +21,14 @@ package org.LexGrid.LexBIG.Impl.function.query.lucene.searchAlgorithms;
 import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet.SearchDesignationOption;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
 /**
  * The Class TestSubStringLiteralSubString.
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class TestSubStringNonLeadingWildcardLiteralSubString extends TestSubString {
 
     /** The algorithm. */
@@ -42,7 +44,7 @@ public class TestSubStringNonLeadingWildcardLiteralSubString extends TestSubStri
     
     public void testOneTermLeadingWildcard() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("grap", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("grap", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -53,7 +55,7 @@ public class TestSubStringNonLeadingWildcardLiteralSubString extends TestSubStri
     
     public void testOneTermTrailingWildcard() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("raph", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("raph", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -64,7 +66,7 @@ public class TestSubStringNonLeadingWildcardLiteralSubString extends TestSubStri
     
     public void testOneTermLeadingAndTrailingWildcardNoMatch() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("rap", SearchDesignationOption.ALL, getAlgorithm(), null);
+        cns = cns.restrictToMatchingDesignations("rap", SearchDesignationOption.ALL, getAlgorithm(), null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestWeightedDoubleMetaphone.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/lucene/searchAlgorithms/TestWeightedDoubleMetaphone.java
@@ -21,12 +21,14 @@ package org.LexGrid.LexBIG.Impl.function.query.lucene.searchAlgorithms;
 import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet.SearchDesignationOption;
+import org.LexGrid.LexBIG.Utility.RemoteApiSafeTest;
 
 /**
  * The Class TestWeightedDoubleMetaphone.
  * 
  * @author <a href="mailto:kevin.peterson@mayo.edu">Kevin Peterson</a>
  */
+@RemoteApiSafeTest
 public class TestWeightedDoubleMetaphone extends BaseSearchAlgorithmTest {
 
     /** The algorithm. */
@@ -50,7 +52,7 @@ public class TestWeightedDoubleMetaphone extends BaseSearchAlgorithmTest {
      */
     public void testDoubleMetaphone() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("car", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("car", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -67,7 +69,7 @@ public class TestWeightedDoubleMetaphone extends BaseSearchAlgorithmTest {
      */
     public void testDoubleMetaphoneDifferentMetaphoneValue() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("kar", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("kar", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -84,7 +86,7 @@ public class TestWeightedDoubleMetaphone extends BaseSearchAlgorithmTest {
      */
     public void testDoubleMetaphoneCaseInsensitive() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("CaR", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("CaR", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -101,7 +103,7 @@ public class TestWeightedDoubleMetaphone extends BaseSearchAlgorithmTest {
      */
     public void testDoubleMetaphoneDifferentMetaphoneValueCaseInsensitive() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("KaR", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("KaR", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -118,7 +120,7 @@ public class TestWeightedDoubleMetaphone extends BaseSearchAlgorithmTest {
      */
     public void testDoubleMetaphoneReturnOrder() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("car", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("car", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -134,7 +136,7 @@ public class TestWeightedDoubleMetaphone extends BaseSearchAlgorithmTest {
      */
     public void testDoubleMetaphoneReturnOrderDifferentMetaphoneValue() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("kar", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("kar", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 
@@ -150,7 +152,7 @@ public class TestWeightedDoubleMetaphone extends BaseSearchAlgorithmTest {
      */
     public void testDoubleMetaphoneANDTerms() throws Exception {
         CodedNodeSet cns = super.getAutosCodedNodeSet();
-        cns.restrictToMatchingDesignations("kar truk", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
+        cns = cns.restrictToMatchingDesignations("kar truk", SearchDesignationOption.PREFERRED_ONLY, algorithm, null);
 
         ResolvedConceptReference[] rcrl = cns.resolveToList(null, null, null, -1).getResolvedConceptReference();
 

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/testUtility/LexBIGServiceTestFactory.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/testUtility/LexBIGServiceTestFactory.java
@@ -1,0 +1,12 @@
+package org.LexGrid.LexBIG.Impl.testUtility;
+
+
+import org.LexGrid.LexBIG.LexBIGService.LexBIGService;
+
+public interface LexBIGServiceTestFactory {
+
+    public final static String LBS_TEST_FACTORY_ENV = "LBS_TEST_FACTORY";
+
+    LexBIGService getLbs();
+
+}

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/testUtility/ServiceHolder.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/testUtility/ServiceHolder.java
@@ -18,19 +18,20 @@
  */
 package org.LexGrid.LexBIG.Impl.testUtility;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Properties;
-import java.util.UUID;
-
 import org.LexGrid.LexBIG.Exceptions.LBException;
 import org.LexGrid.LexBIG.Impl.LexBIGServiceImpl;
 import org.LexGrid.LexBIG.LexBIGService.LexBIGService;
 import org.apache.commons.lang.BooleanUtils;
+import org.apache.commons.lang.StringUtils;
 import org.lexevs.dao.test.BaseInMemoryLexEvsTest;
 import org.lexevs.system.ResourceManager;
 import org.lexevs.system.constants.SystemVariables;
 import org.lexevs.system.utility.PropertiesUtility;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Properties;
+import java.util.UUID;
 
 /**
  * Singleton class for getting a LexBIGService for the JUnit test cases.
@@ -47,7 +48,7 @@ public class ServiceHolder {
     public static File testConfigFolder_;
     private boolean singleConfigMode_;
 
-    private LexBIGServiceImpl lbsi_;
+    private LexBIGService lbsi_;
 
     /**
      * Use this to get an instance of the ServiceHolder. If
@@ -131,8 +132,12 @@ public class ServiceHolder {
                 if(inMemory){
                 	BaseInMemoryLexEvsTest.initInMemory();
                 }
-                
-                lbsi_ = LexBIGServiceImpl.defaultInstance();
+
+                if(StringUtils.isNotBlank(System.getProperty(LexBIGServiceTestFactory.LBS_TEST_FACTORY_ENV))) {
+                    lbsi_ = ((LexBIGServiceTestFactory) Class.forName(System.getProperty(LexBIGServiceTestFactory.LBS_TEST_FACTORY_ENV)).newInstance()).getLbs();
+                } else {
+                    lbsi_ = LexBIGServiceImpl.defaultInstance();
+                }
             }
 
         } catch (Exception e) {

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Utility/RemoteApiSafeTest.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Utility/RemoteApiSafeTest.java
@@ -1,0 +1,11 @@
+package org.LexGrid.LexBIG.Utility;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface RemoteApiSafeTest {
+}


### PR DESCRIPTION
LEXEVS-1847: Added a @RemoteApiSafeTest annotation to allow the re-use of local tests for the remote API.