### PR TITLE
Bugfix/lexevs 3092  Fix for source anomaly in Automobiles.xml

### DIFF
--- a/lbTest/resources/testData/Automobiles.xml
+++ b/lbTest/resources/testData/Automobiles.xml
@@ -33,6 +33,8 @@
 			uri="urn:oid:1.3.6.1.4.1.2114.108.1.8.1">hasSubtype</lgNaming:supportedAssociation>
 		<lgNaming:supportedAssociation localId="uses"
 			uri="urn:oid:11.11.0.1">uses</lgNaming:supportedAssociation>
+		<lgNaming:supportedAssociation localId="is_a"
+			uri="urn:oid:11.11.0.1">is_a</lgNaming:supportedAssociation>	
 		<lgNaming:supportedAssociation localId="A1"
 			uri="http://A1.org" entityCode="AssocEntity" entityCodeNamespace="Automobiles"
 			codingScheme="Automobiles">A1</lgNaming:supportedAssociation>

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestHierarchyAPI.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestHierarchyAPI.java
@@ -26,6 +26,7 @@ import org.LexGrid.LexBIG.DataModel.Core.ConceptReference;
 import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
 import org.LexGrid.LexBIG.Exceptions.LBException;
 import org.LexGrid.LexBIG.Extensions.Generic.LexBIGServiceConvenienceMethods;
+import org.LexGrid.LexBIG.Impl.LexBIGServiceImpl;
 import org.LexGrid.LexBIG.Impl.function.LexBIGServiceTestCase;
 import org.LexGrid.LexBIG.Impl.testUtility.ServiceHolder;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
@@ -484,6 +485,21 @@ public class TestHierarchyAPI extends LexBIGServiceTestCase {
        
 
     }     
+    
+    public void testHierarchyForMultipleAssociations() throws LBException {
+
+            LexBIGService svc = ServiceHolder.instance().getLexBIGService();
+            LexBIGServiceConvenienceMethods lbscm = (LexBIGServiceConvenienceMethods) svc
+                        .getGenericExtension("LexBIGServiceConvenienceMethods");
+            
+                AssociationList list = lbscm.getHierarchyLevelNext("Automobiles", Constructors.createCodingSchemeVersionOrTagFromVersion("1.0"),
+                        null, "C0001", false, null);
+                assertNotNull(list);
+                assertTrue(list.getAssociationCount() > 0);
+                assertTrue(list.getAssociation()[0].getAssociationName()
+                		.equalsIgnoreCase("hasSubtype"));
+
+    }
     
     
     int findMatchingConcept(String code, ConceptReferenceList crl) {

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestHierarchyAPI.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestHierarchyAPI.java
@@ -18,6 +18,8 @@
  */
 package org.LexGrid.LexBIG.Impl.function.query;
 
+import java.util.Iterator;
+
 import org.LexGrid.LexBIG.DataModel.Collections.AssociationList;
 import org.LexGrid.LexBIG.DataModel.Collections.ConceptReferenceList;
 import org.LexGrid.LexBIG.DataModel.Collections.ResolvedConceptReferenceList;
@@ -26,7 +28,6 @@ import org.LexGrid.LexBIG.DataModel.Core.ConceptReference;
 import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
 import org.LexGrid.LexBIG.Exceptions.LBException;
 import org.LexGrid.LexBIG.Extensions.Generic.LexBIGServiceConvenienceMethods;
-import org.LexGrid.LexBIG.Impl.LexBIGServiceImpl;
 import org.LexGrid.LexBIG.Impl.function.LexBIGServiceTestCase;
 import org.LexGrid.LexBIG.Impl.testUtility.ServiceHolder;
 import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
@@ -34,8 +35,6 @@ import org.LexGrid.LexBIG.LexBIGService.LexBIGService;
 import org.LexGrid.LexBIG.Utility.Constructors;
 import org.LexGrid.LexBIG.Utility.ConvenienceMethods;
 import org.lexevs.dao.database.service.codednodegraph.model.CountConceptReference;
-
-import java.util.Iterator;
 
 /**
  * This testcase checks that the hierarchy api works as desired.


### PR DESCRIPTION
Lack of a supported association for one declared in the supported hierarchy caused method to fail.  No code fix needed, just better source configuration.