### PR TITLE
Bugfix/lexevs 2892 Reinstating and repairing some functionality to a Value Set removal tool

### DIFF
--- a/lbAdmin/scripts/RemoveResolvedValueSet.bat
+++ b/lbAdmin/scripts/RemoveResolvedValueSet.bat
@@ -1,11 +1,12 @@
 @echo off
-REM Removes a resolved ValueSet based on coding scheme and version that was used for its resolution.
+REM Removes a resolved ValueSet
 REM
 REM Options:
-REM   -l, The list of resolved value sets to remove, separated by comma. format "resolvedValueSetUri1::version1, resolvedValueSetUri2::version2,...".
+REM   -l, The list of resolved value sets to remove, separated by comma. 
+REM		format "resolvedValueSetUri1::version1, resolvedValueSetUri2::version2,...".
 REM   -f,--force Force de-activation and removal without confirmation.
 REM 
 REM
-REM Example: RemoveResolvedValueSet  -l \"source.coding.scheme.uri::version1, second.source.uri::version2\" -f
+REM Example: RemoveResolvedValueSet  -l \"resolvedValueSetUri1::version1, resolvedValueSetUri2::version2\" -f
 REM
 java -Xmx1000m -cp "..\runtime\lbPatch.jar;..\runtime-components\extLib\*" org.lexgrid.valuesets.admin.RemoveResolvedValueSet %*

--- a/lbAdmin/scripts/RemoveResolvedValueSet.bat
+++ b/lbAdmin/scripts/RemoveResolvedValueSet.bat
@@ -6,6 +6,6 @@ REM   -l, The list of resolved value sets to remove, separated by comma. format 
 REM   -f,--force Force de-activation and removal without confirmation.
 REM 
 REM
-REM Example: RemoveResolvedValueSet  -l \"resolvedValueSetUri1::version1, resolvedValueSetUri2::version2\" -f
+REM Example: RemoveResolvedValueSet  -l \"source.coding.scheme.uri::version1, second.source.uri::version2\" -f
 REM
 java -Xmx1000m -cp "..\runtime\lbPatch.jar;..\runtime-components\extLib\*" org.lexgrid.valuesets.admin.RemoveResolvedValueSet %*

--- a/lbAdmin/scripts/RemoveResolvedValueSet.sh
+++ b/lbAdmin/scripts/RemoveResolvedValueSet.sh
@@ -1,10 +1,11 @@
-# Removes a resolved ValueSet based on coding scheme and version that was used for its resolution.
+# Removes a resolved ValueSet 
 #
 # Options:
-#   -l, The list of resolved value sets to remove, separated by comma. format "resolvedValueSetUri1::version1, resolvedValueSetUri2::version2,...".
+#   -l, The list of resolved value sets to remove, separated by comma. 
+#		format "resolvedValueSetUri1::version1, resolvedValueSetUri2::version2,...".
 #   -f,--force Force de-activation and removal without confirmation.
 # 
 #
-# Example: RemoveResolvedValueSet  -l \"source.coding.scheme.uri::version1, second.source.uri::version2\" -f 
+# Example: RemoveResolvedValueSet  -l \"resolvedValueSetUri1::version1, resolvedValueSetUri2::version2\" -f
 #
 java -Xmx1000m -cp "../runtime/lbPatch.jar:../runtime-components/extLib/*" org.lexgrid.valuesets.admin.RemoveResolvedValueSet $@

--- a/lbAdmin/scripts/RemoveResolvedValueSet.sh
+++ b/lbAdmin/scripts/RemoveResolvedValueSet.sh
@@ -5,6 +5,6 @@
 #   -f,--force Force de-activation and removal without confirmation.
 # 
 #
-# Example: RemoveResolvedValueSet  -l \"resolvedValueSetUri1::version1, resolvedValueSetUri2::version2\" -f
+# Example: RemoveResolvedValueSet  -l \"source.coding.scheme.uri::version1, second.source.uri::version2\" -f 
 #
 java -Xmx1000m -cp "../runtime/lbPatch.jar:../runtime-components/extLib/*" org.lexgrid.valuesets.admin.RemoveResolvedValueSet $@

