### PR TITLE
LEXEVS-2850.  Adding VM args to eclipse Ant launch config for https c…

### DIFF
--- a/lbPackager/resources/lbPackager build.xml [build-lexbig].launch
+++ b/lbPackager/resources/lbPackager build.xml [build-lexbig].launch
@@ -17,6 +17,7 @@
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.eclipse.ant.internal.launching.remote.InternalAntRunner"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="lbPackager"/>
 <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.ant.ui.AntClasspathProvider"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dhttps.protocols=TLSv1.1,TLSv1.2 -Dforce.http.jre.executor=true -Xmx3072m -XX:MaxPermSize=752m"/>
 <stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="${workspace_loc:/lbPackager/build.xml}"/>
 <stringAttribute key="process_factory_id" value="org.eclipse.ant.ui.remoteAntProcessFactory"/>
 </launchConfiguration>


### PR DESCRIPTION
We've persisted a number of release and third party items to an NIH nexus server.  The https configuration requires some special VM arguments for the build.  