### PR TITLE
Bugfix/lexevs 2896  Removing destructive Index management and replacing with exception

### DIFF
--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/testUtility/AllTestsNormalConfig.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/testUtility/AllTestsNormalConfig.java
@@ -192,6 +192,7 @@ import org.lexevs.dao.index.operation.DefaultLexEVSIndexOperationsCreateIndexTes
 import org.lexevs.dao.index.operation.DefaultLexEVSIndexOperationsCreateMultipleIndexesTest;
 import org.lexevs.dao.index.operation.DefaultLexEVSIndexOperationsRemoveTest;
 import org.lexevs.dao.index.operation.ManifestLoadWithAssociationTest;
+import org.lexevs.dao.index.operation.OrphanedIndexTest;
 import org.lexevs.dao.index.operation.SameSessionLoadandQueryTest;
 import org.lexevs.dao.indexer.lucene.analyzers.SnowballAnalyzerTest;
 import org.lexevs.dao.indexer.lucene.analyzers.StringAnalyzerTest;
@@ -521,6 +522,7 @@ public class AllTestsNormalConfig {
         mainSuite.addTest(orderedSuite(DefaultLexEVSIndexOperationsRemoveTest.class));
         mainSuite.addTest(new JUnit4TestAdapter(SameSessionLoadandQueryTest.class));
         mainSuite.addTest(new JUnit4TestAdapter(ManifestLoadWithAssociationTest.class));
+        mainSuite.addTest(new JUnit4TestAdapter(OrphanedIndexTest.class));
         // $JUnit-END$
 
         return mainSuite;

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/testUtility/AllTestsNormalConfig.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/testUtility/AllTestsNormalConfig.java
@@ -522,6 +522,7 @@ public class AllTestsNormalConfig {
         mainSuite.addTest(orderedSuite(DefaultLexEVSIndexOperationsRemoveTest.class));
         mainSuite.addTest(new JUnit4TestAdapter(SameSessionLoadandQueryTest.class));
         mainSuite.addTest(new JUnit4TestAdapter(ManifestLoadWithAssociationTest.class));
+        //*******Always run this last, it breaks a lot of things that are created in ServiceHolder 
         mainSuite.addTest(new JUnit4TestAdapter(OrphanedIndexTest.class));
         // $JUnit-END$
 

--- a/lbTest/src/test/java/org/lexevs/dao/index/operation/OrphanedIndexTest.java
+++ b/lbTest/src/test/java/org/lexevs/dao/index/operation/OrphanedIndexTest.java
@@ -1,0 +1,47 @@
+package org.lexevs.dao.index.operation;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+
+import org.LexGrid.LexBIG.Impl.LexBIGServiceImpl;
+import org.LexGrid.LexBIG.Impl.dataAccess.CleanUpUtility;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.lexevs.system.constants.SystemVariables;
+
+public class OrphanedIndexTest {
+	
+	String uri = "urn:oid:11.11.0.1";
+	String ver = "1.0";
+	
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+		String location = SystemVariables.getAbsoluteIndexLocation();
+		File testIndex = new File(location + System.getProperty("file.separator") + "myIndexTest" );
+		testIndex.mkdir();
+	}
+	
+	@Rule public ExpectedException thrown = ExpectedException.none();
+	@Test
+	public void test() throws RuntimeException{
+		thrown.expect(RuntimeException.class);
+		thrown.expectMessage("Indexes seem to be created in another context as they do not match "
+				+ "database registrations. If these indexes were copied from another service then "
+				+ "please edit the config.props file to match the source service. Otherwise delete "
+				+ "them and rebuild them from scratch");
+		LexBIGServiceImpl.defaultInstance();
+	}
+	
+	@AfterClass
+	public static void tearDownAfterClass() throws Exception {
+		CleanUpUtility.removeAllUnusedDatabases();
+		assertTrue(CleanUpUtility.listUnusedDatabases().length == 0);
+		CleanUpUtility.removeAllUnusedIndexes();
+		assertTrue(CleanUpUtility.listUnusedIndexes().length == 0);
+	}
+
+}

--- a/lbTest/src/test/java/org/lexevs/dao/index/operation/OrphanedIndexTest.java
+++ b/lbTest/src/test/java/org/lexevs/dao/index/operation/OrphanedIndexTest.java
@@ -3,15 +3,23 @@ package org.lexevs.dao.index.operation;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.util.Arrays;
 
+import org.LexGrid.LexBIG.DataModel.Collections.ExtensionDescriptionList;
+import org.LexGrid.LexBIG.DataModel.InterfaceElements.ExtensionDescription;
+import org.LexGrid.LexBIG.Exceptions.LBParameterException;
+import org.LexGrid.LexBIG.Extensions.ExtensionRegistry;
 import org.LexGrid.LexBIG.Impl.LexBIGServiceImpl;
 import org.LexGrid.LexBIG.Impl.dataAccess.CleanUpUtility;
+import org.LexGrid.LexBIG.Impl.testUtility.ServiceHolder;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.lexevs.locator.LexEvsServiceLocator;
 import org.lexevs.system.constants.SystemVariables;
+import org.lexevs.system.utility.MyClassLoader;
 
 public class OrphanedIndexTest {
 	
@@ -20,6 +28,40 @@ public class OrphanedIndexTest {
 	
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
+
+		
+		ExtensionRegistry exReg = ServiceHolder.instance().getLexBIGService().getServiceManager(null).getExtensionRegistry();
+		ExtensionDescription[] descrips =  exReg.getExportExtensions().getExtensionDescription();
+		for(ExtensionDescription ed : descrips){
+			exReg.unregisterExportExtension(ed.getName());
+		}
+		descrips = exReg.getFilterExtensions().getExtensionDescription();
+		for(ExtensionDescription ed : descrips){
+			exReg.unregisterFilterExtension(ed.getName());
+		}
+		descrips = exReg.getGenericExtensions().getExtensionDescription();
+		for(ExtensionDescription ed : descrips){
+			exReg.unregisterGenericExtension(ed.getName());
+		}
+		descrips = exReg.getIndexExtensions().getExtensionDescription();
+		for(ExtensionDescription ed : descrips){
+			exReg.unregisterIndexExtension(ed.getName());
+		}
+		descrips = exReg.getLoadExtensions().getExtensionDescription();
+		for(ExtensionDescription ed : descrips){
+			exReg.unregisterLoadExtension(ed.getName());
+		}
+		descrips = exReg.getSearchExtensions().getExtensionDescription();
+		for(ExtensionDescription ed : descrips){
+			exReg.unregisterSearchExtension(ed.getName());
+		}
+		descrips = exReg.getSortExtensions().getSortDescription();
+		for(ExtensionDescription ed : descrips){
+			exReg.unregisterSortExtension(ed.getName());
+		}
+		LexBIGServiceImpl.setDefaultInstance(null);
+		LexEvsServiceLocator.getInstance().destroy();
+		
 		String location = SystemVariables.getAbsoluteIndexLocation();
 		File testIndex = new File(location + System.getProperty("file.separator") + "myIndexTest" );
 		testIndex.mkdir();

--- a/lexevs-dao/src/main/java/org/lexevs/system/constants/SystemVariables.java
+++ b/lexevs-dao/src/main/java/org/lexevs/system/constants/SystemVariables.java
@@ -789,5 +789,15 @@ public class SystemVariables {
 	public void setGraphdbUrl(String graphdbUrl) {
 		this.graphdbUrl = graphdbUrl;
 	}
+	
+    public static String getAbsoluteIndexLocation(){
+    	String location =  PropertiesUtility.locatePropFile("config" + System.getProperty("file.separator")
+        + CONFIG_FILE_NAME, SystemVariables.class.getName());
+    	File newFile = new File(location);
+    	File tempFile = new File(newFile.getParent());
+    	tempFile = new File(tempFile.getParent());
+    	tempFile = new File(tempFile, "lbIndex");
+    	return tempFile.getAbsolutePath();
+    }
 
 }

--- a/lexevs-dao/src/test/java/org/lexevs/dao/indexer/utility/LazyLoadMetaDataTest.java
+++ b/lexevs-dao/src/test/java/org/lexevs/dao/indexer/utility/LazyLoadMetaDataTest.java
@@ -1,13 +1,12 @@
 package org.lexevs.dao.indexer.utility;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 
+import org.LexGrid.LexBIG.Exceptions.LBInvocationException;
 import org.LexGrid.LexBIG.Exceptions.LBParameterException;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.lexevs.dao.index.lucenesupport.LazyLoadMetaData;
@@ -37,7 +36,7 @@ public class LazyLoadMetaDataTest {
 		applicationListener = (LazyLoadMetaData)context.getBean("eventListenerBean");
 		try {
 			applicationListener.lazyLoadMetadata();
-		} catch (LBParameterException | IOException e) {
+		} catch (LBParameterException | LBInvocationException | IOException e) {
 			// TODO Auto-generated catch block
 			fail();
 		}


### PR DESCRIPTION
This is a feature that some found too unforgiving when a poorly configured environment started up over imported indexes, LexEVS would delete them.  