--- a/lbAdmin/scripts/RemoveVSResolvedFromCodingScheme.bat
+++ b/lbAdmin/scripts/RemoveVSResolvedFromCodingScheme.bat
@@ -1,0 +1,11 @@
+@echo off
+REM Removes resolved value sets based on coding scheme and version that was used for its 
+REM resolution.
+REM
+REM Options:
+REM  	-l, List of coding scheme versions to match when removing the ResolvedValueSet. 
+REM		 -f,--force Force de-activation and removal without confirmation.
+REM
+REM 	Example: RemoveVSResolvedFromCodingSchemes  -l \"source.coding.scheme.uri::version1, second.source.uri::version2\" -f
+REM
+java -Xmx1000m -cp "..\runtime\lbPatch.jar;..\runtime-components\extLib\*" org.lexgrid.valuesets.admin.RemoveVSResolvedFromCodingSchemes %*

--- a/lbAdmin/scripts/RemoveVSResolvedFromCodingScheme.sh
+++ b/lbAdmin/scripts/RemoveVSResolvedFromCodingScheme.sh
@@ -1,0 +1,10 @@
+# Removes a resolved ValueSet based on coding scheme and version that was used for its resolution.
+#
+# Options:
+#   -l, List of coding scheme versions to match when removing the ResolvedValueSet.
+#   -f,--force Force de-activation and removal without confirmation.
+# 
+#
+# Example: RemoveVSResolvedFromCodingSchemes  -l -l \"source.coding.scheme.uri::version1, second.source.uri::version2\" -f
+#
+java -Xmx1000m -cp "../runtime/lbPatch.jar:../runtime-components/extLib/*" org.lexgrid.valuesets.admin.RemoveVSResolvedFromCodingSchemes $@

