### PR TITLE
Bugfix/lexevs 4427 Update getSourceAssertedValueSetForValueSetURI() to return the correct coding scheme when there are multiple to choose from.

### DIFF
--- a/lbTest/src/test/java/edu/mayo/informatics/lexgrid/convert/directConversions/assertedValueSets/SourceAssertedValueSetSearchIndexServiceTest.java
+++ b/lbTest/src/test/java/edu/mayo/informatics/lexgrid/convert/directConversions/assertedValueSets/SourceAssertedValueSetSearchIndexServiceTest.java
@@ -546,8 +546,9 @@ public class SourceAssertedValueSetSearchIndexServiceTest {
 	@Order(12)
 	public void testSchemeData() throws LBException, URISyntaxException {
 		CodingScheme scheme = svc.getSourceAssertedValueSetForValueSetURI(new URI(AssertedValueSetServices.BASE + "C54453"));
-		assertNotNull(scheme);
-		assertNotNull(scheme.getCodingSchemeName());
+		assertEquals(scheme, null);
+		
+		scheme = svc.getSourceAssertedValueSetForValueSetURI(new URI(AssertedValueSetServices.BASE + "FDA/" + "C54453"));
 		assertEquals("Structured Product Labeling Color Terminology",scheme.getCodingSchemeName());
 		assertEquals(AssertedValueSetServices.BASE + "FDA/" + "C54453", scheme.getCodingSchemeURI());
 		assertTrue(scheme.getIsActive());

--- a/lbTest/src/test/java/org/lexevs/dao/index/operation/SourceAssertedVSLoadTest.java
+++ b/lbTest/src/test/java/org/lexevs/dao/index/operation/SourceAssertedVSLoadTest.java
@@ -107,8 +107,9 @@ public class SourceAssertedVSLoadTest {
 	@Test
 	public void testSchemeData() throws LBException, URISyntaxException {
 		CodingScheme scheme = svc.getSourceAssertedValueSetForValueSetURI(new URI(AssertedValueSetServices.BASE + "C54453"));
-		assertNotNull(scheme);
-		assertNotNull(scheme.getCodingSchemeName());
+		assertEquals(scheme, null);
+		
+		scheme = svc.getSourceAssertedValueSetForValueSetURI(new URI(AssertedValueSetServices.BASE + "FDA/" + "C54453"));
 		assertEquals("Structured Product Labeling Color Terminology",scheme.getCodingSchemeName());
 		assertEquals(AssertedValueSetServices.BASE + "FDA/" + "C54453", scheme.getCodingSchemeURI());
 		assertTrue(scheme.getIsActive());

--- a/lgValueSets/src/org/lexgrid/valuesets/sourceasserted/impl/SourceAssertedValueSetServiceImpl.java
+++ b/lgValueSets/src/org/lexgrid/valuesets/sourceasserted/impl/SourceAssertedValueSetServiceImpl.java
@@ -4,6 +4,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -103,11 +104,23 @@ public class SourceAssertedValueSetServiceImpl implements SourceAssertedValueSet
 
 	@Override
 	public CodingScheme getSourceAssertedValueSetForValueSetURI(URI uri) throws LBException {;
-		return getSourceAssertedValueSetforTopNodeEntityCode(
-				AssertedValueSetServices.getConceptCodeForURI(uri)) == null
-				? null
-				:getSourceAssertedValueSetforTopNodeEntityCode(
-						AssertedValueSetServices.getConceptCodeForURI(uri)).get(0);
+		
+		List<CodingScheme> codingSchemes = getSourceAssertedValueSetforTopNodeEntityCode(
+				AssertedValueSetServices.getConceptCodeForURI(uri));
+		if (codingSchemes == null){
+			return null;
+		}
+		CodingScheme codingSchemeMatch = null;
+		
+		for (Iterator iterator = codingSchemes.iterator(); iterator.hasNext();) {
+			CodingScheme codingScheme = (CodingScheme) iterator.next();
+			if (codingScheme.getCodingSchemeURI().equals(uri.toString())) {
+				codingSchemeMatch = codingScheme;
+				break;
+			}
+		}
+		
+		return codingSchemeMatch;
 	}
 
 	@Override


### PR DESCRIPTION
Bugfix/lexevs 4427 Update getSourceAssertedValueSetForValueSetURI() to return the correct coding scheme when there are multiple to choose from.