### PR TITLE
LEXEVS-3783. Fixing OWL2 loader issue that uses manifest to update an…

### DIFF
--- a/lexevs-dao/src/main/java/org/lexevs/dao/database/service/listener/LuceneEntityUpdateListener.java
+++ b/lexevs-dao/src/main/java/org/lexevs/dao/database/service/listener/LuceneEntityUpdateListener.java
@@ -67,11 +67,6 @@ public class LuceneEntityUpdateListener extends DefaultServiceEventListener {
 			entityIndexService.updateIndexForEntity(event.getCodingSchemeUri(),
 					event.getCodingSchemeVersion(), updatedEntity);
 			
-			if(vsIndexSvc.doesIndexExist(ref)){
-				vsIndexSvc.updateIndexForEntity(event
-						.getCodingSchemeUri(), event.getCodingSchemeVersion(),
-						updatedEntity);
-			}
 		}
 		
 		


### PR DESCRIPTION
… association entity.

This was an inappropriate use of this listener that accessed an out of date method.  No test on this code path left this exposed to eventual failure.