### PR TITLE
Bugfix/lexevs 4535  Correcting a Hierarchy implementation issue for Tree Extension

### DIFF
--- a/lbImpl/src/org/LexGrid/LexBIG/Impl/Extensions/tree/service/PathToRootTreeServiceImpl.java
+++ b/lbImpl/src/org/LexGrid/LexBIG/Impl/Extensions/tree/service/PathToRootTreeServiceImpl.java
@@ -186,7 +186,12 @@ public class PathToRootTreeServiceImpl extends AbstractExtendable implements Tre
 			String namespace, String hierarchyId) {
 		LexEvsTree tree = new LexEvsTree();
 
-		List<SupportedHierarchy> hierarchies = this.getSupportedHierarchies(codingScheme, versionOrTag, hierarchyId);
+        List<SupportedHierarchy> hierarchies = this.getSupportedHierarchies(
+                codingScheme, versionOrTag, hierarchyId).
+                stream().filter(x -> x.getAssociationNames()[0].equals("subClassOf") || 
+                        x.getContent().equals("is_a") || 
+                        x.getLocalId().equals("is_a")).
+                collect(Collectors.toList());
 		Direction direction = this.getDirection(hierarchies);
 		String root = this.getRoot(hierarchies);
 		List<String> associationNames = this.getAssociationNames(hierarchies);

--- a/lbPackager/build.properties
+++ b/lbPackager/build.properties
@@ -1,5 +1,5 @@
 #Product version - major release
-vMajor=SNAPSHOT.DEV.SPRINT107.2019.05.01
+vMajor=SNAPSHOT.DEV.SPRINT107.2019.05.02
 
 #Product version - minor release
 vMinor=5

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/Extensions/tree/test/TestGetTree.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/Extensions/tree/test/TestGetTree.java
@@ -7,6 +7,7 @@ import org.LexGrid.LexBIG.Impl.Extensions.tree.service.PathToRootTreeServiceImpl
 import org.LexGrid.LexBIG.Impl.Extensions.tree.service.TreeServiceFactory;
 import org.LexGrid.LexBIG.Impl.testUtility.ServiceHolder;
 import org.LexGrid.LexBIG.LexBIGService.LexBIGService;
+import org.LexGrid.LexBIG.Utility.Constructors;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -28,4 +29,12 @@ public class TestGetTree extends TestCase{
 		  assertNotNull(iterator.next());
 	}
 
+	@Test
+	public void testGetTreeWithMultipleHierarchyAsscDirectionNames() {
+		 lbs = ServiceHolder.instance().getLexBIGService();
+		  pathToRootTreeServiceImpl = (PathToRootTreeServiceImpl) TreeServiceFactory.getInstance().getTreeService(lbs);
+		  iterator = pathToRootTreeServiceImpl.getTree("http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl", 
+				  Constructors.createCodingSchemeVersionOrTagFromVersion("0.1.5"), "Patient").getCurrentFocus().getChildIterator();
+		  assertNotNull(iterator.next());
+	}
 }


### PR DESCRIPTION
Fixes an issue where empty and other poorly defined hierarchies break the tree extension resolution functions. 