### PR TITLE
Bugfix/lexevs 2802  OWL2 Loader updated to reference complex property style annotation properties

### DIFF
--- a/lbTest/resources/testData/owl2/catalog-v001.xml
+++ b/lbTest/resources/testData/owl2/catalog-v001.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1487861134557" name="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2-snippet.owl" uri="owl2-snippet-data.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1487861134557" name="duplicate:http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl" uri="owl2-special-cases-byName-Defined-Annotated2.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1487861134557" name="duplicate:http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl" uri="owl2-special-cases-Defined-Annotated.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1487861134557" name="duplicate:http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl" uri="owl2-test-cases-Defined-Annotated.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1487861134557" name="duplicate:http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl" uri="owl2-test-cases-Defined-Unannotated.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1487861134557" name="duplicate:http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl" uri="owl2-test-cases-Primitive-Annotated.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1487861134557" name="duplicate:http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl" uri="owl2-test-cases-Primitive-Unannotated.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1490114891844" name="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2-snippet.owl" uri="owl2-snippet-data.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1490114891844" name="duplicate:http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl" uri="owl2-special-cases-byName-Defined-Annotated2.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1490114891844" name="duplicate:http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl" uri="owl2-special-cases-Defined-Annotated.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1490114891844" name="duplicate:http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl" uri="owl2-test-cases-Defined-Annotated.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1490114891844" name="duplicate:http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl" uri="owl2-test-cases-Defined-Unannotated.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1490114891844" name="duplicate:http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl" uri="owl2-test-cases-Primitive-Annotated.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1490114891844" name="duplicate:http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl" uri="owl2-test-cases-Primitive-Unannotated.owl"/>
     </group>
 </catalog>

--- a/lbTest/resources/testData/owl2/owl2-special-cases-Defined-Annotated.owl
+++ b/lbTest/resources/testData/owl2/owl2-special-cases-Defined-Annotated.owl
@@ -247,6 +247,28 @@
         <P384>NCI</P384>
     </owl:Axiom>
     
+       <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#ALT_DEFINITION -->
+
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P325">
+        <P97>English language definitions of what a source other than NCI means by the concept. These are limited to 1024 characters. They include information about the definition&apos;s source in a form that can easily be interpreted by software.</P97>
+        <P90>ALT_DEFINITION</P90>
+        <NHC0>P325</NHC0>
+        <rdfs:label>ALT_DEFINITION</rdfs:label>
+    </owl:AnnotationProperty>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P325"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97"/>
+        <owl:annotatedTarget>English language definitions of what a source other than NCI means by the concept. These are limited to 1024 characters. They include information about the definition&apos;s source in a form that can easily be interpreted by software.</owl:annotatedTarget>
+        <P378>NCI</P378>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P325"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
+        <owl:annotatedTarget>ALT_DEFINITION</owl:annotatedTarget>
+        <P383>PT</P383>
+        <P384>NCI</P384>
+    </owl:Axiom>
+    
        <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Term_Browser_Value_Set_Description -->
 
     <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P376">
@@ -312,6 +334,14 @@
         <owl:annotatedTarget>code</owl:annotatedTarget>
         <P383>PT</P383>
     </owl:Axiom>
+    
+        <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#def-source -->
+
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P378">
+        <P108>def-source</P108>
+        <NHC0>P378</NHC0>
+        <rdfs:label>def-source</rdfs:label>
+    </owl:AnnotationProperty>
     
         <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term-group -->
 
@@ -2148,6 +2178,12 @@ A cultured cell population maintained in vitro: "Rat cortical neurons from 15 da
         <P90>SDTM-OETESTCD</P90>
         <rdfs:label>CDISC SDTM Ophthalmic Exam Test Code Terminology</rdfs:label>
     </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C117743"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P325"/>
+        <owl:annotatedTarget>Terminology relevant to the test codes that describe findings from ophthalmic examinations.</owl:annotatedTarget>
+        <P378>CDISC</P378>
+    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C117743"/>
         <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>

--- a/lbTest/src/test/java/edu/mayo/informatics/lexgrid/convert/directConversions/owl2/NewOWL2SnippetTestIT.java
+++ b/lbTest/src/test/java/edu/mayo/informatics/lexgrid/convert/directConversions/owl2/NewOWL2SnippetTestIT.java
@@ -155,6 +155,16 @@ public class NewOWL2SnippetTestIT extends DataLoadTestBaseSnippet2 {
 		assertFalse(validateProperty("AssociationURI", "http://purl.obolibrary.org/obo/CL_0000148", rcr));
 	}
 	