--- a/lbTest/src/test/java/org/LexGrid/valueset/impl/LexEVSResolvedValueSetTest.java
+++ b/lbTest/src/test/java/org/LexGrid/valueset/impl/LexEVSResolvedValueSetTest.java
@@ -57,6 +57,7 @@ public class LexEVSResolvedValueSetTest extends TestCase {
 	public void testListAllResolvedValueSets() throws Exception {
 		List<CodingScheme> list = service.listAllResolvedValueSets();
 		assertTrue(list.size() > 0);
+		assertTrue(list.size() == 3);
 		CodingScheme scheme = list.get(0);
 		
 		// no coding scheme version or tag was passed in, so retrieve the PRODUCTION tag (version 1.1)

--- a/lbTest/src/test/java/org/LexGrid/valueset/impl/LexEVSValueSetDefServicesImplTest.java
+++ b/lbTest/src/test/java/org/LexGrid/valueset/impl/LexEVSValueSetDefServicesImplTest.java
@@ -629,7 +629,7 @@ public class LexEVSValueSetDefServicesImplTest extends TestCase {
         assertTrue(csvr == null);
         
         csvr = getValueSetDefinitionService().isEntityInValueSet("Focus", new URI("Automobiles"), new URI("SRITEST:AUTO:AllDomesticButGM"), null, null, LBConstants.KnownTags.PRODUCTION.toString());
-        assertTrue(csvr == null);
+        assertTrue(csvr != null);
 	}
 
 	@Test

--- a/lbTest/src/test/java/org/LexGrid/valueset/test/CleanUpTest.java
+++ b/lbTest/src/test/java/org/LexGrid/valueset/test/CleanUpTest.java
@@ -22,11 +22,11 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
 
-import junit.framework.TestCase;
-
 import org.LexGrid.LexBIG.DataModel.Collections.AbsoluteCodingSchemeVersionReferenceList;
 import org.LexGrid.LexBIG.DataModel.Core.AbsoluteCodingSchemeVersionReference;
 import org.LexGrid.LexBIG.Exceptions.LBException;
+import org.LexGrid.LexBIG.Exceptions.LBInvocationException;
+import org.LexGrid.LexBIG.Exceptions.LBParameterException;
 import org.LexGrid.LexBIG.Impl.LexBIGServiceImpl;
 import org.LexGrid.LexBIG.LexBIGService.LexBIGServiceManager;
 import org.LexGrid.LexBIG.Utility.Constructors;
@@ -38,6 +38,8 @@ import org.lexgrid.valuesets.LexEVSValueSetDefinitionServices;
 import org.lexgrid.valuesets.admin.RemoveResolvedValueSet;
 import org.lexgrid.valuesets.impl.LexEVSPickListDefinitionServicesImpl;
 import org.lexgrid.valuesets.impl.LexEVSValueSetDefinitionServicesImpl;
+
+import junit.framework.TestCase;
 
 /**
  * This test removes the terminologies loaded by the JUnit tests.
@@ -182,22 +184,51 @@ public class CleanUpTest extends TestCase {
     	remove_rvs.remove(acsvrl, true);
     }
     
-    @Test 
-    public void testRemoveResolvedAllButGM() throws Exception {
-        LexBIGServiceManager lbsm = LexBIGServiceImpl.defaultInstance().getServiceManager(null);
-        AbsoluteCodingSchemeVersionReference acsvr = Constructors.
+    @Test
+    public void testRemoveResolvedAllButGM() throws LBParameterException, LBInvocationException, LBException{
+    	LexBIGServiceManager lbsm = null;
+    	AbsoluteCodingSchemeVersionReference acsvr = null;
+    
+         lbsm = LexBIGServiceImpl.defaultInstance().getServiceManager(null);
+         acsvr = Constructors.
     			createAbsoluteCodingSchemeVersionReference("SRITEST:AUTO:AllDomesticButGM", "12.03test");
-        lbsm.deactivateCodingSchemeVersion(acsvr , null);
-    	lbsm.removeCodingSchemeVersion(acsvr);
+
+         try{
+        	 lbsm.deactivateCodingSchemeVersion(acsvr , null);  
+        	 fail("LBParameterException should be thrown");
+         }
+         catch(LBParameterException e){
+        	 assertEquals(e.getMessage(), "Could not find Resource:SRITEST:AUTO:AllDomesticButGM, 12.03test");
+         }
+         try{
+        	 lbsm.removeCodingSchemeVersion(acsvr);
+          	 fail("RuntimeException should be thrown");
+         }
+         catch(RuntimeException e){
+        	 assertEquals(e.getMessage(), "No CodingScheme Entry for URI: SRITEST:AUTO:AllDomesticButGM, Version: 12.03test");
+         }
     }
     
     @Test 
-    public void testRemoveXTest() throws Exception {
-        LexBIGServiceManager lbsm = LexBIGServiceImpl.defaultInstance().getServiceManager(null);
+    public void testRemoveXTest() throws LBException{
+
+    	LexBIGServiceManager lbsm = LexBIGServiceImpl.defaultInstance().getServiceManager(null);
     	AbsoluteCodingSchemeVersionReference acsvr = Constructors.
     			createAbsoluteCodingSchemeVersionReference("XTEST:One.Node.ValueSet", "1.0");
-    	        lbsm.deactivateCodingSchemeVersion(acsvr , null);
-    	    	lbsm.removeCodingSchemeVersion(acsvr);
+    	try {
+    		lbsm.deactivateCodingSchemeVersion(acsvr , null);
+    		fail("LBParameterException should be thrown");
+    	}
+    	catch(LBParameterException e){
+    		assertEquals(e.getMessage(), "Could not find Resource:XTEST:One.Node.ValueSet, 1.0");
+    	}
+    	try{
+    		lbsm.removeCodingSchemeVersion(acsvr);
+    		fail("RuntimeException should be thrown");
+    	}
+    	catch(RuntimeException e){
+    		assertEquals(e.getMessage(), "No CodingScheme Entry for URI: XTEST:One.Node.ValueSet, Version: 1.0");
+    	}
     }
         
 	private LexEVSValueSetDefinitionServices getValueSetDefService(){

--- a/lbTest/src/test/java/org/LexGrid/valueset/test/CleanUpTest.java
+++ b/lbTest/src/test/java/org/LexGrid/valueset/test/CleanUpTest.java
@@ -31,13 +31,16 @@ import org.LexGrid.LexBIG.Impl.LexBIGServiceImpl;
 import org.LexGrid.LexBIG.LexBIGService.LexBIGServiceManager;
 import org.LexGrid.LexBIG.Utility.Constructors;
 import org.LexGrid.LexBIG.Utility.ConvenienceMethods;
+import org.LexGrid.LexBIG.Utility.OrderingTestRunner;
 import org.LexGrid.valueSets.PickListDefinition;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.lexgrid.valuesets.LexEVSPickListDefinitionServices;
 import org.lexgrid.valuesets.LexEVSValueSetDefinitionServices;
 import org.lexgrid.valuesets.admin.RemoveResolvedValueSet;
 import org.lexgrid.valuesets.impl.LexEVSPickListDefinitionServicesImpl;
 import org.lexgrid.valuesets.impl.LexEVSValueSetDefinitionServicesImpl;
+import org.springframework.core.annotation.Order;
 
 import junit.framework.TestCase;
 
@@ -47,11 +50,13 @@ import junit.framework.TestCase;
  * @author <A HREF="mailto:dwarkanath.sridhar@mayo.edu">Sridhar Dwarkanath</A>
  * @version subversion $Revision: $ checked in on $Date: $
  */
+@RunWith(OrderingTestRunner.class)
 public class CleanUpTest extends TestCase {
     
 	private LexEVSValueSetDefinitionServices vds_;
 	private LexEVSPickListDefinitionServices pls_;
 	
+	@Order(0)
 	public void testRemoveAutombiles() throws LBException {
         LexBIGServiceManager lbsm = LexBIGServiceImpl.defaultInstance().getServiceManager(null);
 
@@ -63,6 +68,7 @@ public class CleanUpTest extends TestCase {
         lbsm.removeCodingSchemeVersion(a);
     }
 	
+	@Order(1)
 	public void testRemoveAutombilesV2() throws LBException {
         LexBIGServiceManager lbsm = LexBIGServiceImpl.defaultInstance().getServiceManager(null);
         
@@ -74,6 +80,7 @@ public class CleanUpTest extends TestCase {
         lbsm.removeCodingSchemeVersion(a);
     }
 	
+	@Order(2)
 	public void testRemoveGermanMadeParts() throws LBException {
         LexBIGServiceManager lbsm = LexBIGServiceImpl.defaultInstance().getServiceManager(null);
 
@@ -85,6 +92,7 @@ public class CleanUpTest extends TestCase {
         lbsm.removeCodingSchemeVersion(a);
     }
 
+	@Order(3)
     public void testRemoveObo() throws LBException {
         LexBIGServiceManager lbsm = LexBIGServiceImpl.defaultInstance().getServiceManager(null);
 
@@ -96,6 +104,7 @@ public class CleanUpTest extends TestCase {
 
     }
     
+	@Order(4)
     public void testRemoveOWL2() throws LBException {
         LexBIGServiceManager lbsm = LexBIGServiceImpl.defaultInstance().getServiceManager(null);
 
@@ -108,6 +117,7 @@ public class CleanUpTest extends TestCase {
     }
     
     @Test
+	@Order(5)
 	public void testRemoveAllTestValueSetDefs() throws LBException, URISyntaxException {
 		List<String> uris = getValueSetDefService().listValueSetDefinitions(null);
 		assertTrue(uris.size() > 0);
@@ -131,6 +141,7 @@ public class CleanUpTest extends TestCase {
 	}
 	
 	@Test
+	@Order(6)
 	public void testRemovePickList() {
 		try {
 			getPickListService().removePickList("SRITEST:AUTO:DomesticAutoMakers");
@@ -151,6 +162,7 @@ public class CleanUpTest extends TestCase {
 	}
 	
 	@Test
+	@Order(7)
 	public void testRemoveAllTestPickLists() throws LBException {
 		List<String> pickListIds = getPickListService().listPickListIds();
 		for (String pickListId : pickListIds)
@@ -171,6 +183,7 @@ public class CleanUpTest extends TestCase {
 	}
 	
     @Test 
+	@Order(8)
     public void testRemoveResolvedValueSet() throws Exception {
     	RemoveResolvedValueSet remove_rvs= new RemoveResolvedValueSet();
     	AbsoluteCodingSchemeVersionReferenceList acsvrl= remove_rvs.getCodingSchemeVersions("urn:oid:11.11.0.1::1.0");
@@ -178,6 +191,7 @@ public class CleanUpTest extends TestCase {
     }
     
     @Test 
+	@Order(9)
     public void testRemoveResolvedValueSe2t() throws Exception {
     	RemoveResolvedValueSet remove_rvs= new RemoveResolvedValueSet();
     	AbsoluteCodingSchemeVersionReferenceList acsvrl= remove_rvs.getCodingSchemeVersions("urn:oid:11.11.0.1::1.1");
@@ -185,6 +199,7 @@ public class CleanUpTest extends TestCase {
     }
     
     @Test
+	@Order(10)
     public void testRemoveResolvedAllButGM() throws LBParameterException, LBInvocationException, LBException{
     	LexBIGServiceManager lbsm = null;
     	AbsoluteCodingSchemeVersionReference acsvr = null;
@@ -210,6 +225,7 @@ public class CleanUpTest extends TestCase {
     }
     
     @Test 
+	@Order(11)
     public void testRemoveXTest() throws LBException{
 
     	LexBIGServiceManager lbsm = LexBIGServiceImpl.defaultInstance().getServiceManager(null);

--- a/lbTest/src/test/java/org/LexGrid/valueset/test/CleanUpTest.java
+++ b/lbTest/src/test/java/org/LexGrid/valueset/test/CleanUpTest.java
@@ -38,6 +38,7 @@ import org.junit.runner.RunWith;
 import org.lexgrid.valuesets.LexEVSPickListDefinitionServices;
 import org.lexgrid.valuesets.LexEVSValueSetDefinitionServices;
 import org.lexgrid.valuesets.admin.RemoveResolvedValueSet;
+import org.lexgrid.valuesets.admin.RemoveVSResolvedFromCodingSchemes;
 import org.lexgrid.valuesets.impl.LexEVSPickListDefinitionServicesImpl;
 import org.lexgrid.valuesets.impl.LexEVSValueSetDefinitionServicesImpl;
 import org.springframework.core.annotation.Order;
@@ -56,6 +57,7 @@ public class CleanUpTest extends TestCase {
 	private LexEVSValueSetDefinitionServices vds_;
 	private LexEVSPickListDefinitionServices pls_;
 	
+	@Test
 	@Order(0)
 	public void testRemoveAutombiles() throws LBException {
         LexBIGServiceManager lbsm = LexBIGServiceImpl.defaultInstance().getServiceManager(null);
@@ -68,6 +70,7 @@ public class CleanUpTest extends TestCase {
         lbsm.removeCodingSchemeVersion(a);
     }
 	
+	@Test
 	@Order(1)
 	public void testRemoveAutombilesV2() throws LBException {
         LexBIGServiceManager lbsm = LexBIGServiceImpl.defaultInstance().getServiceManager(null);
@@ -80,6 +83,7 @@ public class CleanUpTest extends TestCase {
         lbsm.removeCodingSchemeVersion(a);
     }
 	
+	@Test
 	@Order(2)
 	public void testRemoveGermanMadeParts() throws LBException {
         LexBIGServiceManager lbsm = LexBIGServiceImpl.defaultInstance().getServiceManager(null);
@@ -92,6 +96,7 @@ public class CleanUpTest extends TestCase {
         lbsm.removeCodingSchemeVersion(a);
     }
 
+	@Test
 	@Order(3)
     public void testRemoveObo() throws LBException {
         LexBIGServiceManager lbsm = LexBIGServiceImpl.defaultInstance().getServiceManager(null);
@@ -104,6 +109,7 @@ public class CleanUpTest extends TestCase {
 
     }
     
+	@Test
 	@Order(4)
     public void testRemoveOWL2() throws LBException {
         LexBIGServiceManager lbsm = LexBIGServiceImpl.defaultInstance().getServiceManager(null);
@@ -185,7 +191,7 @@ public class CleanUpTest extends TestCase {
     @Test 
 	@Order(8)
     public void testRemoveResolvedValueSet() throws Exception {
-    	RemoveResolvedValueSet remove_rvs= new RemoveResolvedValueSet();
+    	RemoveVSResolvedFromCodingSchemes remove_rvs= new RemoveVSResolvedFromCodingSchemes();
     	AbsoluteCodingSchemeVersionReferenceList acsvrl= remove_rvs.getCodingSchemeVersions("urn:oid:11.11.0.1::1.0");
     	remove_rvs.remove(acsvrl, true);
     }
@@ -193,7 +199,7 @@ public class CleanUpTest extends TestCase {
     @Test 
 	@Order(9)
     public void testRemoveResolvedValueSe2t() throws Exception {
-    	RemoveResolvedValueSet remove_rvs= new RemoveResolvedValueSet();
+    	RemoveVSResolvedFromCodingSchemes remove_rvs= new RemoveVSResolvedFromCodingSchemes();
     	AbsoluteCodingSchemeVersionReferenceList acsvrl= remove_rvs.getCodingSchemeVersions("urn:oid:11.11.0.1::1.1");
     	remove_rvs.remove(acsvrl, true);
     }

--- a/lgValueSets/src/org/lexgrid/resolvedvalueset/impl/LexEVSResolvedValueSetServiceImpl.java
+++ b/lgValueSets/src/org/lexgrid/resolvedvalueset/impl/LexEVSResolvedValueSetServiceImpl.java
@@ -40,20 +40,9 @@ public class LexEVSResolvedValueSetServiceImpl implements LexEVSResolvedValueSet
 	public List<CodingScheme> listAllResolvedValueSets() throws LBException {
 		LexBIGService lbs= getLexBIGService();
 		List<CodingScheme> resolvedValueSetList= new ArrayList<CodingScheme>();
-
-		List<CodingSchemeRendering> candidateRenderingList= new ArrayList<CodingSchemeRendering>();
 		CodingSchemeRenderingList schemes = lbs.getSupportedCodingSchemes();
-        for (CodingSchemeRendering csr:  schemes.getCodingSchemeRendering()) {
-        	CodingSchemeSummary css= csr.getCodingSchemeSummary();
-        	String version = css.getRepresentsVersion();
-        	//Resolved ValueSet versions are generated as 32 hex value of its MD5
-        	if (version.length()==32) {
-        		candidateRenderingList.add(csr);
-        	}
-        	
-        }
         
-        for (CodingSchemeRendering csr: candidateRenderingList) {
+        for (CodingSchemeRendering csr: schemes.getCodingSchemeRendering()) {
         	CodingScheme cs= getResolvedCodingScheme(csr);
         	if (isResolvedValueSetCodingScheme(cs) ) {
         	    resolvedValueSetList.add(cs);

--- a/lgValueSets/src/org/lexgrid/valuesets/admin/RemoveResolvedValueSet.java
+++ b/lgValueSets/src/org/lexgrid/valuesets/admin/RemoveResolvedValueSet.java
@@ -95,7 +95,7 @@ public class RemoveResolvedValueSet {
 			Util.displayCommandOptions(
 					"RemoveResolvedValueSet",
 					options,
-					"RemoveResolvedValueSet  -l \"resolved-value-set1::version1, resolved-value-set2::version2\" -f ",
+					"RemoveResolvedValueSet  -l \"source.coding.scheme.uri::version1, second.source.uri::version2\" -f ",
 					e);
 			Util.displayMessage(Util.getPromptForSchemeHelp());
 			return;

--- a/lgValueSets/src/org/lexgrid/valuesets/admin/RemoveVSResolvedFromCodingSchemes.java
+++ b/lgValueSets/src/org/lexgrid/valuesets/admin/RemoveVSResolvedFromCodingSchemes.java
@@ -45,32 +45,32 @@ import org.lexgrid.resolvedvalueset.LexEVSResolvedValueSetService;
 import org.lexgrid.resolvedvalueset.impl.LexEVSResolvedValueSetServiceImpl;
 
 /**
- * Remove the resolvedValueSet
+ * Remove resolved value set associated with the given coding scheme(s)
  * 
  * <pre>
- * Example: java org.lexgrid.valuesets.admin.RemoveResolvedValueSet
- *   -l, &lt;id&gt; List of coding scheme versions to match when removing the ResolvedValueSet. The
- *       format is "vsuri1::version1, vsuri2::version2"
- *   -f Force remove of active schemes    
- * 
  * Note: If the URN and version values are unspecified, a
  * list of available coding schemes will be presented for
  * user selection.
  * 
+ * Example: java -Xmx512m -cp lgRuntime.jar
+ *  org.lexgrid.valuesets.admin.RemoveResolvedValueSet
+ *    -l &quot;urn:oid:11.11.0.1::version1, GM_URI::version2&quot; -f
+ * </pre>
+ * 
  * @author <A HREF="mailto:kanjamala.pradip@mayo.edu">Pradip Kanjamala</A>
  */
 @LgAdminFunction
-public class RemoveResolvedValueSet {
+public class RemoveVSResolvedFromCodingSchemes {
 
 	public static void main(String[] args) {
 		try {
-			new RemoveResolvedValueSet().run(args);
+			new RemoveVSResolvedFromCodingSchemes().run(args);
 		} catch (Exception e) {
 			Util.displayAndLogError("REQUEST FAILED !!!", e);
 		}
 	}
 
-	public RemoveResolvedValueSet() {
+	public RemoveVSResolvedFromCodingSchemes() {
 		super();
 	}
 
@@ -90,7 +90,7 @@ public class RemoveResolvedValueSet {
 			Util.displayCommandOptions(
 					"RemoveResolvedValueSet",
 					options,
-					"RemoveResolvedValueSet  -l \"resolved-value-set1::version1, resolved-value-set2::version2\" -f ",
+					"RemoveResolvedValueSet  -l \"source.coding.scheme.uri::version1, second.source.uri::version2\" -f ",
 					e);
 			Util.displayMessage(Util.getPromptForSchemeHelp());
 			return;
@@ -101,23 +101,10 @@ public class RemoveResolvedValueSet {
 		boolean force = cl.hasOption("f");
 
 		AbsoluteCodingSchemeVersionReferenceList acsvl = getCodingSchemeVersions(csList);
-		boolean foundToRemove = false;
-		LexEVSResolvedValueSetService resolved_vs_service = new LexEVSResolvedValueSetServiceImpl();
-		for (CodingScheme cs : resolved_vs_service.listAllResolvedValueSets()) 
-		{
-			if (!matchesWithResolvedVS(acsvl, cs))
-				continue;
-			
-			AbsoluteCodingSchemeVersionReference remove_acst = Constructors
-						.createAbsoluteCodingSchemeVersionReference(
-								cs.getCodingSchemeURI(),
-								cs.getRepresentsVersion());
-				foundToRemove = true;
-				remove(remove_acst, force);
-		}
-		
-		if (!foundToRemove)
-			Util.displayTaggedMessage("Could not find Resolved valueset(s) coding scheme to remove.");
+
+				remove(acsvl, force);
+
+
 	}
 
 	public AbsoluteCodingSchemeVersionReferenceList getCodingSchemeVersions(
@@ -145,21 +132,61 @@ public class RemoveResolvedValueSet {
 		return acsvl;
 	}
 
-	boolean matchesWithResolvedVS(AbsoluteCodingSchemeVersionReferenceList containedList,
-			CodingScheme cs) {
-		for (AbsoluteCodingSchemeVersionReference contained_acsr : containedList
-				.getAbsoluteCodingSchemeVersionReference()) {
-				if (contained_acsr.getCodingSchemeURN().equalsIgnoreCase(
-						cs.getCodingSchemeURI())
-						&& contained_acsr.getCodingSchemeVersion()
-								.equalsIgnoreCase(
-										cs.getRepresentsVersion())) {
-					return true;
-				}
+	public void remove(
+			AbsoluteCodingSchemeVersionReferenceList csVersionList,
+			boolean force) throws Exception {		
+		boolean foundToRemove = false;
+		LexEVSResolvedValueSetService resolved_vs_service = new LexEVSResolvedValueSetServiceImpl();
+		for (CodingScheme cs : resolved_vs_service.listAllResolvedValueSets()) {
+			AbsoluteCodingSchemeVersionReferenceList acsvl = resolved_vs_service
+					.getListOfCodingSchemeVersionsUsedInResolution(cs);
+			if (matches(csVersionList, acsvl)) {
+				AbsoluteCodingSchemeVersionReference remove_acst = Constructors
+						.createAbsoluteCodingSchemeVersionReference(
+								cs.getCodingSchemeURI(),
+								cs.getRepresentsVersion());
+				foundToRemove = true;
+				doRemove(remove_acst, force);
+			}
 		}
-		return false;
+		
+		if (!foundToRemove)
+			Util.displayTaggedMessage("Could not find Resolved valueset(s) coding scheme to remove.");
 	}
 	
+	void doRemove(AbsoluteCodingSchemeVersionReference acsvr, boolean force)
+			throws Exception {
+		// Continue and confirm the action (if not bypassed by force option)
+		// ...
+		Util.displayTaggedMessage("A matching resolved valueset coding scheme was found with urn: "+ acsvr.getCodingSchemeURN());
+		LexBIGServiceManager lbsm = LexBIGServiceImpl.defaultInstance()
+				.getServiceManager(null);
+		boolean isActive = getCodingSchemeStatus(acsvr.getCodingSchemeURN(),
+				acsvr.getCodingSchemeVersion());
+		boolean confirmed = true;
+		if (!force) {
+			if (isActive) {
+				Util.displayMessage("SCHEME IS ACTIVE! DEACTIVATE? ('Y' to confirm, any other key to cancel)");
+				char choice = Util.getConsoleCharacter();
+				if (confirmed = choice == 'Y' || choice == 'y')
+					lbsm.deactivateCodingSchemeVersion(acsvr, null);
+			}
+			if (!isActive || confirmed) {
+				Util.displayMessage("DELETE? ('Y' to confirm, any other key to cancel)");
+				char choice = Util.getConsoleCharacter();
+				confirmed = choice == 'Y' || choice == 'y';
+			}
+		} else
+			lbsm.deactivateCodingSchemeVersion(acsvr, null);
+
+		if (confirmed) {
+			lbsm.removeCodingSchemeVersion(acsvr);
+			Util.displayTaggedMessage("Resolved valueset [URN=" + acsvr.getCodingSchemeURN() + ", Version=" + acsvr.getCodingSchemeVersion() + "] was removed.");
+		} else {
+			Util.displayTaggedMessage("Action cancelled by user");
+		}
+	}
+
 	boolean matches(AbsoluteCodingSchemeVersionReferenceList containedList,
 			AbsoluteCodingSchemeVersionReferenceList sourceList) {
 		for (AbsoluteCodingSchemeVersionReference contained_acsr : containedList
@@ -206,38 +233,6 @@ public class RemoveResolvedValueSet {
 		return isActive;
 	}
 
-	void remove(AbsoluteCodingSchemeVersionReference acsvr, boolean force)
-			throws Exception {
-		// Continue and confirm the action (if not bypassed by force option)
-		// ...
-		Util.displayTaggedMessage("A matching resolved valueset coding scheme was found with urn: "+ acsvr.getCodingSchemeURN());
-		LexBIGServiceManager lbsm = LexBIGServiceImpl.defaultInstance()
-				.getServiceManager(null);
-		boolean isActive = getCodingSchemeStatus(acsvr.getCodingSchemeURN(),
-				acsvr.getCodingSchemeVersion());
-		boolean confirmed = true;
-		if (!force) {
-			if (isActive) {
-				Util.displayMessage("SCHEME IS ACTIVE! DEACTIVATE? ('Y' to confirm, any other key to cancel)");
-				char choice = Util.getConsoleCharacter();
-				if (confirmed = choice == 'Y' || choice == 'y')
-					lbsm.deactivateCodingSchemeVersion(acsvr, null);
-			}
-			if (!isActive || confirmed) {
-				Util.displayMessage("DELETE? ('Y' to confirm, any other key to cancel)");
-				char choice = Util.getConsoleCharacter();
-				confirmed = choice == 'Y' || choice == 'y';
-			}
-		} else
-			lbsm.deactivateCodingSchemeVersion(acsvr, null);
-
-		if (confirmed) {
-			lbsm.removeCodingSchemeVersion(acsvr);
-			Util.displayTaggedMessage("Resolved valueset [URN=" + acsvr.getCodingSchemeURN() + ", Version=" + acsvr.getCodingSchemeVersion() + "] was removed.");
-		} else {
-			Util.displayTaggedMessage("Action cancelled by user");
-		}
-	}
 
 	/**
 	 * Return supported command options.

--- a/lgValueSets/src/org/lexgrid/valuesets/helper/VSDServiceHelper.java
+++ b/lgValueSets/src/org/lexgrid/valuesets/helper/VSDServiceHelper.java
@@ -541,6 +541,7 @@ public class VSDServiceHelper {
 				String tagVersion = rm_.getInternalVersionStringForTag(csURI,
 						versionTag);
 				if (!StringUtils.isEmpty(tagVersion)){
+					refVersions.put(csURI, tagVersion);
 					return Constructors
 							.createAbsoluteCodingSchemeVersionReference(csURI,
 									tagVersion);


### PR DESCRIPTION
We broke this tool, thinking it should do something else.  In the meantime other errors crept in that were not caught by current testing.  We should have full testing and correct code in place now.  We also have separated functionality into two classes so that the intent of both the original class and new implementation have been preserved.  