### PR TITLE
Bugfix/lexevs 2848 Query against non  production terminology using namespace fails

### DIFF
--- a/lbImpl/src/org/LexGrid/LexBIG/Impl/namespace/DefaultNamespaceHandler.java
+++ b/lbImpl/src/org/LexGrid/LexBIG/Impl/namespace/DefaultNamespaceHandler.java
@@ -45,6 +45,15 @@ public class DefaultNamespaceHandler implements NamespaceHandler {
 
     private static final long serialVersionUID = 7565547967975571009L;
     
+    private LexEvsServiceLocator serviceLocator;
+    
+    public DefaultNamespaceHandler(){
+        this(LexEvsServiceLocator.getInstance());
+    }
+    
+    protected DefaultNamespaceHandler(LexEvsServiceLocator instance) {
+       serviceLocator = instance;
+    }
     @Override
     @CacheMethod
     public String getCodingSchemeNameForNamespace(String codingSchemeUri, String version, String namespace)
@@ -82,7 +91,9 @@ public class DefaultNamespaceHandler implements NamespaceHandler {
         
         if(sns == null || 
                 StringUtils.isBlank(sns.getEquivalentCodingScheme()) ||
-                namespace.equals(cs.getCodingSchemeName())){
+                namespace.equals(cs.getCodingSchemeName())                
+                || sns.getEquivalentCodingScheme().equals(cs.getCodingSchemeName())
+                ){
             return Constructors.createAbsoluteCodingSchemeVersionReference(codingSchemeUri, version);
         }
         String uri;
@@ -93,7 +104,7 @@ public class DefaultNamespaceHandler implements NamespaceHandler {
             uri = scs.getUri();
         } else {
             try {
-                uri = LexEvsServiceLocator.getInstance().
+                uri = serviceLocator.
                     getSystemResourceService().getUriForUserCodingSchemeName(sns.getEquivalentCodingScheme(), null);
             } catch (Exception e) {
                 LoggerFactory.getLogger().info("The Equivalent Coding Scheme:" + sns.getEquivalentCodingScheme() + " was not found in the system.");
@@ -101,7 +112,7 @@ public class DefaultNamespaceHandler implements NamespaceHandler {
             }
         }
         
-        Registry registry = LexEvsServiceLocator.getInstance().getRegistry();
+        Registry registry = serviceLocator.getRegistry();
         
         List<RegistryEntry> entries = registry.getAllRegistryEntriesOfTypeAndURI(ResourceType.CODING_SCHEME, uri);
         
@@ -130,7 +141,7 @@ public class DefaultNamespaceHandler implements NamespaceHandler {
     
     private CodingScheme getCodingScheme(String uri, String version) {
         CodingSchemeService service = 
-            LexEvsServiceLocator.getInstance().getDatabaseServiceManager().getCodingSchemeService();
+            serviceLocator.getDatabaseServiceManager().getCodingSchemeService();
         
         return service.getCodingSchemeByUriAndVersion(uri, version);  
     }

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/namespace/DefaultNamespaceHandlerTest.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/namespace/DefaultNamespaceHandlerTest.java
@@ -1,7 +1,5 @@
 package org.LexGrid.LexBIG.Impl.namespace;
 
-import static org.junit.Assert.*;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -21,7 +19,9 @@ import org.lexevs.registry.service.Registry.ResourceType;
 import org.lexevs.system.service.SystemResourceService;
 import org.mockito.Mockito;
 
-public class DefaultNamespaceHandlerTest {
+import junit.framework.TestCase;
+
+public class DefaultNamespaceHandlerTest extends TestCase {
 	
 	String uri = "urn:oid:11.11.0.1";
 	String ver1 = "1.0";

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/namespace/DefaultNamespaceHandlerTest.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/namespace/DefaultNamespaceHandlerTest.java
@@ -1,0 +1,102 @@
+package org.LexGrid.LexBIG.Impl.namespace;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.LexGrid.LexBIG.Exceptions.LBParameterException;
+import org.LexGrid.codingSchemes.CodingScheme;
+import org.LexGrid.naming.Mappings;
+import org.LexGrid.naming.SupportedCodingScheme;
+import org.LexGrid.naming.SupportedNamespace;
+import org.junit.Before;
+import org.junit.Test;
+import org.lexevs.dao.database.service.DatabaseServiceManager;
+import org.lexevs.dao.database.service.codingscheme.CodingSchemeService;
+import org.lexevs.locator.LexEvsServiceLocator;
+import org.lexevs.registry.model.RegistryEntry;
+import org.lexevs.registry.service.Registry;
+import org.lexevs.registry.service.Registry.ResourceType;
+import org.lexevs.system.service.SystemResourceService;
+import org.mockito.Mockito;
+
+public class DefaultNamespaceHandlerTest {
+	
+	String uri = "urn:oid:11.11.0.1";
+	String ver1 = "1.0";
+	String name1 = "Automobiles";
+	String nmspc = "Autos";
+	String ver2 = "1.1";
+	
+
+	CodingScheme scheme1;
+	
+	Mappings maps;
+	private SupportedCodingScheme supScheme;
+	private SupportedNamespace namespace;
+
+	public LexEvsServiceLocator locator = Mockito.mock(LexEvsServiceLocator.class);
+	public DatabaseServiceManager dbs = Mockito.mock(DatabaseServiceManager.class);
+	public CodingSchemeService css = Mockito.mock(CodingSchemeService.class);
+	public SystemResourceService srs = Mockito.mock(SystemResourceService.class);
+	public DefaultNamespaceHandler constHandler = new DefaultNamespaceHandler(locator);
+	private Registry registry = Mockito.mock(Registry.class);
+	private List<RegistryEntry> entries;
+
+	
+
+	
+	@Before
+	public void setUp() throws Exception {
+		scheme1 = new CodingScheme();
+		scheme1.setCodingSchemeName(name1);
+		scheme1.setCodingSchemeURI(uri);
+		scheme1.setRepresentsVersion("1.0");
+		
+		supScheme = new SupportedCodingScheme();
+		supScheme.setContent(name1);
+		supScheme.setLocalId(name1);
+		supScheme.setUri(uri);
+	
+		
+		namespace = new SupportedNamespace();
+		namespace.setContent(nmspc);
+		namespace.setEquivalentCodingScheme(name1);
+		namespace.setLocalId(nmspc);
+		namespace.setUri(uri);
+		
+		maps = new Mappings();
+		maps.addSupportedCodingScheme(supScheme);
+		maps.addSupportedNamespace(namespace);
+		scheme1.setMappings(maps);
+		
+		RegistryEntry ent1 = new RegistryEntry();
+		ent1.setResourceType(ResourceType.CODING_SCHEME);
+		ent1.setResourceUri(uri);
+		ent1.setResourceVersion(ver1);
+		
+		RegistryEntry ent2 = new RegistryEntry();
+		ent2.setResourceType(ResourceType.CODING_SCHEME);
+		ent2.setResourceUri(uri);
+		ent2.setResourceVersion(ver2);
+		ent2.setTag("PRODUCTION");
+		
+		entries = new ArrayList<RegistryEntry>();
+		entries.add(ent1);
+		entries.add(ent2);
+
+		Mockito.when(locator.getDatabaseServiceManager()).thenReturn(dbs);
+		Mockito.when(dbs.getCodingSchemeService()).thenReturn(css);
+		Mockito.when(css.getCodingSchemeByUriAndVersion(uri, "1.0")).thenReturn(scheme1);
+		Mockito.when(srs.getUriForUserCodingSchemeName(name1, null)).thenReturn(uri);
+		Mockito.when(locator.getRegistry()).thenReturn(registry);
+		Mockito.when(registry.getAllRegistryEntriesOfTypeAndURI(ResourceType.CODING_SCHEME, uri)).thenReturn(entries);
+	}
+	
+	@Test
+	public void testDefaultHandler() throws LBParameterException{
+		assertTrue(constHandler.getCodingSchemeForNamespace(uri, ver1, nmspc).getCodingSchemeVersion().equals(ver1));
+	}
+
+}

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/testUtility/AllTestsNormalConfig.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/testUtility/AllTestsNormalConfig.java
@@ -182,6 +182,7 @@ import org.LexGrid.LexBIG.Impl.load.meta.MrrankQualifierDataTestIT;
 import org.LexGrid.LexBIG.Impl.load.meta.MrstyPropertyDataTestIT;
 import org.LexGrid.LexBIG.Impl.load.meta.PresentationPropertyDataTestIT;
 import org.LexGrid.LexBIG.Impl.load.meta.PresentationQualifiersDataTestIT;
+import org.LexGrid.LexBIG.Impl.namespace.DefaultNamespaceHandlerTest;
 import org.LexGrid.LexBIG.Utility.OrderingTestRunnerTest;
 import org.junit.runners.model.InitializationError;
 import org.lexevs.dao.database.service.listener.DuplicatePropertyIdListenerTest;
@@ -331,6 +332,10 @@ public class AllTestsNormalConfig {
         TestSuite comparatorSuite = new TestSuite("Comparator Tests");
         comparatorSuite.addTestSuite(ResultComparatorTest.class);
         mainSuite.addTest(comparatorSuite);
+        
+        TestSuite namespaceSuite = new TestSuite("Namespace Tests");
+        namespaceSuite.addTestSuite(DefaultNamespaceHandlerTest.class);
+        mainSuite.addTest(namespaceSuite);
       
         TestSuite codedNodeSetSuite = new TestSuite("CodedNodeSet Tests");
         codedNodeSetSuite.addTestSuite(ResolveTest.class);


### PR DESCRIPTION
This is a fairly narrow use case that only occurs when querying on non production terminologies that have a different namespace applied to the entity than is the coding scheme name.  We've added some logic to remedy this.