### PR TITLE
Bugfix/lexevs 3877 Documentation: Script SourceAssertedValueSetDefinitionLoad.sh example is not correct

### DIFF
--- a/lbAdmin/scripts/SourceAssertedValueSetDefinitionLoad.sh
+++ b/lbAdmin/scripts/SourceAssertedValueSetDefinitionLoad.sh
@@ -20,6 +20,6 @@
 #
 #    -cd, --conceptDomainName" usage= "Gives the name of the property to resolve the concept domain value against" 
 #        
-# Example: SourceAssertedValueSetDefinition.bat -v "17.04d"
+# Example: SourceAssertedValueSetDefinition.sh -v "17.04d"
 #
 java -Xmx3000m -Djava.awt.headless=true -cp "../runtime/lbPatch.jar:../runtime-components/extLib/*" org.LexGrid.LexBIG.admin.SourceAssertedValueSetDefinitionLauncher $@


### PR DESCRIPTION
Bugfix/lexevs 3877 Documentation: Script SourceAssertedValueSetDefinitionLoad.sh example is not correct