+	@Test 
+	public void testPropertyForAnnotationPropertyAssociationDescription()throws LBInvocationException, LBParameterException, LBResourceUnavailableException{
+		cns = cns.restrictToCodes(Constructors.createConceptReferenceList("AssociationURI"));
+		ResolvedConceptReferencesIterator itr = cns.resolve(null, null, null);
+		assertNotNull(itr);
+		assertTrue(itr.hasNext());
+		ResolvedConceptReference rcr = itr.next();		
+		assertTrue(rcr.getEntityDescription().getContent().equals("AssociationURI"));
+	}
+	
 	@Test
 	public void testPropertyForAnnotationPropertyAssociationLIT()throws LBInvocationException, LBParameterException, LBResourceUnavailableException{
 		cns = cns.restrictToCodes(Constructors.createConceptReferenceList("HappyPatientWalkingAround"));
@@ -989,6 +999,5 @@ public class NewOWL2SnippetTestIT extends DataLoadTestBaseSnippet2 {
 		Iterator<? extends ResolvedConceptReference> itr1 = list1.iterateResolvedConceptReference();
 		assertTrue(validateQualifier("PlainLiteral", "homo sapiens", itr1));
 	}
-	
 
 }

--- a/lbTest/src/test/java/edu/mayo/informatics/lexgrid/convert/directConversions/owl2/OWL2SpecialCaseSnippetTestIT.java
+++ b/lbTest/src/test/java/edu/mayo/informatics/lexgrid/convert/directConversions/owl2/OWL2SpecialCaseSnippetTestIT.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import org.LexGrid.LexBIG.DataModel.Collections.AssociationList;
 import org.LexGrid.LexBIG.DataModel.Collections.ResolvedConceptReferenceList;
+import org.LexGrid.LexBIG.Utility.Iterators.ResolvedConceptReferencesIterator;
 import org.LexGrid.LexBIG.DataModel.Core.AssociatedConcept;
 import org.LexGrid.LexBIG.DataModel.Core.Association;
 import org.LexGrid.LexBIG.DataModel.Core.CodingSchemeVersionOrTag;
@@ -21,6 +22,7 @@ import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
 import org.LexGrid.LexBIG.Utility.Constructors;
 import org.LexGrid.codingSchemes.CodingScheme;
 import org.LexGrid.commonTypes.Property;
+import org.LexGrid.concepts.Definition;
 import org.LexGrid.concepts.Presentation;
 import org.LexGrid.naming.SupportedHierarchy;
 import org.apache.commons.lang.StringUtils;
@@ -482,6 +484,7 @@ public class OWL2SpecialCaseSnippetTestIT extends DataLoadTestBaseSpecialCases {
 				.iterateResolvedConceptReference();
 		assertTrue(validateTarget("C117743", itr));
 	}
+		
 	
 	@Test
 	public void testAnnotationPropAsProperty() throws LBInvocationException, LBParameterException{
@@ -532,8 +535,30 @@ public class OWL2SpecialCaseSnippetTestIT extends DataLoadTestBaseSpecialCases {
 			assertTrue(prop.getSource().length > 0);
 			assertTrue(prop.getSource()[0].getContent().equals("CDISC"));
 		}
-		}	
+		}
 	}
+		
+		@Test
+		public void testDefSourceAsSource() throws LBException{
+			CodingSchemeVersionOrTag versionOrTag = new CodingSchemeVersionOrTag();
+			versionOrTag.setVersion("0.1.5");
+			CodedNodeSet set = lbs.getCodingSchemeConcepts(
+					LexBIGServiceTestCase.OWL2_SNIPPET_INDIVIDUAL_URN, versionOrTag);
+			set = set.restrictToCodes(Constructors.createConceptReferenceList("C117743"));
+			ResolvedConceptReferenceList rcrlist = set.resolveToList(null, null, null, -1);
+			Iterator<? extends ResolvedConceptReference> itr = rcrlist.iterateResolvedConceptReference();
+			assertNotNull(itr);
+			assertTrue(itr.hasNext());
+			ResolvedConceptReference rcr = itr.next();
+			assertTrue(rcr.getEntity().getDefinition().length > 0);
+			for(Definition def :rcr.getEntity().getDefinition()){
+				if(def.getValue().getContent().equals("Terminology relevant to the test codes that describe findings from ophthalmic examinations.")){
+				assertTrue(def.getSource().length > 0);
+				assertTrue(def.getSource()[0].getContent().equals("CDISC"));
+			}
+			}
+		}
+	
 	
 	
 

--- a/lgConverter/src/edu/mayo/informatics/lexgrid/convert/directConversions/owlapi/AssociationWrapper.java
+++ b/lgConverter/src/edu/mayo/informatics/lexgrid/convert/directConversions/owlapi/AssociationWrapper.java
@@ -18,6 +18,7 @@
  */
 package edu.mayo.informatics.lexgrid.convert.directConversions.owlapi;
 
