### PR TITLE
LEXEVS-2020 Updated OWL2 loader to default the presentation property isPreferred value to false, if it wasn't set.

### DIFF
--- a/lbTest/src/test/java/edu/mayo/informatics/lexgrid/convert/directConversions/owl2/OWL2SpecialCaseSnippetTestIT.java
+++ b/lbTest/src/test/java/edu/mayo/informatics/lexgrid/convert/directConversions/owl2/OWL2SpecialCaseSnippetTestIT.java
@@ -84,7 +84,42 @@ public class OWL2SpecialCaseSnippetTestIT extends DataLoadTestBaseSpecialCases {
 		assertTrue(hasEditorTerm);
 	}
 
-
+	@Test
+	public void testPreferredPresentationPropNotNull() 
+			throws LBException{
+	
+		CodingSchemeVersionOrTag versionOrTag = new CodingSchemeVersionOrTag();
+		versionOrTag.setVersion("0.1.5");
+		CodedNodeSet newSet = lbs.getNodeSet(LexBIGServiceTestCase.OWL2_SNIPPET_INDIVIDUAL_URN, versionOrTag , null);
+		
+		newSet= newSet.restrictToCodes(Constructors.createConceptReferenceList("C117743"));
+		ResolvedConceptReferenceList list = newSet.resolveToList(null, null, null, -1);
+		Iterator<? extends ResolvedConceptReference> itr = list.iterateResolvedConceptReference();
+		assertTrue(itr.hasNext());
+		
+		ResolvedConceptReference ref = itr.next();
+		org.LexGrid.concepts.Entity e = ref.getEntity();
+		
+		Presentation[] presentations = e.getPresentation();
+		for( int i = 0; i < presentations.length; i++) {
+			Presentation p = presentations[i];
+			
+			// isPreferred should not be null
+			assertNotNull(p.getIsPreferred());
+			
+			if(p.getIsPreferred() ) {
+				System.out.print(p.getValue().getContent() + "\t");
+				Property[] props = e.getAllProperties();
+				for( Property prop : props ) {
+					if( prop.getPropertyName().equals("Semantic_Type") ) {
+						System.out.print(prop.getValue().getContent() + "\t");
+					}
+				}
+			}
+		}
+		
+	}
+	
 	@Test
 	public void testRestrictOnSubClassOfToProperty() 
 			throws LBInvocationException, LBParameterException, LBResourceUnavailableException{

--- a/lgConverter/src/edu/mayo/informatics/lexgrid/convert/directConversions/owlapi/OwlApi2LG.java
+++ b/lgConverter/src/edu/mayo/informatics/lexgrid/convert/directConversions/owlapi/OwlApi2LG.java
@@ -1348,6 +1348,12 @@ public class OwlApi2LG {
                 // Remember that a preferred definition was assigned ...
                 assignedPreferredDefn = true;
             }
+            else if (prop instanceof Presentation){
+                // default the presentation property isPreferred value to false, if it wasn't set.
+                if (((Presentation) prop).getIsPreferred() == null) {
+                    ((Presentation) prop).setIsPreferred(Boolean.FALSE);
+                }
+            }
         }
 
         // Updated on 05/28/2008: It was decided that we also need to


### PR DESCRIPTION
LEXEVS-2020 Updated OWL2 loader to default the presentation property isPreferred value to false, if it wasn't set.