### PR TITLE
LEXEVS-3748.  Update Mapping Concept Reference Namespace Implementation

### DIFF
--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/Extensions/GenericExtensions/MappingExtensionImplTest.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/Extensions/GenericExtensions/MappingExtensionImplTest.java
@@ -100,7 +100,10 @@ public class MappingExtensionImplTest extends LexBIGServiceTestCase {
 		ResolvedConceptReferencesIterator itr = mapping.resolveMapping();
 		
 		assertTrue(itr.hasNext());
-		this.checkResolvedConceptReference(itr.next());
+		ResolvedConceptReference ref = itr.next();
+		assertNotSame(ref.getCodeNamespace(), "Automobiles_Different_NS");
+		assertEquals(ref.getCodeNamespace(), "Automobiles");
+		this.checkResolvedConceptReference(ref);
 		assertFalse(itr.hasNext());
 	}
 	

--- a/lexevs-dao/src/main/resources/ibatis/v20/entityAssnsToEntity.xml
+++ b/lexevs-dao/src/main/resources/ibatis/v20/entityAssnsToEntity.xml
@@ -1968,7 +1968,7 @@
 			eate.entityAssnsGuid AS tripleUid,
 
 			eate.sourceEntityCode AS sourceEntityCode,
-			eate.sourceEntityCodeNamespace AS sourceEntityCodeNamespace,
+			sourceEntity.entityCodeNamespace AS sourceEntityCodeNamespace,
 			<isNotNull property="param2">
 				sourceEntity.description AS sourceEntityDescription,
 			</isNotNull>


### PR DESCRIPTION
This now pulls the namespace from the target scheme.  Update to the query is minimal, testing is a couple of additional assertions.