### PR TITLE
LEXEVS-3741 Fixed typo in namespace for "valueSetss"

### DIFF
--- a/lbModel/master/Core.xsd
+++ b/lbModel/master/Core.xsd
@@ -13,7 +13,7 @@
 	<xs:import namespace="http://LexGrid.org/schema/2010/01/LexGrid/commonTypes" schemaLocation="commonTypes.xsd"/>
 	<xs:import namespace="http://LexGrid.org/schema/2010/01/LexGrid/concepts" schemaLocation="concepts.xsd"/>
 	<xs:import namespace="http://LexGrid.org/schema/2010/01/LexGrid/naming" schemaLocation="naming.xsd"/>
-	<xs:import namespace="http://LexGrid.org/schema/2010/01/LexGrid/valueSetss" schemaLocation="valueSets.xsd"/>
+	<xs:import namespace="http://LexGrid.org/schema/2010/01/LexGrid/valueSets" schemaLocation="valueSets.xsd"/>
 	<!-- ================================================= -->
 	<!-- Package: <<XSDschema>> Core	   				   -->
 	<!-- ================================================= -->


### PR DESCRIPTION
LEXEVS-3741 Fixed typo in namespace for "valueSetss"