### PR TITLE
LEXEVS-2994.  Anonymous node entityDescriptions contain return characters

### DIFF
--- a/lbTest/src/test/java/edu/mayo/informatics/lexgrid/convert/directConversions/owl2/NewOWL2SnippetTestIT.java
+++ b/lbTest/src/test/java/edu/mayo/informatics/lexgrid/convert/directConversions/owl2/NewOWL2SnippetTestIT.java
@@ -5,9 +5,13 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Iterator;
 
+import org.LexGrid.LexBIG.DataModel.Collections.AssociatedConceptList;
+import org.LexGrid.LexBIG.DataModel.Collections.AssociationList;
 import org.LexGrid.LexBIG.DataModel.Collections.ConceptReferenceList;
 import org.LexGrid.LexBIG.DataModel.Collections.NameAndValueList;
 import org.LexGrid.LexBIG.DataModel.Collections.ResolvedConceptReferenceList;
+import org.LexGrid.LexBIG.DataModel.Core.AssociatedConcept;
+import org.LexGrid.LexBIG.DataModel.Core.Association;
 import org.LexGrid.LexBIG.DataModel.Core.ConceptReference;
 import org.LexGrid.LexBIG.DataModel.Core.NameAndValue;
 import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
@@ -16,6 +20,7 @@ import org.LexGrid.LexBIG.Exceptions.LBInvocationException;
 import org.LexGrid.LexBIG.Exceptions.LBParameterException;
 import org.LexGrid.LexBIG.Exceptions.LBResourceUnavailableException;
 import org.LexGrid.LexBIG.Impl.function.LexBIGServiceTestCase;
+import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet.AnonymousOption;
 import org.LexGrid.LexBIG.Utility.Constructors;
 import org.LexGrid.LexBIG.Utility.Iterators.ResolvedConceptReferencesIterator;
 import org.LexGrid.commonTypes.Property;
@@ -284,6 +289,27 @@ public class NewOWL2SnippetTestIT extends DataLoadTestBaseSnippet2 {
 		ResolvedConceptReferencesIterator itr = cns.resolve(null, null, null);
 		assertNotNull(itr);
 		assertFalse(itr.hasNext());
+	}
+	
+	@Test
+	public void testAnonEntityForBadFormating()throws LBInvocationException, LBParameterException, LBResourceUnavailableException{
+		cng = cng.restrictToAssociations(Constructors.createNameAndValueList("equivalentClass"), null);
+		ResolvedConceptReferenceList list = cng.resolveAsList(Constructors.createConceptReference("Brca1", null), true, false, 1, 1, null, null, null, null, 10);
+		assertFalse(list.getResolvedConceptReferenceCount() < 1);
+		ResolvedConceptReference ref = list.getResolvedConceptReference(0);
+		assertNotNull(ref.getSourceOf());
+		AssociationList assocs = ref.getSourceOf();
+		for(Association as: assocs.getAssociation()){
+			AssociatedConceptList asList = as.getAssociatedConcepts();
+			for(AssociatedConcept ac : asList.getAssociatedConcept()){
+				if(ac.getEntityDescription().getContent().contains("\n") || 
+						ac.getEntityDescription().getContent().contains("\r")){
+					fail();
+				}
+			}
+		}
+		String desc = ref.getEntityDescription().getContent();
+		System.out.println(desc);
 	}
 	
 	

--- a/lgConverter/src/edu/mayo/informatics/lexgrid/convert/directConversions/owlapi/OwlApi2LG.java
+++ b/lgConverter/src/edu/mayo/informatics/lexgrid/convert/directConversions/owlapi/OwlApi2LG.java
@@ -1651,7 +1651,8 @@ public class OwlApi2LG {
         lgClass.setEntityCodeNamespace(nameSpace);
 
         EntityDescription ed = new EntityDescription();
-        ed.setContent(renderer.render(owlClassExp));
+        String desc = renderer.render(owlClassExp).replace("\n", " ").replaceAll("\r", " ");
+        ed.setContent(desc);
         lgClass.setEntityDescription(ed);
 
         int lgPropNum = 0;


### PR DESCRIPTION
Fixes some bad formatting caused by the Manchester OWL rendering engine.