### PR TITLE
Fix allowing transitive properties in OWL to be loaded as hierarchies…

### DIFF
--- a/lbTest/resources/testData/owl2/owl2-special-cases-Defined-Annotated.owl
+++ b/lbTest/resources/testData/owl2/owl2-special-cases-Defined-Annotated.owl
@@ -287,7 +287,15 @@
         <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000081"/><!-- role of -->
     </owl:ObjectProperty>                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            
-    
+       <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#Anatomic_Structure_Has_Location -->
+
+    <owl:ObjectProperty rdf:about="#R81">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Anatomic_Structure_Has_Location</rdfs:label>
+        <code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R81</code>
+        <rdfs:range rdf:resource="#C12219"/>
+        <rdfs:domain rdf:resource="#C12219"/>
+    </owl:ObjectProperty>
 
 
     <!-- 

--- a/lbTest/src/test/java/edu/mayo/informatics/lexgrid/convert/directConversions/owl2/OWL2SpecialCaseSnippetTestIT.java
+++ b/lbTest/src/test/java/edu/mayo/informatics/lexgrid/convert/directConversions/owl2/OWL2SpecialCaseSnippetTestIT.java
@@ -19,8 +19,10 @@ import org.LexGrid.LexBIG.Impl.function.LexBIGServiceTestCase;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeGraph;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.Utility.Constructors;
+import org.LexGrid.codingSchemes.CodingScheme;
 import org.LexGrid.commonTypes.Property;
 import org.LexGrid.concepts.Presentation;
+import org.LexGrid.naming.SupportedHierarchy;
 import org.apache.commons.lang.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -404,5 +406,22 @@ public class OWL2SpecialCaseSnippetTestIT extends DataLoadTestBaseSpecialCases {
 				.iterateResolvedConceptReference();
 		assertTrue(validateTarget("obi.owl", itr));
 	}
+	
+	@Test
+	public void testLoadTransitivePropertiesAsHierarchies() throws LBException {
+
+		CodingSchemeVersionOrTag versionOrTag = new CodingSchemeVersionOrTag();
+		versionOrTag.setVersion("0.1.5");
+		CodingScheme scheme = lbs.resolveCodingScheme(LexBIGServiceTestCase.OWL2_SNIPPET_INDIVIDUAL_URN, versionOrTag);
+		List<SupportedHierarchy> hrchy = scheme.getMappings().getSupportedHierarchyAsReference();
+		boolean exists = false;
+		for(SupportedHierarchy sh :hrchy){
+			if(sh.getLocalId().equals("Anatomic_Structure_Has_Location")){
+				exists = true;
+			}
+		}
+		assertTrue(exists);
+	}
+
 
 }

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/testUtility/AllTestsNormalConfig.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/testUtility/AllTestsNormalConfig.java
@@ -203,6 +203,7 @@ import edu.mayo.informatics.lexgrid.convert.directConversions.owl2.NewOWL2Unanno
 import edu.mayo.informatics.lexgrid.convert.directConversions.owl2.OWL2LoaderLexGridTest;
 import edu.mayo.informatics.lexgrid.convert.directConversions.owl2.OWL2PrimitivesSnippetTestIT;
 import edu.mayo.informatics.lexgrid.convert.directConversions.owl2.OWL2PrimitivesUnannotatedSnippetTestIT;
+import edu.mayo.informatics.lexgrid.convert.directConversions.owl2.OWL2SpecialCaseSnippetTestIT;
 import edu.mayo.informatics.lexgrid.convert.directConversions.owl2.PresentationPropertyTestIT;
 import edu.mayo.informatics.lexgrid.convert.directConversions.owlapi.OWL2UnitTests;
 import edu.mayo.informatics.lexgrid.convert.directConversions.owlapi.OWLUnitTests;
@@ -267,6 +268,7 @@ public class AllTestsNormalConfig {
         owl2LoaderSuite.addTestSuite(NewOWL2UnannotatedSnippetTestIT.class);
         owl2LoaderSuite.addTestSuite(OWL2PrimitivesSnippetTestIT.class);
         owl2LoaderSuite.addTestSuite(OWL2PrimitivesUnannotatedSnippetTestIT.class);
+        owl2LoaderSuite.addTestSuite(OWL2SpecialCaseSnippetTestIT.class);
         owl2LoaderSuite.addTestSuite(OWL2UnitTests.class);
         mainSuite.addTest(owl2LoaderSuite);
         

--- a/lgConverter/src/edu/mayo/informatics/lexgrid/convert/directConversions/owlapi/OwlApi2LG.java
+++ b/lgConverter/src/edu/mayo/informatics/lexgrid/convert/directConversions/owlapi/OwlApi2LG.java
@@ -2197,8 +2197,15 @@ public class OwlApi2LG {
         }
         if (owlProp instanceof OWLObjectProperty) {
             OWLObjectProperty objectProp = (OWLObjectProperty) owlProp;
+            boolean isTransitive = objectProp.isTransitive(ontology);
             resolveAssociationProperty(assocWrap.getAssociationEntity(), objectProp);
-            assocWrap.setIsTransitive(objectProp.isTransitive(ontology));
+            assocWrap.setIsTransitive(isTransitive);
+            List<String> list = new ArrayList<String>();
+            list.add(label);
+            if(isTransitive){
+                lgSupportedMappings_.registerSupportedHierarchy(label, 
+                        owlProp.getIRI().toString(), label, "@@", list, false, true);
+            }
         } else if (owlProp instanceof OWLDataProperty) {
             OWLDataProperty dataProp = (OWLDataProperty) owlProp;
             resolveAssociationProperty(assocWrap.getAssociationEntity(), dataProp);
@@ -2214,6 +2221,7 @@ public class OwlApi2LG {
 
         lgSupportedMappings_.registerSupportedAssociation(label, owlProp.getIRI().toString(), label, propertyName,
                 nameSpace, true);
+        
         return assocWrap;
 
     }


### PR DESCRIPTION
… without configuring in the manifest