+import org.LexGrid.commonTypes.EntityDescription;
 import org.LexGrid.commonTypes.Property;
 import org.LexGrid.custom.concepts.EntityFactory;
 import org.LexGrid.relations.AssociationEntity;
@@ -73,6 +74,12 @@ public class AssociationWrapper {
     
     public void setForwardName(String forwardName) {
         ae.setForwardName(forwardName);
+    }
+    
+    public void setEntityDescription(String description) {
+        EntityDescription ed = new EntityDescription();
+        ed.setContent(description);
+        ae.setEntityDescription(ed);
     }
     
     public void setReverseName(String reverseName) {

--- a/lgConverter/src/edu/mayo/informatics/lexgrid/convert/directConversions/owlapi/OwlApi2LG.java
+++ b/lgConverter/src/edu/mayo/informatics/lexgrid/convert/directConversions/owlapi/OwlApi2LG.java
@@ -2237,23 +2237,29 @@ public class OwlApi2LG {
         Set<OWLAnnotationAssertionAxiom> assertions = ontology.getAnnotationAssertionAxioms(owlProp.getIRI());
         AssociationWrapper assocWrap = new AssociationWrapper();
         if(!assertions.isEmpty()){
-        for(OWLAnnotationAssertionAxiom ax : assertions){
-            Property prop = new Property();
-            prop.setPropertyName(ax.getProperty().getIRI().getFragment());
-            //If not a literal -- don't try to add it as a property.
-            if(ax.getValue() instanceof IRI){
-                continue;
+            for(OWLAnnotationAssertionAxiom ax : assertions){
+                Property prop = new Property();
+                prop.setPropertyName(ax.getProperty().getIRI().getFragment());
+                //If not a literal -- don't try to add it as a property.
+                if(ax.getValue() instanceof IRI){
+                    continue;
+                }
+                OWLLiteral literal = (OWLLiteral) ax.getValue();
+                prop.setValue(Constructors.createText(literal.getLiteral()));
+                assocWrap.addProperty(prop);
             }
-            OWLLiteral literal = (OWLLiteral) ax.getValue();
-            prop.setValue(Constructors.createText(literal.getLiteral()));
-            assocWrap.addProperty(prop);
-        }
         }
         String propertyName = getLocalName(owlProp);
         assocWrap.setEntityCode(propertyName);
         String label = resolveLabel(owlProp);
         assocWrap.setAssociationName(label);
-        assocWrap.setForwardName(getAssociationLabel(label, true));
+        
+        String forwardName = getAssociationLabel(label, true);
+        assocWrap.setForwardName(forwardName);
+        
+        // set the description to be the same as the forward name
+        assocWrap.setEntityDescription(forwardName);
+        
         String nameSpace = getNameSpace(owlProp);
         assocWrap.setEntityCodeNamespace(nameSpace);
         assocWrap = assocManager.addAssociation(lgRelationsContainer_Assoc, assocWrap);

--- a/lgConverter/src/edu/mayo/informatics/lexgrid/convert/directConversions/owlapi/OwlApi2LG.java
+++ b/lgConverter/src/edu/mayo/informatics/lexgrid/convert/directConversions/owlapi/OwlApi2LG.java
@@ -222,7 +222,7 @@ public class OwlApi2LG {
     final static OWLDataFactory factory = manager.getOWLDataFactory();
 
     private static final Object PROPERTY_SOURCE = "term-source";
-
+    private static final Object DEFINITION_SOURCE = "def-source";
     private static final Object REPRESENTATIONAL_FORM = "term-group";
     
     /**
@@ -1515,6 +1515,14 @@ public class OwlApi2LG {
                  continue;
                 }
             }
+            
+            //Do the same for Definition sources
+            if(lgProp instanceof Definition && isSource(annotationName)){
+                Source source = new Source();
+                source.setContent(annotationValue);
+                sources.add(source);
+                continue;
+            }
                 
             if (StringUtils.isNotBlank(annotationName) && StringUtils.isNotBlank(annotationValue)) {
                 lgProp.addPropertyQualifier(CreateUtils.createPropertyQualifier(annotationName, annotationValue,
@@ -1538,7 +1546,7 @@ public class OwlApi2LG {
 
     private boolean isSource(String annotationValue) {
         // TODO Auto-generated method stub
-        return annotationValue.equals(PROPERTY_SOURCE);
+        return annotationValue.equals(PROPERTY_SOURCE ) || annotationValue.equals(DEFINITION_SOURCE);
     }
 
     private boolean isRepresentationalForm(String annotationValue) {


### PR DESCRIPTION
OWL2 loads of OWL2 source no longer reference complex properties to define attributes such as source for definitions.  This remedies some of the source related failings of the OWL2 loader. 