### PR TITLE
bugfix/LEXEVS-2801 Updated AssociationWrapper to set the entityDescription as the formal name (6.4.0 branch).

### DIFF
--- a/lbTest/src/test/java/edu/mayo/informatics/lexgrid/convert/directConversions/owl2/NewOWL2SnippetTestIT.java
+++ b/lbTest/src/test/java/edu/mayo/informatics/lexgrid/convert/directConversions/owl2/NewOWL2SnippetTestIT.java
@@ -155,6 +155,16 @@ public class NewOWL2SnippetTestIT extends DataLoadTestBaseSnippet2 {
 		assertFalse(validateProperty("AssociationURI", "http://purl.obolibrary.org/obo/CL_0000148", rcr));
 	}
 	
+	@Test 
+	public void testPropertyForAnnotationPropertyAssociationDescription()throws LBInvocationException, LBParameterException, LBResourceUnavailableException{
+		cns = cns.restrictToCodes(Constructors.createConceptReferenceList("AssociationURI"));
+		ResolvedConceptReferencesIterator itr = cns.resolve(null, null, null);
+		assertNotNull(itr);
+		assertTrue(itr.hasNext());
+		ResolvedConceptReference rcr = itr.next();		
+		assertTrue(rcr.getEntityDescription().getContent().equals("AssociationURI"));
+	}
+	
 	@Test
 	public void testPropertyForAnnotationPropertyAssociationLIT()throws LBInvocationException, LBParameterException, LBResourceUnavailableException{
 		cns = cns.restrictToCodes(Constructors.createConceptReferenceList("HappyPatientWalkingAround"));
@@ -989,6 +999,5 @@ public class NewOWL2SnippetTestIT extends DataLoadTestBaseSnippet2 {
 		Iterator<? extends ResolvedConceptReference> itr1 = list1.iterateResolvedConceptReference();
 		assertTrue(validateQualifier("PlainLiteral", "homo sapiens", itr1));
 	}
-	
 
 }

--- a/lgConverter/src/edu/mayo/informatics/lexgrid/convert/directConversions/owlapi/AssociationWrapper.java
+++ b/lgConverter/src/edu/mayo/informatics/lexgrid/convert/directConversions/owlapi/AssociationWrapper.java
@@ -18,6 +18,7 @@
  */
 package edu.mayo.informatics.lexgrid.convert.directConversions.owlapi;
 
+import org.LexGrid.commonTypes.EntityDescription;
 import org.LexGrid.commonTypes.Property;
 import org.LexGrid.custom.concepts.EntityFactory;
 import org.LexGrid.relations.AssociationEntity;
@@ -73,6 +74,12 @@ public class AssociationWrapper {
     
     public void setForwardName(String forwardName) {
         ae.setForwardName(forwardName);
+    }
+    
+    public void setEntityDescription(String description) {
+        EntityDescription ed = new EntityDescription();
+        ed.setContent(description);
+        ae.setEntityDescription(ed);
     }
     
     public void setReverseName(String reverseName) {

--- a/lgConverter/src/edu/mayo/informatics/lexgrid/convert/directConversions/owlapi/OwlApi2LG.java
+++ b/lgConverter/src/edu/mayo/informatics/lexgrid/convert/directConversions/owlapi/OwlApi2LG.java
@@ -2237,23 +2237,29 @@ public class OwlApi2LG {
         Set<OWLAnnotationAssertionAxiom> assertions = ontology.getAnnotationAssertionAxioms(owlProp.getIRI());
         AssociationWrapper assocWrap = new AssociationWrapper();
         if(!assertions.isEmpty()){
-        for(OWLAnnotationAssertionAxiom ax : assertions){
-            Property prop = new Property();
-            prop.setPropertyName(ax.getProperty().getIRI().getFragment());
-            //If not a literal -- don't try to add it as a property.
-            if(ax.getValue() instanceof IRI){
-                continue;
+            for(OWLAnnotationAssertionAxiom ax : assertions){
+                Property prop = new Property();
+                prop.setPropertyName(ax.getProperty().getIRI().getFragment());
+                //If not a literal -- don't try to add it as a property.
+                if(ax.getValue() instanceof IRI){
+                    continue;
+                }
+                OWLLiteral literal = (OWLLiteral) ax.getValue();
+                prop.setValue(Constructors.createText(literal.getLiteral()));
+                assocWrap.addProperty(prop);
             }
-            OWLLiteral literal = (OWLLiteral) ax.getValue();
-            prop.setValue(Constructors.createText(literal.getLiteral()));
-            assocWrap.addProperty(prop);
-        }
         }
         String propertyName = getLocalName(owlProp);
         assocWrap.setEntityCode(propertyName);
         String label = resolveLabel(owlProp);
         assocWrap.setAssociationName(label);
-        assocWrap.setForwardName(getAssociationLabel(label, true));
+        
+        String forwardName = getAssociationLabel(label, true);
+        assocWrap.setForwardName(forwardName);
+        
+        // set the description to be the same as the forward name
+        assocWrap.setEntityDescription(forwardName);
+        
         String nameSpace = getNameSpace(owlProp);
         assocWrap.setEntityCodeNamespace(nameSpace);
         assocWrap = assocManager.addAssociation(lgRelationsContainer_Assoc, assocWrap);


### PR DESCRIPTION
LEXEVS-2801 Updated AssociationWrapper to set the entityDescription as the formal name.   This is for Annotations As Association. (6.4.0 branch)