### PR TITLE
LEXEVS-4607. OWL API bug requires adaptation for numeric IRI remainder.

### DIFF
--- a/lbTest/resources/[lbImpl] All Tests - NormalConfig.launch
+++ b/lbTest/resources/[lbImpl] All Tests - NormalConfig.launch
@@ -7,9 +7,6 @@
 <listEntry value="1"/>
 </listAttribute>
 <booleanAttribute key="org.eclipse.debug.core.appendEnvironmentVariables" value="true"/>
-<mapAttribute key="org.eclipse.debug.core.preferred_launchers">
-<mapEntry key="[run]" value="org.eclipse.jdt.junit.launchconfig"/>
-</mapAttribute>
 <listAttribute key="org.eclipse.debug.ui.favoriteGroups">
 <listEntry value="org.eclipse.debug.ui.launchGroup.debug"/>
 <listEntry value="org.eclipse.debug.ui.launchGroup.run"/>

--- a/lbTest/resources/[lbImpl] All Tests - NormalConfig.launch
+++ b/lbTest/resources/[lbImpl] All Tests - NormalConfig.launch
@@ -7,6 +7,9 @@
 <listEntry value="1"/>
 </listAttribute>
 <booleanAttribute key="org.eclipse.debug.core.appendEnvironmentVariables" value="true"/>
+<mapAttribute key="org.eclipse.debug.core.preferred_launchers">
+<mapEntry key="[run]" value="org.eclipse.jdt.junit.launchconfig"/>
+</mapAttribute>
 <listAttribute key="org.eclipse.debug.ui.favoriteGroups">
 <listEntry value="org.eclipse.debug.ui.launchGroup.debug"/>
 <listEntry value="org.eclipse.debug.ui.launchGroup.run"/>

--- a/lbTest/resources/testData/owl2/owl2-special-cases-Defined-Annotated.owl
+++ b/lbTest/resources/testData/owl2/owl2-special-cases-Defined-Annotated.owl
@@ -1,24 +1,33 @@
-<?xml version="1.0"?>
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE rdf:RDF [
+    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
+    <!ENTITY dc "http://purl.org/dc/elements/1.1/" >
+    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
+    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
+    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
+    <!ENTITY owl2lexevs "http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#" >
+]>
+
+
 <rdf:RDF xmlns="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#"
      xml:base="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl"
      xmlns:dc="http://purl.org/dc/elements/1.1/"
-     xmlns:obo="http://purl.obolibrary.org/obo/"
-     xmlns:owl="http://www.w3.org/2002/07/owl#"
-     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-     xmlns:xml="http://www.w3.org/XML/1998/namespace"
-     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
-     xmlns:doap="http://usefulinc.com/ns/doap#"
-     xmlns:foaf="http://xmlns.com/foaf/0.1/"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-     xmlns:protege="http://protege.stanford.edu/plugins/owl/protege#"
+     xmlns:owl2lexevs="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:obo="http://purl.obolibrary.org/obo/"
+     xmlns:doap="http://usefulinc.com/ns/doap#" 
+     xmlns:foaf="http://xmlns.com/foaf/0.1/"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#"
-     xmlns:owl2lexevs="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#">
+     xmlns:protege="http://protege.stanford.edu/plugins/owl/protege#">
     <owl:Ontology rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl">
-        <owl:versionIRI rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl/0.1.5"/>
-        <note xml:lang="en">Test of OWL2 constructions for import into LexEVS.  This file contains defines with annotations.</note>
         <source>nci evs</source>
         <dc:date>august 8, 2014</dc:date>
         <owl:versionInfo>0.1.5</owl:versionInfo>
+        <note xml:lang="en">Test of OWL2 constructions for import into LexEVS.  This file contains defines with annotations.</note>
+        <owl:versionIRI rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl/0.1.5"/>
     </owl:Ontology>
     
 
@@ -34,140 +43,219 @@
     
 
 
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#A8 -->
-
-    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#A8">
-        <P90>Concept_In_Subset</P90>
-        <P97>Used to associate the concept defining a particular terminology subset with concepts that belong to this subset.</P97>
-        <rdfs:label>Concept_In_Subset</rdfs:label>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#anyURI"/>
-    </owl:AnnotationProperty>
-    
-
-
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationLIT -->
 
-    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationLIT">
-        <term rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Association</term>
+    <owl:AnnotationProperty rdf:about="&owl2lexevs;AssociationLIT">
+        <term rdf:datatype="&xsd;string">Association</term>
     </owl:AnnotationProperty>
     
 
 
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationSTR -->
 
-    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationSTR">
-        <term rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Association</term>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+    <owl:AnnotationProperty rdf:about="&owl2lexevs;AssociationSTR">
+        <term rdf:datatype="&xsd;string">Association</term>
+        <rdfs:range rdf:resource="&xsd;string"/>
     </owl:AnnotationProperty>
     
 
 
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationURI -->
 
-    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationURI">
-        <term rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Association</term>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#anyURI"/>
+    <owl:AnnotationProperty rdf:about="&owl2lexevs;AssociationURI">
+        <term rdf:datatype="&xsd;string">Association</term>
+        <rdfs:range rdf:resource="&xsd;anyURI"/>
     </owl:AnnotationProperty>
     
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationURIAsResource -->
-
-    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationURIAsResource">
-        <term rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Association</term>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#anyURI"/>
+     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationURIAsResource -->
+     
+   <owl:AnnotationProperty rdf:about="&owl2lexevs;AssociationURIAsResource">
+        <term rdf:datatype="&xsd;string">Association</term>
+        <rdfs:range rdf:resource="&xsd;anyURI"/>
     </owl:AnnotationProperty>
     
-
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#InvalideAssociationURIAsResource -->
+ 	<owl:AnnotationProperty rdf:about="&owl2lexevs;InvalidAssociationURIAsResource"/>
 
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationV1 -->
 
-    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationV1"/>
+    <owl:AnnotationProperty rdf:about="&owl2lexevs;AssociationV1">
+        <term rdf:datatype="&xsd;string">Association</term>
+    </owl:AnnotationProperty>
     
 
 
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#definition -->
+
+    <owl:AnnotationProperty rdf:about="&owl2lexevs;definition"/>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#note -->
+
+    <owl:AnnotationProperty rdf:about="&owl2lexevs;note"/>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#provenance -->
+
+    <owl:AnnotationProperty rdf:about="&owl2lexevs;provenance"/>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#semanticType -->
+
+    <owl:AnnotationProperty rdf:about="&owl2lexevs;semanticType">
+        <semanticType rdf:datatype="&xsd;string">Conceptual</semanticType>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#source -->
+
+    <owl:AnnotationProperty rdf:about="&owl2lexevs;source"/>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term -->
+
+    <owl:AnnotationProperty rdf:about="&owl2lexevs;term"/>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term_type -->
+
+    <owl:AnnotationProperty rdf:about="&owl2lexevs;term_type"/>
+    
+
+
+    <!-- http://purl.org/dc/elements/1.1/date -->
+
+    <owl:AnnotationProperty rdf:about="&dc;date"/>
+    
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0010000"><!-- has axiom label -->
+        <rdfs:label xml:lang="en">has axiom label</rdfs:label>
+        <obo:IAO_0000600 xml:lang="en">A URI that is intended to be unique label for an axiom used for tracking change to the ontology. For an axiom expressed in different languages, each expression is given the same URI</obo:IAO_0000600>
+        <obo:IAO_0000117 xml:lang="en">Person:Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">Person:Alan Ruttenberg</obo:IAO_0000119>
+        <obo:IAO_0000111 xml:lang="en">has axiom label</obo:IAO_0000111>
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+    </owl:AnnotationProperty>
+
+
+      <!-- http://purl.obolibrary.org/obo/IAO_0000114 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000114"><!-- has curation status -->
+        <rdfs:label xml:lang="en">has curation status</rdfs:label>
+        <obo:IAO_0000119 xml:lang="en">OBI_0000281</obo:IAO_0000119>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Bill Bug</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Melanie Courtot</obo:IAO_0000117>
+        <obo:IAO_0000111 xml:lang="en">has curation status</obo:IAO_0000111>
+    </owl:AnnotationProperty>
+
+        <!-- http://purl.obolibrary.org/obo/IAO_0000412 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000412"><!-- imported from -->
+        <rdfs:label xml:lang="en">imported from</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">For external terms/classes, the ontology from which the term was imported</obo:IAO_0000115>
+        <obo:IAO_0000119 xml:lang="en">GROUP:OBI:&lt;http://purl.obolibrary.org/obo/obi></obo:IAO_0000119>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Melanie Courtot</obo:IAO_0000117>
+        <obo:IAO_0000111 xml:lang="en">imported from</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/><!-- pending final vetting -->
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+    </owl:AnnotationProperty>
+
+        <!-- http://purl.obolibrary.org/obo/IAO_0100001 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0100001"><!-- term replaced by -->
+        <rdfs:label xml:lang="en">term replaced by</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">Add as annotation triples in the granting ontology</obo:IAO_0000115>
+        <obo:IAO_0000119 xml:lang="en">Person:Alan Ruttenberg</obo:IAO_0000119>
+        <obo:IAO_0000117 xml:lang="en">Person:Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000115 xml:lang="en">Use on obsolete terms, relating the term to another term that can be used as a substitute</obo:IAO_0000115>
+        <obo:IAO_0000111 xml:lang="en">term replaced by</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/><!-- pending final vetting -->
+    </owl:AnnotationProperty>
+    
+    
+        <!-- http://purl.obolibrary.org/obo/IAO_0000111 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000111"><!-- editor preferred label -->
+        <rdfs:label>editor preferred term</rdfs:label>
+        <rdfs:label>editor preferred term~editor preferred label</rdfs:label>
+        <rdfs:label>editor preferred label</rdfs:label>
+        <rdfs:label xml:lang="en">editor preferred label</rdfs:label>
+        <rdfs:label xml:lang="en">editor preferred term</rdfs:label>
+        <obo:IAO_0000119 xml:lang="en">GROUP:OBI:&lt;http://purl.obolibrary.org/obo/obi></obo:IAO_0000119>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Daniel Schober</obo:IAO_0000117>
+        <obo:IAO_0000115 xml:lang="en">The concise, meaningful, and human-friendly name for a class or property preferred by the ontology developers. (US-English)</obo:IAO_0000115>
+        <obo:IAO_0000111 xml:lang="en">editor preferred label</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/><!-- ready for release -->
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+    </owl:AnnotationProperty>
+    
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#FULL_SYN -->
 
-    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#FULL_SYN"/>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#InvalidAssociationURIAsResource -->
-
-    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#InvalidAssociationURIAsResource"/>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#NHC0 -->
-
-    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#NHC0">
-        <NHC0>NHC0</NHC0>
-        <P108>code</P108>
-        <P90>code</P90>
-        <protege:readOnly rdf:datatype="http://www.w3.org/2001/XMLSchema#string">true</protege:readOnly>
-        <rdfs:label>code</rdfs:label>
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90">
+        <P90>FULL_SYN</P90>
+        <P90>Synonym with Source Data</P90>
+        <rdfs:label>FULL_SYN</rdfs:label>
     </owl:AnnotationProperty>
     <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#NHC0"/>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97"/>
+        <owl:annotatedTarget>Fully qualified synonym, contains the string, term type, source, and an optional source code if appropriate. Each subfield is deliniated to facilitate interpretation by software.</owl:annotatedTarget>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
         <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
-        <owl:annotatedTarget>code</owl:annotatedTarget>
-        <P383>PT</P383>
+        <owl:annotatedTarget>FULL_SYN</owl:annotatedTarget>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
+        <owl:annotatedTarget>Synonym with Source Data</owl:annotatedTarget>
     </owl:Axiom>
     
+    
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#DEFINITION -->
 
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P106 -->
-
-    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P106">
-        <P108>Semantic_Type</P108>
-        <P90>Semantic_Type</P90>
-        <rdfs:label>Semantic_Type</rdfs:label>
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97">
+        <P97>English language definitions of what NCI means by the concept. These are limited to 1024 characters. They may also include information about the definition&apos;s source and attribution in a form that can easily be interpreted by software.</P97>
+        <P90>DEFINITION</P90>
+        <P108>DEFINITION</P108>
+        <P106>Conceptual Entity</P106>
+        <NHC0>P97</NHC0>
+        <rdfs:label>DEFINITION</rdfs:label>
     </owl:AnnotationProperty>
     <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P106"/>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97"/>
+        <owl:annotatedTarget>English language definitions of what NCI means by the concept. These are limited to 1024 characters. They may also include information about the definition&apos;s source and attribution in a form that can easily be interpreted by software.</owl:annotatedTarget>
+        <P380>060127</P380>
+        <P379>DEFAULT_Review</P379>
+        <P378>NCI</P378>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97"/>
         <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
-        <owl:annotatedTarget>Semantic_Type</owl:annotatedTarget>
+        <owl:annotatedTarget>DEFINITION</owl:annotatedTarget>
         <P383>PT</P383>
         <P384>NCI</P384>
     </owl:Axiom>
     
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P108 -->
-
-    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P108">
-        <NHC0>P108</NHC0>
-        <P108>Preferred_Name</P108>
-        <P90>Preferred Name</P90>
-        <P90>Preferred Term</P90>
-        <P90>Preferred_Name</P90>
-        <rdfs:label>Preferred_Name</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P207 -->
-
-    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P207"/>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P317 -->
-
-    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P317"/>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P322 -->
+    <!-- Contributing_Source -->
 
     <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P322">
+        <rdfs:label>Contributing_Source</rdfs:label>
+        <rdfs:range rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Contributing_Source-enum"/>
         <NHC0>P322</NHC0>
         <P106>Conceptual Entity</P106>
         <P108>Contributing_Source</P108>
         <P90>Contributing_Source</P90>
         <P97>This property is used to indicate when a non-EVS entity has contributed to, and has a stake in, a concept.  This is used where such entities, within or outside NCI, have indicated the need to be able to track their own concepts. A single concept can have multiple instances of this property if multiple entities have such a defined stake.</P97>
-        <rdfs:label>Contributing_Source</rdfs:label>
-        <rdfs:range rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Contributing_Source-enum"/>
     </owl:AnnotationProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P322"/>
@@ -181,18 +269,24 @@
         <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97"/>
         <owl:annotatedTarget>This property is used to indicate when a non-EVS entity has contributed to, and has a stake in, a concept.  This is used where such entities, within or outside NCI, have indicated the need to be able to track their own concepts. A single concept can have multiple instances of this property if multiple entities have such a defined stake.</owl:annotatedTarget>
         <P378>NCI</P378>
+        <P379>DEFAULT_Review</P379>
+        <P380>060127</P380>
     </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P325 -->
+      
+       <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#ALT_DEFINITION -->
 
     <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P325">
-        <NHC0>P325</NHC0>
-        <P90>ALT_DEFINITION</P90>
         <P97>English language definitions of what a source other than NCI means by the concept. These are limited to 1024 characters. They include information about the definition&apos;s source in a form that can easily be interpreted by software.</P97>
+        <P90>ALT_DEFINITION</P90>
+        <NHC0>P325</NHC0>
         <rdfs:label>ALT_DEFINITION</rdfs:label>
     </owl:AnnotationProperty>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P325"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97"/>
+        <owl:annotatedTarget>English language definitions of what a source other than NCI means by the concept. These are limited to 1024 characters. They include information about the definition&apos;s source in a form that can easily be interpreted by software.</owl:annotatedTarget>
+        <P378>NCI</P378>
+    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P325"/>
         <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
@@ -200,32 +294,18 @@
         <P383>PT</P383>
         <P384>NCI</P384>
     </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P325"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97"/>
-        <owl:annotatedTarget>English language definitions of what a source other than NCI means by the concept. These are limited to 1024 characters. They include information about the definition&apos;s source in a form that can easily be interpreted by software.</owl:annotatedTarget>
-        <P378>NCI</P378>
-    </owl:Axiom>
     
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P366 -->
-
-    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P366"/>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P372 -->
+        <!-- Publish_Value_Set -->
 
     <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P372">
+        <rdfs:label>Publish_Value_Set</rdfs:label>
+        <rdfs:range rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Publish_Value_Set-enum"/>
         <NHC0>P372</NHC0>
         <P106>Conceptual Entity</P106>
         <P108>Publish_Value_Set</P108>
         <P90>Publish_Value_Set</P90>
         <P95>This property will be used internally, and scrubbed before publication to the ftp and browser.</P95>
         <P97>Indicates whether or not a value set is ready for publication in the browser.</P97>
-        <rdfs:label>Publish_Value_Set</rdfs:label>
-        <rdfs:range rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Publish_Value_Set-enum"/>
     </owl:AnnotationProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P372"/>
@@ -239,355 +319,127 @@
         <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97"/>
         <owl:annotatedTarget>Indicates whether or not a value set is ready for publication in the browser.</owl:annotatedTarget>
         <P378>NCI</P378>
+        <P379>Elizabeth Hahn-Dantona</P379>
+        <P380>160413</P380>
     </owl:Axiom>
     
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P376 -->
+    
+       <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Term_Browser_Value_Set_Description -->
 
     <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P376">
         <P90>Term_Browser_Value_Set_Description</P90>
-        <P97>Used to house the text on the introductory page on the NCI Term Browser for the Value Set named by a concept when that text differs from the DEFINITION for that concept.</P97>
         <rdfs:label>Term_Browser_Value_Set_Description</rdfs:label>
     </owl:AnnotationProperty>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P378 -->
-
-    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P378">
-        <NHC0>P378</NHC0>
-        <P108>def-source</P108>
-        <rdfs:label>def-source</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P382 -->
-
-    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P382">
-        <NHC0>P382</NHC0>
-        <P108>term-name</P108>
-        <rdfs:label>term-name</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P383 -->
-
-    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P383">
-        <NHC0>P383</NHC0>
-        <P108>term-group</P108>
-        <rdfs:label>term-group</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P384 -->
-
-    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P384">
-        <NHC0>P384</NHC0>
-        <P108>term-source</P108>
-        <rdfs:label>term-source</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90 -->
-
-    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90">
-        <P90>FULL_SYN</P90>
-        <P90>Synonym with Source Data</P90>
-        <P97>Fully qualified synonym, contains the string, term type, source, and an optional source code if appropriate. Each subfield is deliniated to facilitate interpretation by software.</P97>
-        <rdfs:label>FULL_SYN</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P95 -->
-
-    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P95"/>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97 -->
-
-    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97">
-        <NHC0>P97</NHC0>
-        <P106>Conceptual Entity</P106>
-        <P108>DEFINITION</P108>
-        <P90>DEFINITION</P90>
-        <P97>English language definitions of what NCI means by the concept. These are limited to 1024 characters. They may also include information about the definition&apos;s source and attribution in a form that can easily be interpreted by software.</P97>
-        <rdfs:label>DEFINITION</rdfs:label>
-    </owl:AnnotationProperty>
     <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97"/>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P376"/>
         <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97"/>
-        <owl:annotatedTarget>English language definitions of what NCI means by the concept. These are limited to 1024 characters. They may also include information about the definition&apos;s source and attribution in a form that can easily be interpreted by software.</owl:annotatedTarget>
-        <P378>NCI</P378>
+        <owl:annotatedTarget>Used to house the text on the introductory page on the NCI Term Browser for the Value Set named by a concept when that text differs from the DEFINITION for that concept.</owl:annotatedTarget>
     </owl:Axiom>
     <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97"/>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P376"/>
         <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
-        <owl:annotatedTarget>DEFINITION</owl:annotatedTarget>
+        <owl:annotatedTarget>Term_Browser_Value_Set_Description</owl:annotatedTarget>
+    </owl:Axiom>
+    
+    
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Concept_In_Subset -->
+
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#A8">
+        <P90>Concept_In_Subset</P90>
+        <rdfs:label>Concept_In_Subset</rdfs:label>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#anyURI"/>
+    </owl:AnnotationProperty>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#A8"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97"/>
+        <owl:annotatedTarget>Used to associate the concept defining a particular terminology subset with concepts that belong to this subset.</owl:annotatedTarget>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#A8"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
+        <owl:annotatedTarget>Concept_In_Subset</owl:annotatedTarget>
+    </owl:Axiom>
+    
+    <!-- Semantic_Type -->
+
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P106">
+        <rdfs:label>Semantic_Type</rdfs:label>
+        <P108>Semantic_Type</P108>
+        <P90>Semantic_Type</P90>
+    </owl:AnnotationProperty>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P106"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
+        <owl:annotatedTarget>Semantic_Type</owl:annotatedTarget>
         <P383>PT</P383>
         <P384>NCI</P384>
     </owl:Axiom>
     
 
-
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Preferred_Name -->
-
-    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Preferred_Name"/>
     
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P108">
+        <P90>Preferred Name</P90>
+        <P90>Preferred Term</P90>
+        <P90>Preferred_Name</P90>
+        <P108>Preferred_Name</P108>
+        <NHC0>P108</NHC0>
+        <rdfs:label>Preferred_Name</rdfs:label>
+    </owl:AnnotationProperty>
 
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Semantic_Type -->
-
-    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Semantic_Type"/>
     
+        <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#code -->
 
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#code -->
-
-    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#code"/>
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#NHC0">
+        <P90>code</P90>
+        <P108>code</P108>
+        <NHC0>NHC0</NHC0>
+        <protege:readOnly rdf:datatype="http://www.w3.org/2001/XMLSchema#string">true</protege:readOnly>
+        <rdfs:label>code</rdfs:label>
+    </owl:AnnotationProperty>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#NHC0"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
+        <owl:annotatedTarget>code</owl:annotatedTarget>
+        <P383>PT</P383>
+    </owl:Axiom>
     
+        <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#def-source -->
 
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#definition -->
-
-    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#definition"/>
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P378">
+        <P108>def-source</P108>
+        <NHC0>P378</NHC0>
+        <rdfs:label>def-source</rdfs:label>
+    </owl:AnnotationProperty>
     
+        <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term-group -->
 
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#note -->
-
-    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#note"/>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#provenance -->
-
-    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#provenance"/>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#semanticType -->
-
-    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#semanticType"/>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#source -->
-
-    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#source"/>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term -->
-
-    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term"/>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term_type -->
-
-    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term_type"/>
-    
-
-
-    <!-- http://protege.stanford.edu/plugins/owl/protege#readOnly -->
-
-    <owl:AnnotationProperty rdf:about="http://protege.stanford.edu/plugins/owl/protege#readOnly"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/BFO_0000179 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/BFO_0000179"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/BFO_0000180 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/BFO_0000180"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000111 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000111">
-        <obo:IAO_0000111 xml:lang="en">editor preferred label</obo:IAO_0000111>
-        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
-        <obo:IAO_0000115 xml:lang="en">The concise, meaningful, and human-friendly name for a class or property preferred by the ontology developers. (US-English)</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">PERSON:Daniel Schober</obo:IAO_0000117>
-        <obo:IAO_0000119 xml:lang="en">GROUP:OBI:&lt;http://purl.obolibrary.org/obo/obi&gt;</obo:IAO_0000119>
-        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
-        <rdfs:label>editor preferred label</rdfs:label>
-        <rdfs:label xml:lang="en">editor preferred label</rdfs:label>
-        <rdfs:label>editor preferred term</rdfs:label>
-        <rdfs:label xml:lang="en">editor preferred term</rdfs:label>
-        <rdfs:label>editor preferred term~editor preferred label</rdfs:label>
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P383">
+        <P108>term-group</P108>
+        <NHC0>P383</NHC0>
+        <rdfs:label>term-group</rdfs:label>
     </owl:AnnotationProperty>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_0000112 -->
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term-name -->
 
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000112"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000114 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000114">
-        <obo:IAO_0000111 xml:lang="en">has curation status</obo:IAO_0000111>
-        <obo:IAO_0000117 xml:lang="en">PERSON:Alan Ruttenberg</obo:IAO_0000117>
-        <obo:IAO_0000117 xml:lang="en">PERSON:Bill Bug</obo:IAO_0000117>
-        <obo:IAO_0000117 xml:lang="en">PERSON:Melanie Courtot</obo:IAO_0000117>
-        <obo:IAO_0000119 xml:lang="en">OBI_0000281</obo:IAO_0000119>
-        <rdfs:label xml:lang="en">has curation status</rdfs:label>
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P382">
+        <P108>term-name</P108>
+        <NHC0>P382</NHC0>
+        <rdfs:label>term-name</rdfs:label>
     </owl:AnnotationProperty>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_0000115 -->
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term-source -->
 
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000115"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000116 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000116"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000117 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000117"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000118 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000118"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000119 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000119"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000232 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000232"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000412 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000412">
-        <obo:IAO_0000111 xml:lang="en">imported from</obo:IAO_0000111>
-        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
-        <obo:IAO_0000115 xml:lang="en">For external terms/classes, the ontology from which the term was imported</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">PERSON:Alan Ruttenberg</obo:IAO_0000117>
-        <obo:IAO_0000117 xml:lang="en">PERSON:Melanie Courtot</obo:IAO_0000117>
-        <obo:IAO_0000119 xml:lang="en">GROUP:OBI:&lt;http://purl.obolibrary.org/obo/obi&gt;</obo:IAO_0000119>
-        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
-        <rdfs:label xml:lang="en">imported from</rdfs:label>
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P384">
+        <P108>term-source</P108>
+        <NHC0>P384</NHC0>
+        <rdfs:label>term-source</rdfs:label>
     </owl:AnnotationProperty>
     
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000600 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000600"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000601 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000601"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000602 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000602"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0010000 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0010000">
-        <obo:IAO_0000111 xml:lang="en">has axiom label</obo:IAO_0000111>
-        <obo:IAO_0000117 xml:lang="en">Person:Alan Ruttenberg</obo:IAO_0000117>
-        <obo:IAO_0000119 xml:lang="en">Person:Alan Ruttenberg</obo:IAO_0000119>
-        <obo:IAO_0000600 xml:lang="en">A URI that is intended to be unique label for an axiom used for tracking change to the ontology. For an axiom expressed in different languages, each expression is given the same URI</obo:IAO_0000600>
-        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
-        <rdfs:label xml:lang="en">has axiom label</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0100001 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0100001">
-        <obo:IAO_0000111 xml:lang="en">term replaced by</obo:IAO_0000111>
-        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
-        <obo:IAO_0000115 xml:lang="en">Add as annotation triples in the granting ontology</obo:IAO_0000115>
-        <obo:IAO_0000115 xml:lang="en">Use on obsolete terms, relating the term to another term that can be used as a substitute</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">Person:Alan Ruttenberg</obo:IAO_0000117>
-        <obo:IAO_0000119 xml:lang="en">Person:Alan Ruttenberg</obo:IAO_0000119>
-        <rdfs:label xml:lang="en">term replaced by</rdfs:label>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_9991118 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/OBI_9991118"/>
-    
-
-
-    <!-- http://purl.org/dc/elements/1.1/date -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/date"/>
-    
-
-
-    <!-- http://purl.org/dc/elements/1.1/source -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/source"/>
-    
-
-
-    <!-- http://www.w3.org/2002/07/owl#minCardinality -->
-
-    <owl:AnnotationProperty rdf:about="http://www.w3.org/2002/07/owl#minCardinality"/>
-    
-
-
-    <!-- 
-    ///////////////////////////////////////////////////////////////////////////////////////
-    //
-    // Datatypes
-    //
-    ///////////////////////////////////////////////////////////////////////////////////////
-     -->
-
-    
-
-
-    <!-- http://www.w3.org/2001/XMLScheme#string -->
-
-    <rdfs:Datatype rdf:about="http://www.w3.org/2001/XMLScheme#string"/>
-    
-
-
     <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //
@@ -601,67 +453,101 @@
 
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationV1 -->
 
-    <owl:ObjectProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationV1"/>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#R81 -->
-
-    <owl:ObjectProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#R81">
-        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
-        <rdfs:domain rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C12219"/>
-        <rdfs:range rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C12219"/>
-        <code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R81</code>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Anatomic_Structure_Has_Location</rdfs:label>
+    <owl:ObjectProperty rdf:about="&owl2lexevs;AssociationV1">
+        <term rdf:datatype="&xsd;string">Association</term>
     </owl:ObjectProperty>
     
 
 
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#gene_expressed_in -->
 
-    <owl:ObjectProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#gene_expressed_in">
-        <term rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gene expressed in</term>
+    <owl:ObjectProperty rdf:about="&owl2lexevs;gene_expressed_in">
+        <term rdf:datatype="&xsd;string">gene expressed in</term>
     </owl:ObjectProperty>
     <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#gene_expressed_in"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gene expressed in</owl:annotatedTarget>
-        <term_type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PT</term_type>
+        <term_type rdf:datatype="&xsd;string">PT</term_type>
+        <owl:annotatedTarget rdf:datatype="&xsd;string">gene expressed in</owl:annotatedTarget>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;gene_expressed_in"/>
+        <owl:annotatedProperty rdf:resource="&owl2lexevs;term"/>
     </owl:Axiom>
     
 
 
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#gene_related_to_disease -->
 
-    <owl:ObjectProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#gene_related_to_disease">
-        <rdfs:domain rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
-        <rdfs:range rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#DiseasesDisordersFindings"/>
+    <owl:ObjectProperty rdf:about="&owl2lexevs;gene_related_to_disease">
+        <rdfs:domain rdf:resource="&owl2lexevs;C123"/>
+        <rdfs:range rdf:resource="&owl2lexevs;DiseasesDisordersFindings"/>
     </owl:ObjectProperty>
     
 
 
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_finding -->
 
-    <owl:ObjectProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_finding">
-        <rdfs:range rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Finding"/>
+    <owl:ObjectProperty rdf:about="&owl2lexevs;patient_has_finding">
+        <rdfs:range rdf:resource="&owl2lexevs;Finding"/>
     </owl:ObjectProperty>
     
 
 
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_prognosis -->
 
-    <owl:ObjectProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_prognosis">
-        <rdfs:domain rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Patient"/>
-        <rdfs:range rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Prognosis"/>
+    <owl:ObjectProperty rdf:about="&owl2lexevs;patient_has_prognosis">
+        <rdfs:domain rdf:resource="&owl2lexevs;Patient"/>
+        <rdfs:range rdf:resource="&owl2lexevs;Prognosis"/>
     </owl:ObjectProperty>
     
-
-
-    <!-- http://purl.obolibrary.org/obo/BFO_0000051 -->
-
-    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/BFO_0000051"/>
     
+     <!-- http://purl.obolibrary.org/obo/OBI_0000643 -->                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+ <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/OBI_0000643"><!-- has grain -->                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has grain</rdfs:label>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+     <obo:IAO_0000119 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PAPER: Granularity, scale and collectivity: When size does and does not matter, Alan Rector, Jeremy Rogers, Thomas Bittner, Journal of Biomedical Informatics 39 (2006) 333-349</obo:IAO_0000119>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+     <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has grain</obo:IAO_0000111>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
+     <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">the relation of the cells in the finger of the skin to the finger, in which an indeterminate number of grains are parts of the whole by virtue of being grains in a collective that is part of the whole, and in which removing one granular part does not nec- essarily damage or diminish the whole. Ontological Whether there is a fixed, or nearly fixed number of parts - e.g. fingers of the hand, chambers of the heart, or wheels of a car - such that there can be a notion of a single one being missing, or whether, by contrast, the number of parts is indeterminate - e.g., cells in the skin of the hand, red cells in blood, or rubber molecules in the tread of the tire of the wheel of the car.</obo:IAO_0000115>                          
+     <obo:IAO_0000116 xml:lang="en">Discussion in Karslruhe with, among others, Alan Rector, Stefan Schulz, Marijke Keet, Melanie Courtot, and Alan Ruttenberg. Definition take from the definition of granular parthood in the cited paper. Needs work to put into standard form</obo:IAO_0000116>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
+     <obo:IAO_0000117 xml:lang="en">PERSON: Alan Ruttenberg</obo:IAO_0000117>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              
+     <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/><!-- has part -->                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      
+     <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/><!-- metadata complete -->                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
+ </owl:ObjectProperty>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     
+                                  
+                                                                                                                                                                                                                                                                                                                                            
+  <!-- http://purl.obolibrary.org/obo/OBI_0000312 -->                                                                                                                                                                                                                                                     
+                                                                                                                                                                                                                                                                                                          
+  <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/OBI_0000312"><!-- is_specified_output_of -->                                                                                                                                                                                              
+      <rdfs:label xml:lang="en">is_specified_output_of</rdfs:label>                                                                                                                                                                                                                                       
+      <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PERSON:Bjoern Peters</obo:IAO_0000117>                                                                                                                                                                                      
+      <obo:IAO_0000115 xml:lang="en">A relation between a planned process and a continuant participating in that process. The presence of the continuant at the end of the process is explicitly specified in the objective specification which the process realizes the concretization of.</obo:IAO_0000115>
+      <obo:IAO_0000117 xml:lang="en">Alan Ruttenberg</obo:IAO_0000117>                                                                                                                                                                                                                                    
+      <obo:IAO_0000111 xml:lang="en">is_specified_output_of</obo:IAO_0000111>                                                                                                                                                                                                                             
+      <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/><!-- ready for release -->                                                                                                                                                                                              
+      <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/OBI_0000011"/><!-- planned process -->                                                                                                                                                                                                     
+      <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000056"/><!-- participates in -->                                                                                                                                                                                              
+      <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>                                                                                                                                                                                                                            
+  </owl:ObjectProperty>                                                                                                                                                                                                                                                                                   
+                                                                                                                                                                                                                                                                                                          
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0000087"><!-- has role -->
+        <rdfs:label xml:lang="en">has role</rdfs:label>
+        <obo:IAO_0000116 xml:lang="en">A bearer can have many roles, and its roles can exist for different periods of time, but none of its roles can exist when the bearer does not exist. A role need not be realized at all the times that the role exists.</obo:IAO_0000116>
+        <obo:IAO_0000115 xml:lang="en">a relation between an independent continuant (the bearer) and a role, in which the role specifically depends on the bearer for its existence</obo:IAO_0000115>
+        <obo:IAO_0000111 xml:lang="en">has role</obo:IAO_0000111>
+        <obo:IAO_0000118 xml:lang="en">has_role</obo:IAO_0000118>
+        <obo:IAO_0000112 xml:lang="en">this person has role this investigator role (more colloquially: this person has this role of investigator)</obo:IAO_0000112>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000004"/><!-- independent continuant -->
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/BFO_0000023"/><!-- role -->
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000053"/><!-- bearer of -->
+        <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000081"/><!-- role of -->
+    </owl:ObjectProperty>                                                                                                                                                                                                                                                                                      
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+       <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Anatomic_Structure_Has_Location -->
 
+    <owl:ObjectProperty rdf:about="#R81">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Anatomic_Structure_Has_Location</rdfs:label>
+        <code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R81</code>
+        <rdfs:range rdf:resource="#C12219"/>
+        <rdfs:domain rdf:resource="#C12219"/>
+    </owl:ObjectProperty>
 
     <!-- http://purl.obolibrary.org/obo/BFO_0000062 -->
 
@@ -691,8 +577,6 @@
         <rdfs:label xml:lang="en">precedes</rdfs:label>
     </owl:ObjectProperty>
     
-
-
     <!-- http://purl.obolibrary.org/obo/BSO_0000062 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/BSO_0000062">
@@ -713,6 +597,7 @@
     <!-- http://purl.obolibrary.org/obo/BSO_0000063 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/BSO_0000063">
+        <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/BSO_0000062"/>
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002222"/>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000003"/>
@@ -721,116 +606,6 @@
         <rdfs:label xml:lang="en">unwilling</rdfs:label>
     </owl:ObjectProperty>
     
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000136 -->
-
-    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000136"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0000293 -->
-
-    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/OBI_0000293"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0000299 -->
-
-    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/OBI_0000299"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0000312 -->
-
-    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/OBI_0000312">
-        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000056"/>
-        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/OBI_0000011"/>
-        <obo:IAO_0000111 xml:lang="en">is_specified_output_of</obo:IAO_0000111>
-        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
-        <obo:IAO_0000115 xml:lang="en">A relation between a planned process and a continuant participating in that process. The presence of the continuant at the end of the process is explicitly specified in the objective specification which the process realizes the concretization of.</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">Alan Ruttenberg</obo:IAO_0000117>
-        <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PERSON:Bjoern Peters</obo:IAO_0000117>
-        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
-        <rdfs:label xml:lang="en">is_specified_output_of</rdfs:label>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0000417 -->
-
-    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/OBI_0000417"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0000643 -->
-
-    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/OBI_0000643">
-        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
-        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has grain</obo:IAO_0000111>
-        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">the relation of the cells in the finger of the skin to the finger, in which an indeterminate number of grains are parts of the whole by virtue of being grains in a collective that is part of the whole, and in which removing one granular part does not nec- essarily damage or diminish the whole. Ontological Whether there is a fixed, or nearly fixed number of parts - e.g. fingers of the hand, chambers of the heart, or wheels of a car - such that there can be a notion of a single one being missing, or whether, by contrast, the number of parts is indeterminate - e.g., cells in the skin of the hand, red cells in blood, or rubber molecules in the tread of the tire of the wheel of the car.</obo:IAO_0000115>
-        <obo:IAO_0000116 xml:lang="en">Discussion in Karslruhe with, among others, Alan Rector, Stefan Schulz, Marijke Keet, Melanie Courtot, and Alan Ruttenberg. Definition take from the definition of granular parthood in the cited paper. Needs work to put into standard form</obo:IAO_0000116>
-        <obo:IAO_0000117 xml:lang="en">PERSON: Alan Ruttenberg</obo:IAO_0000117>
-        <obo:IAO_0000119 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PAPER: Granularity, scale and collectivity: When size does and does not matter, Alan Rector, Jeremy Rogers, Thomas Bittner, Journal of Biomedical Informatics 39 (2006) 333-349</obo:IAO_0000119>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has grain</rdfs:label>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0001938 -->
-
-    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/OBI_0001938"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/RO_0000053 -->
-
-    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0000053"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/RO_0000056 -->
-
-    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0000056"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/RO_0000081 -->
-
-    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0000081">
-        <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/RO_0000087 -->
-
-    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0000087">
-        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000053"/>
-        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000004"/>
-        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/BFO_0000023"/>
-        <obo:IAO_0000111 xml:lang="en">has role</obo:IAO_0000111>
-        <obo:IAO_0000112 xml:lang="en">this person has role this investigator role (more colloquially: this person has this role of investigator)</obo:IAO_0000112>
-        <obo:IAO_0000115 xml:lang="en">a relation between an independent continuant (the bearer) and a role, in which the role specifically depends on the bearer for its existence</obo:IAO_0000115>
-        <obo:IAO_0000116 xml:lang="en">A bearer can have many roles, and its roles can exist for different periods of time, but none of its roles can exist when the bearer does not exist. A role need not be realized at all the times that the role exists.</obo:IAO_0000116>
-        <obo:IAO_0000118 xml:lang="en">has_role</obo:IAO_0000118>
-        <rdfs:label xml:lang="en">has role</rdfs:label>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/RO_0001000 -->
-
-    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0001000"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/RO_0002222 -->
-
-    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002222"/>
-    
-
 
     <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
@@ -845,51 +620,52 @@
 
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#has_physical_location -->
 
-    <owl:DatatypeProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#has_physical_location"/>
+    <owl:DatatypeProperty rdf:about="&owl2lexevs;has_physical_location"/>
     
 
 
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#in_organism -->
 
-    <owl:DatatypeProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#in_organism">
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hello there</definition>
+    <owl:DatatypeProperty rdf:about="&owl2lexevs;in_organism">
+        <definition rdf:datatype="&xsd;string">hello there</definition>
+        <rdfs:range rdf:resource="&xsd;string"/>
     </owl:DatatypeProperty>
     <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#in_organism"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#definition"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hello there</owl:annotatedTarget>
-        <provenance rdf:datatype="http://www.w3.org/2001/XMLSchema#string">somebody said so</provenance>
+        <owl:annotatedTarget rdf:datatype="&xsd;string">hello there</owl:annotatedTarget>
+        <provenance rdf:datatype="&xsd;string">somebody said so</provenance>
+        <owl:annotatedProperty rdf:resource="&owl2lexevs;definition"/>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;in_organism"/>
     </owl:Axiom>
     
 
 
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#semanticType -->
 
-    <owl:DatatypeProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#semanticType">
+    <owl:DatatypeProperty rdf:about="&owl2lexevs;semanticType">
+        <semanticType rdf:datatype="&xsd;string">Conceptual</semanticType>
         <rdfs:range>
             <rdfs:Datatype>
                 <owl:oneOf>
                     <rdf:Description>
-                        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+                        <rdf:type rdf:resource="&rdf;List"/>
                         <rdf:first>Anatomic</rdf:first>
                         <rdf:rest>
                             <rdf:Description>
-                                <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+                                <rdf:type rdf:resource="&rdf;List"/>
                                 <rdf:first>Conceptual</rdf:first>
                                 <rdf:rest>
                                     <rdf:Description>
-                                        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+                                        <rdf:type rdf:resource="&rdf;List"/>
                                         <rdf:first>Disease</rdf:first>
                                         <rdf:rest>
                                             <rdf:Description>
-                                                <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+                                                <rdf:type rdf:resource="&rdf;List"/>
                                                 <rdf:first>Gene</rdf:first>
                                                 <rdf:rest>
                                                     <rdf:Description>
-                                                        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
+                                                        <rdf:type rdf:resource="&rdf;List"/>
                                                         <rdf:first>Organism</rdf:first>
-                                                        <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+                                                        <rdf:rest rdf:resource="&rdf;nil"/>
                                                     </rdf:Description>
                                                 </rdf:rest>
                                             </rdf:Description>
@@ -904,21 +680,7 @@
         </rdfs:range>
     </owl:DatatypeProperty>
     
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000004 -->
-
-    <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000004">
-        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topDataProperty"/>
-        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
-        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/IAO_0000032"/>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#double"/>
-        <rdfs:label xml:lang="en">has measurement value</rdfs:label>
-    </owl:DatatypeProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0001937 -->
+        <!-- http://purl.obolibrary.org/obo/OBI_0001937 -->
 
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/OBI_0001937">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0002135"/>
@@ -933,11 +695,16 @@
         <rdfs:label>has specified numeric value</rdfs:label>
     </owl:DatatypeProperty>
     
+        <!-- http://purl.obolibrary.org/obo/IAO_0000004 -->
 
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0002135 -->
-
-    <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/OBI_0002135"/>
+    <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000004">
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topDataProperty"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/IAO_0000032"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#double"/>
+        <rdfs:label xml:lang="en">has measurement value</rdfs:label>
+    </owl:DatatypeProperty>
+    
     
 
 
@@ -949,18 +716,23 @@
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#112233 -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#112233">
+        <rdfs:label>NumericalID</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#BRaf -->
 
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#BRaf">
+    <owl:Class rdf:about="&owl2lexevs;BRaf">
         <owl:equivalentClass>
             <owl:Class>
                 <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
+                    <rdf:Description rdf:about="&owl2lexevs;C123"/>
                     <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#gene_expressed_in"/>
+                        <owl:onProperty rdf:resource="&owl2lexevs;gene_expressed_in"/>
                         <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CL_0000148"/>
                     </owl:Restriction>
                 </owl:intersectionOf>
@@ -968,39 +740,39 @@
         </owl:equivalentClass>
     </owl:Class>
     <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#BRaf"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
+        <note rdf:datatype="&xsd;string">test of annotation on object restriction subclass to external class</note>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;BRaf"/>
+        <owl:annotatedProperty rdf:resource="&owl;equivalentClass"/>
         <owl:annotatedTarget>
             <owl:Class>
                 <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
+                    <rdf:Description rdf:about="&owl2lexevs;C123"/>
                     <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#gene_expressed_in"/>
+                        <owl:onProperty rdf:resource="&owl2lexevs;gene_expressed_in"/>
                         <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CL_0000148"/>
                     </owl:Restriction>
                 </owl:intersectionOf>
             </owl:Class>
         </owl:annotatedTarget>
-        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">test of annotation on object restriction subclass to external class</note>
     </owl:Axiom>
     
 
 
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Brca1 -->
 
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Brca1">
+    <owl:Class rdf:about="&owl2lexevs;Brca1">
         <owl:equivalentClass>
             <owl:Class>
                 <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
+                    <rdf:Description rdf:about="&owl2lexevs;C123"/>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#gene_expressed_in"/>
-                                <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#EpithelialCell"/>
+                                <owl:onProperty rdf:resource="&owl2lexevs;gene_expressed_in"/>
+                                <owl:someValuesFrom rdf:resource="&owl2lexevs;EpithelialCell"/>
                             </owl:Restriction>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#in_organism"/>
+                                <owl:onProperty rdf:resource="&owl2lexevs;in_organism"/>
                                 <owl:hasValue>homo sapiens</owl:hasValue>
                             </owl:Restriction>
                         </owl:intersectionOf>
@@ -1010,20 +782,21 @@
         </owl:equivalentClass>
     </owl:Class>
     <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Brca1"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
+        <note rdf:datatype="&xsd;string">test of annotation on intersection of datatype and object restriction subclass</note>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;Brca1"/>
+        <owl:annotatedProperty rdf:resource="&owl;equivalentClass"/>
         <owl:annotatedTarget>
             <owl:Class>
                 <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
+                    <rdf:Description rdf:about="&owl2lexevs;C123"/>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#gene_expressed_in"/>
-                                <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#EpithelialCell"/>
+                                <owl:onProperty rdf:resource="&owl2lexevs;gene_expressed_in"/>
+                                <owl:someValuesFrom rdf:resource="&owl2lexevs;EpithelialCell"/>
                             </owl:Restriction>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#in_organism"/>
+                                <owl:onProperty rdf:resource="&owl2lexevs;in_organism"/>
                                 <owl:hasValue>homo sapiens</owl:hasValue>
                             </owl:Restriction>
                         </owl:intersectionOf>
@@ -1031,21 +804,1562 @@
                 </owl:intersectionOf>
             </owl:Class>
         </owl:annotatedTarget>
-        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">test of annotation on intersection of datatype and object restriction subclass</note>
     </owl:Axiom>
     
 
 
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C117743 -->
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123 -->
 
+    <owl:Class rdf:about="&owl2lexevs;C123">
+        <rdfs:label>Gene</rdfs:label>
+        <definition rdf:datatype="&xsd;string">The fundamental unit of heredity.</definition>
+        <term>gene</term>
+        <owl:disjointUnionOf rdf:parseType="Collection">
+            <rdf:Description rdf:about="&owl2lexevs;BRaf"/>
+            <rdf:Description rdf:about="&owl2lexevs;Erbb2"/>
+            <rdf:Description rdf:about="&owl2lexevs;Mefv"/>
+            <rdf:Description rdf:about="&owl2lexevs;Ras"/>
+            <rdf:Description rdf:about="&owl2lexevs;SHH"/>
+            <rdf:Description rdf:about="&owl2lexevs;SOS"/>
+            <rdf:Description rdf:about="&owl2lexevs;actin"/>
+            <rdf:Description rdf:about="&owl2lexevs;k-Ras"/>
+        </owl:disjointUnionOf>
+    </owl:Class>
+    <owl:Axiom>
+        <term_type rdf:datatype="&xsd;string">PT</term_type>
+        <source rdf:datatype="&xsd;string">Wikipedia</source>
+        <owl:annotatedTarget>gene</owl:annotatedTarget>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;C123"/>
+        <owl:annotatedProperty rdf:resource="&owl2lexevs;term"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <source rdf:datatype="&xsd;string">Encyclopedia</source>
+        <provenance rdf:datatype="&xsd;string">Gregor Mendel</provenance>
+        <owl:annotatedTarget rdf:datatype="&xsd;string">The fundamental unit of heredity.</owl:annotatedTarget>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;C123"/>
+        <owl:annotatedProperty rdf:resource="&owl2lexevs;definition"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <note rdf:datatype="&xsd;string">all genes are disjoint.  splicing variants are not considered individual genes.</note>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;C123"/>
+        <owl:annotatedProperty rdf:resource="&owl;disjointUnionOf"/>
+        <owl:annotatedTarget rdf:parseType="Collection">
+            <rdf:Description rdf:about="&owl2lexevs;BRaf"/>
+            <rdf:Description rdf:about="&owl2lexevs;Erbb2"/>
+            <rdf:Description rdf:about="&owl2lexevs;Mefv"/>
+            <rdf:Description rdf:about="&owl2lexevs;Ras"/>
+            <rdf:Description rdf:about="&owl2lexevs;SHH"/>
+            <rdf:Description rdf:about="&owl2lexevs;SOS"/>
+            <rdf:Description rdf:about="&owl2lexevs;actin"/>
+            <rdf:Description rdf:about="&owl2lexevs;k-Ras"/>
+        </owl:annotatedTarget>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#CancerPatient -->
+
+    <owl:Class rdf:about="&owl2lexevs;CancerPatient">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="&owl2lexevs;SickPatient"/>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <owl:Class>
+                                <owl:intersectionOf rdf:parseType="Collection">
+                                    <owl:Restriction>
+                                        <owl:onProperty rdf:resource="&owl2lexevs;patient_has_finding"/>
+                                        <owl:someValuesFrom rdf:resource="&owl2lexevs;TumorBenign"/>
+                                    </owl:Restriction>
+                                    <owl:Restriction>
+                                        <owl:onProperty rdf:resource="&owl2lexevs;patient_has_prognosis"/>
+                                        <owl:someValuesFrom rdf:resource="&owl2lexevs;PrognosisGood"/>
+                                    </owl:Restriction>
+                                </owl:intersectionOf>
+                            </owl:Class>
+                            <owl:Class>
+                                <owl:intersectionOf rdf:parseType="Collection">
+                                    <owl:Restriction>
+                                        <owl:onProperty rdf:resource="&owl2lexevs;patient_has_finding"/>
+                                        <owl:someValuesFrom rdf:resource="&owl2lexevs;TumorMalignant"/>
+                                    </owl:Restriction>
+                                    <owl:Restriction>
+                                        <owl:onProperty rdf:resource="&owl2lexevs;patient_has_prognosis"/>
+                                        <owl:someValuesFrom rdf:resource="&owl2lexevs;PrognosisBad"/>
+                                    </owl:Restriction>
+                                </owl:intersectionOf>
+                            </owl:Class>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+    </owl:Class>
+    <owl:Axiom>
+        <note rdf:datatype="&xsd;string">test of annotation on role group subclass</note>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;CancerPatient"/>
+        <owl:annotatedProperty rdf:resource="&owl;equivalentClass"/>
+        <owl:annotatedTarget>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="&owl2lexevs;SickPatient"/>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <owl:Class>
+                                <owl:intersectionOf rdf:parseType="Collection">
+                                    <owl:Restriction>
+                                        <owl:onProperty rdf:resource="&owl2lexevs;patient_has_finding"/>
+                                        <owl:someValuesFrom rdf:resource="&owl2lexevs;TumorBenign"/>
+                                    </owl:Restriction>
+                                    <owl:Restriction>
+                                        <owl:onProperty rdf:resource="&owl2lexevs;patient_has_prognosis"/>
+                                        <owl:someValuesFrom rdf:resource="&owl2lexevs;PrognosisGood"/>
+                                    </owl:Restriction>
+                                </owl:intersectionOf>
+                            </owl:Class>
+                            <owl:Class>
+                                <owl:intersectionOf rdf:parseType="Collection">
+                                    <owl:Restriction>
+                                        <owl:onProperty rdf:resource="&owl2lexevs;patient_has_finding"/>
+                                        <owl:someValuesFrom rdf:resource="&owl2lexevs;TumorMalignant"/>
+                                    </owl:Restriction>
+                                    <owl:Restriction>
+                                        <owl:onProperty rdf:resource="&owl2lexevs;patient_has_prognosis"/>
+                                        <owl:someValuesFrom rdf:resource="&owl2lexevs;PrognosisBad"/>
+                                    </owl:Restriction>
+                                </owl:intersectionOf>
+                            </owl:Class>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:annotatedTarget>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Cold -->
+
+    <owl:Class rdf:about="&owl2lexevs;Cold">
+        <rdfs:subClassOf rdf:resource="&owl2lexevs;Disease"/>
+    </owl:Class>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Disease -->
+
+    <owl:Class rdf:about="&owl2lexevs;Disease">
+        <rdfs:subClassOf rdf:resource="&owl2lexevs;DiseasesDisordersFindings"/>
+        <term>disease</term>
+        <definition>any entity that impacts the health of a patient.</definition>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedTarget>disease</owl:annotatedTarget>
+        <term_type>pt</term_type>
+        <source>nci</source>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;Disease"/>
+        <owl:annotatedProperty rdf:resource="&owl2lexevs;term"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <definition rdf:datatype="&xsd;string">One of the three entities in the parent covering partition.</definition>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;Disease"/>
+        <owl:annotatedTarget rdf:resource="&owl2lexevs;DiseasesDisordersFindings"/>
+        <owl:annotatedProperty rdf:resource="&rdfs;subClassOf"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedTarget>any entity that impacts the health of a patient.</owl:annotatedTarget>
+        <source>nih</source>
+        <provenance>joe blow via lily librarian</provenance>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;Disease"/>
+        <owl:annotatedProperty rdf:resource="&owl2lexevs;definition"/>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#DiseasesDisordersFindings -->
+
+    <owl:Class rdf:about="&owl2lexevs;DiseasesDisordersFindings">
+        <owl:disjointWith rdf:resource="&owl2lexevs;Person"/>
+        <definition>any entitie categorized as a disease, a disorder, or a finding.</definition>
+        <term>diseases, disorders, and findings</term>
+    </owl:Class>
+    <owl:Axiom>
+        <source>ctep</source>
+        <owl:annotatedTarget>any entitie categorized as a disease, a disorder, or a finding.</owl:annotatedTarget>
+        <provenance>pers. comm.</provenance>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;DiseasesDisordersFindings"/>
+        <owl:annotatedProperty rdf:resource="&owl2lexevs;definition"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <source>nci</source>
+        <owl:annotatedTarget>diseases, disorders, and findings</owl:annotatedTarget>
+        <term_type>sy</term_type>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;DiseasesDisordersFindings"/>
+        <owl:annotatedProperty rdf:resource="&owl2lexevs;term"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <note>treat disorders as always disjoint with people.</note>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;DiseasesDisordersFindings"/>
+        <owl:annotatedTarget rdf:resource="&owl2lexevs;Person"/>
+        <owl:annotatedProperty rdf:resource="&owl;disjointWith"/>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#EpithelialCell -->
+
+    <owl:Class rdf:about="&owl2lexevs;EpithelialCell">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL_0000000"/>
+        <term>epithelial cell</term>
+        <definition>a cell located in an epithelial surface.</definition>
+    </owl:Class>
+    <owl:Axiom>
+        <source rdf:datatype="&xsd;string">caDSR</source>
+        <term_type>pt</term_type>
+        <owl:annotatedTarget>epithelial cell</owl:annotatedTarget>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;EpithelialCell"/>
+        <owl:annotatedProperty rdf:resource="&owl2lexevs;term"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <definition rdf:datatype="&xsd;string">an isa relation to an external entity.</definition>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;EpithelialCell"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/CL_0000000"/>
+        <owl:annotatedProperty rdf:resource="&rdfs;subClassOf"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <provenance rdf:datatype="&xsd;string">NLM</provenance>
+        <source>nci</source>
+        <owl:annotatedTarget>a cell located in an epithelial surface.</owl:annotatedTarget>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;EpithelialCell"/>
+        <owl:annotatedProperty rdf:resource="&owl2lexevs;definition"/>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Erbb2 -->
+
+    <owl:Class rdf:about="&owl2lexevs;Erbb2">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="&owl2lexevs;C123"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="&owl2lexevs;gene_expressed_in"/>
+                        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CL_0000148"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+    </owl:Class>
+    <owl:Axiom>
+        <note rdf:datatype="&xsd;string">test of annotation on object restriction subclass to external class</note>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;Erbb2"/>
+        <owl:annotatedProperty rdf:resource="&owl;equivalentClass"/>
+        <owl:annotatedTarget>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="&owl2lexevs;C123"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="&owl2lexevs;gene_expressed_in"/>
+                        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CL_0000148"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:annotatedTarget>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Finding -->
+
+    <owl:Class rdf:about="&owl2lexevs;Finding">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="&owl2lexevs;DiseasesDisordersFindings"/>
+                    <owl:Class>
+                        <owl:oneOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="&owl2lexevs;Fever"/>
+                            <rdf:Description rdf:about="&owl2lexevs;ShallowBreathing"/>
+                            <rdf:Description rdf:about="&owl2lexevs;PaleSkin"/>
+                        </owl:oneOf>
+                    </owl:Class>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <semanticType rdf:datatype="&xsd;string">Disease</semanticType>
+    </owl:Class>
+    <owl:Axiom>
+        <definition rdf:datatype="&xsd;string">One of the three entities in the parent covering partition.</definition>
+        <note rdf:datatype="&xsd;string">the extension of the class</note>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;Finding"/>
+        <owl:annotatedProperty rdf:resource="&owl;equivalentClass"/>
+        <owl:annotatedTarget>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="&owl2lexevs;DiseasesDisordersFindings"/>
+                    <owl:Class>
+                        <owl:oneOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="&owl2lexevs;Fever"/>
+                            <rdf:Description rdf:about="&owl2lexevs;ShallowBreathing"/>
+                            <rdf:Description rdf:about="&owl2lexevs;PaleSkin"/>
+                        </owl:oneOf>
+                    </owl:Class>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:annotatedTarget>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientDrivingAround -->
+
+    <owl:Class rdf:about="&owl2lexevs;HappyPatientDrivingAround">
+        <rdfs:subClassOf rdf:resource="&owl2lexevs;Patient"/>
+        <AssociationURIAsResource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood"/>
+        <InvalidAssociationURIAsResource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood"/>
+        <AssociationURI rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood"/>
+        <AssociationSTR rdf:datatype="&xsd;string">http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood</AssociationSTR>
+        <AssociationLIT>http://ncicb.nci.nih.gov/xml/owl/evs/owl2lexevs.owl#PrognosisGood</AssociationLIT>
+        <AssociationV1 rdf:resource="&owl2lexevs;PrognosisGood"/>
+        <AssociationURI rdf:resource="&owl2lexevs;PrognosisGood"/>
+    </owl:Class>
+    <owl:Axiom>
+        <note rdf:datatype="&xsd;string">annotation on an AssociationLIT.</note>
+        <owl:annotatedTarget>http://ncicb.nci.nih.gov/xml/owl/evs/owl2lexevs.owl#PrognosisGood</owl:annotatedTarget>
+        <owl:annotatedProperty rdf:resource="&owl2lexevs;AssociationLIT"/>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;HappyPatientDrivingAround"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <note rdf:datatype="&xsd;string">annotation on an AssociationURI of a class (rdf:resource).</note>
+        <owl:annotatedProperty rdf:resource="&owl2lexevs;AssociationURI"/>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;HappyPatientDrivingAround"/>
+        <owl:annotatedTarget rdf:resource="&owl2lexevs;PrognosisGood"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <note rdf:datatype="&xsd;string">annotation on an AssociationSTR.</note>
+        <owl:annotatedTarget rdf:datatype="&xsd;string">http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood</owl:annotatedTarget>
+        <owl:annotatedProperty rdf:resource="&owl2lexevs;AssociationSTR"/>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;HappyPatientDrivingAround"/>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientWalkingAround -->
+
+    <owl:Class rdf:about="&owl2lexevs;HappyPatientWalkingAround">
+        <rdfs:subClassOf rdf:resource="&owl2lexevs;Patient"/>
+        <AssociationURI rdf:datatype="&xsd;anyURI">http://purl.obolibrary.org/obo/CL_0000148</AssociationURI>
+        <AssociationSTR rdf:datatype="&xsd;string">http://purl.obolibrary.org/obo/CL_0000148</AssociationSTR>
+        <AssociationLIT>http://purl.obolibrary.org/obo/cl_0000148</AssociationLIT>
+        <AssociationURI rdf:resource="http://purl.obolibrary.org/obo/CL_0000148"/>
+        <AssociationV1 rdf:resource="http://purl.obolibrary.org/obo/CL_0000148"/>
+    </owl:Class>
+    <owl:Axiom>
+        <note rdf:datatype="&xsd;string">annotation on an AssociationURI of external class (rdf:resource)</note>
+        <owl:annotatedProperty rdf:resource="&owl2lexevs;AssociationURI"/>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;HappyPatientWalkingAround"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/CL_0000148"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <note rdf:datatype="&xsd;string">annotation on an AssociationURI of external.</note>
+        <owl:annotatedTarget rdf:datatype="&xsd;anyURI">http://purl.obolibrary.org/obo/CL_0000148</owl:annotatedTarget>
+        <owl:annotatedProperty rdf:resource="&owl2lexevs;AssociationURI"/>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;HappyPatientWalkingAround"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <note rdf:datatype="&xsd;string">annotation on an AssociationSTR of external.</note>
+        <owl:annotatedTarget rdf:datatype="&xsd;string">http://purl.obolibrary.org/obo/CL_0000148</owl:annotatedTarget>
+        <owl:annotatedProperty rdf:resource="&owl2lexevs;AssociationSTR"/>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;HappyPatientWalkingAround"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <note rdf:datatype="&xsd;string">annotation on an AssociationLIT of external.</note>
+        <owl:annotatedTarget>http://purl.obolibrary.org/obo/cl_0000148</owl:annotatedTarget>
+        <owl:annotatedProperty rdf:resource="&owl2lexevs;AssociationLIT"/>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;HappyPatientWalkingAround"/>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HealthyPatient -->
+
+    <owl:Class rdf:about="&owl2lexevs;HealthyPatient">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="&owl2lexevs;Patient"/>
+                    <owl:Class>
+                        <owl:complementOf rdf:resource="&owl2lexevs;SickPatient"/>
+                    </owl:Class>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+    </owl:Class>
+    <owl:Axiom>
+        <note rdf:datatype="&xsd;string">definitely you are healthy if you are not sick.</note>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;HealthyPatient"/>
+        <owl:annotatedProperty rdf:resource="&owl;equivalentClass"/>
+        <owl:annotatedTarget>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="&owl2lexevs;Patient"/>
+                    <owl:Class>
+                        <owl:complementOf rdf:resource="&owl2lexevs;SickPatient"/>
+                    </owl:Class>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:annotatedTarget>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Mefv -->
+
+    <owl:Class rdf:about="&owl2lexevs;Mefv">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="&owl2lexevs;C123"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="&owl2lexevs;gene_related_to_disease"/>
+                        <owl:hasValue rdf:resource="&owl2lexevs;Fever"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+    </owl:Class>
+    <owl:Axiom>
+        <note rdf:datatype="&xsd;string">test of annotation on object restriction value subclass</note>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;Mefv"/>
+        <owl:annotatedProperty rdf:resource="&owl;equivalentClass"/>
+        <owl:annotatedTarget>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="&owl2lexevs;C123"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="&owl2lexevs;gene_related_to_disease"/>
+                        <owl:hasValue rdf:resource="&owl2lexevs;Fever"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:annotatedTarget>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#MildlySickCancerPatient -->
+
+    <owl:Class rdf:about="&owl2lexevs;MildlySickCancerPatient">
+        <P108>slightly sick cancer patient</P108>
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="&owl2lexevs;MildlySickPatient"/>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="&owl2lexevs;patient_has_finding"/>
+                                <owl:someValuesFrom rdf:resource="&owl2lexevs;TumorBenign"/>
+                            </owl:Restriction>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="&owl2lexevs;patient_has_prognosis"/>
+                                <owl:someValuesFrom rdf:resource="&owl2lexevs;PrognosisGood"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+    </owl:Class>
+    <owl:Axiom>
+        <note rdf:datatype="&xsd;string">test of annotation on intersection of object restriction subclass</note>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;MildlySickCancerPatient"/>
+        <owl:annotatedProperty rdf:resource="&owl;equivalentClass"/>
+        <owl:annotatedTarget>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="&owl2lexevs;MildlySickPatient"/>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="&owl2lexevs;patient_has_finding"/>
+                                <owl:someValuesFrom rdf:resource="&owl2lexevs;TumorBenign"/>
+                            </owl:Restriction>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="&owl2lexevs;patient_has_prognosis"/>
+                                <owl:someValuesFrom rdf:resource="&owl2lexevs;PrognosisGood"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:annotatedTarget>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#MildlySickPatient -->
+
+    <owl:Class rdf:about="&owl2lexevs;MildlySickPatient">
+        <rdfs:subClassOf rdf:resource="&owl2lexevs;SickPatient"/>
+    </owl:Class>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#NeoplasticDisease -->
+
+    <owl:Class rdf:about="&owl2lexevs;NeoplasticDisease">
+        <rdfs:subClassOf rdf:resource="&owl2lexevs;Disease"/>
+        <semanticType rdf:datatype="&xsd;string">Disease</semanticType>
+    </owl:Class>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#OncogeneTim -->
+
+    <owl:Class rdf:about="&owl2lexevs;OncogeneTim">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="&owl2lexevs;C123"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="&owl2lexevs;has_physical_location"/>
+                        <owl:hasValue rdf:datatype="&xsd;integer">12345</owl:hasValue>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+    </owl:Class>
+    <owl:Axiom>
+        <note rdf:datatype="&xsd;string">test of annotation on datatype restriction value subclass</note>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;OncogeneTim"/>
+        <owl:annotatedProperty rdf:resource="&owl;equivalentClass"/>
+        <owl:annotatedTarget>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="&owl2lexevs;C123"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="&owl2lexevs;has_physical_location"/>
+                        <owl:hasValue rdf:datatype="&xsd;integer">12345</owl:hasValue>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:annotatedTarget>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Patient -->
+
+    <owl:Class rdf:about="&owl2lexevs;Patient">
+        <rdfs:subClassOf rdf:resource="&owl2lexevs;Person"/>
+        <semanticType rdf:datatype="&xsd;string">Organism</semanticType>
+    </owl:Class>
+    <owl:Axiom>
+        <definition rdf:datatype="&xsd;string">a role taken by a person on a health care provider visit.</definition>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;Patient"/>
+        <owl:annotatedTarget rdf:resource="&owl2lexevs;Person"/>
+        <owl:annotatedProperty rdf:resource="&rdfs;subClassOf"/>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PatientWithCold -->
+
+    <owl:Class rdf:about="&owl2lexevs;PatientWithCold">
+        <rdfs:subClassOf rdf:resource="&owl2lexevs;MildlySickPatient"/>
+        <P108>Patient With Cold</P108>
+        <P90>slightly sick patient</P90>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="&owl2lexevs;patient_has_finding"/>
+                <owl:someValuesFrom rdf:resource="&owl2lexevs;Cold"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+    </owl:Class>   
+    <owl:Axiom>
+        <source rdf:datatype="&xsd;string">CDISC</source>
+        <term_type rdf:datatype="&xsd;string">PT</term_type>
+        <owl:annotatedTarget rdf:datatype="&xsd;string">slightly sick patient</owl:annotatedTarget>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;PatientWithCold"/>
+        <owl:annotatedProperty rdf:resource="&owl2lexevs;term"/>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Person -->
+
+    <owl:Class rdf:about="&owl2lexevs;Person">
+        <definition rdf:datatype="&xsd;string">Any human being.</definition>
+        <term rdf:datatype="&xsd;string">Human</term>
+        <term rdf:datatype="&xsd;string">Person</term>
+    </owl:Class>
+    <owl:Axiom>
+        <source rdf:datatype="&xsd;string">NCI</source>
+        <term_type rdf:datatype="&xsd;string">PT</term_type>
+        <owl:annotatedTarget rdf:datatype="&xsd;string">Person</owl:annotatedTarget>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;Person"/>
+        <owl:annotatedProperty rdf:resource="&owl2lexevs;term"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedTarget rdf:datatype="&xsd;string">Any human being.</owl:annotatedTarget>
+        <source rdf:datatype="&xsd;string">common knowledge</source>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;Person"/>
+        <owl:annotatedProperty rdf:resource="&owl2lexevs;definition"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedTarget rdf:datatype="&xsd;string">Human</owl:annotatedTarget>
+        <source rdf:datatype="&xsd;string">LOC</source>
+        <term_type rdf:datatype="&xsd;string">SY</term_type>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;Person"/>
+        <owl:annotatedProperty rdf:resource="&owl2lexevs;term"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <note>treat disorders as always disjoint with people.</note>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;DiseasesDisordersFindings"/>
+        <owl:annotatedTarget rdf:resource="&owl2lexevs;Person"/>
+        <owl:annotatedProperty rdf:resource="&owl;disjointWith"/>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PersonRole -->
+
+    <owl:Class rdf:about="&owl2lexevs;PersonRole">
+        <definition rdf:datatype="&xsd;string">Any role adopted by a person.</definition>
+        <term rdf:datatype="&xsd;string">Personal Role</term>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedTarget rdf:datatype="&xsd;string">Any role adopted by a person.</owl:annotatedTarget>
+        <provenance rdf:datatype="&xsd;string">JQ Public</provenance>
+        <source rdf:datatype="&xsd;string">ONC</source>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;PersonRole"/>
+        <owl:annotatedProperty rdf:resource="&owl2lexevs;definition"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <source rdf:datatype="&xsd;string">NCI</source>
+        <owl:annotatedTarget rdf:datatype="&xsd;string">Personal Role</owl:annotatedTarget>
+        <term_type rdf:datatype="&xsd;string">SY</term_type>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;PersonRole"/>
+        <owl:annotatedProperty rdf:resource="&owl2lexevs;term"/>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Prognosis -->
+
+    <owl:Class rdf:about="&owl2lexevs;Prognosis">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="&owl2lexevs;DiseasesDisordersFindings"/>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="&owl2lexevs;PrognosisBad"/>
+                            <rdf:Description rdf:about="&owl2lexevs;PrognosisGood"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <semanticType rdf:datatype="&xsd;string">Disease</semanticType>
+    </owl:Class>
+    <owl:Axiom>
+        <definition rdf:datatype="&xsd;string">One of the three entities in the parent covering partition.</definition>
+        <note rdf:datatype="&xsd;string">essentially the sum of subclasses</note>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;Prognosis"/>
+        <owl:annotatedProperty rdf:resource="&owl;equivalentClass"/>
+        <owl:annotatedTarget>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="&owl2lexevs;DiseasesDisordersFindings"/>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="&owl2lexevs;PrognosisBad"/>
+                            <rdf:Description rdf:about="&owl2lexevs;PrognosisGood"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:annotatedTarget>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisBad -->
+
+    <owl:Class rdf:about="&owl2lexevs;PrognosisBad">
+        <rdfs:subClassOf rdf:resource="&owl2lexevs;Prognosis"/>
+    </owl:Class>
+    <owl:Axiom>
+        <definition rdf:datatype="&xsd;string">One of the two entities in the parent undeclared covering partition.</definition>
+        <owl:annotatedTarget rdf:resource="&owl2lexevs;Prognosis"/>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;PrognosisBad"/>
+        <owl:annotatedProperty rdf:resource="&rdfs;subClassOf"/>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood -->
+
+    <owl:Class rdf:about="&owl2lexevs;PrognosisGood">
+        <rdfs:subClassOf rdf:resource="&owl2lexevs;Prognosis"/>
+    </owl:Class>
+    <owl:Axiom>
+        <definition rdf:datatype="&xsd;string">One of the two entities in the parent undeclared covering partition.</definition>
+        <owl:annotatedTarget rdf:resource="&owl2lexevs;Prognosis"/>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;PrognosisGood"/>
+        <owl:annotatedProperty rdf:resource="&rdfs;subClassOf"/>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Ras -->
+
+    <owl:Class rdf:about="&owl2lexevs;Ras">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="&owl2lexevs;C123"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="&owl2lexevs;has_physical_location"/>
+                        <owl:someValuesFrom rdf:resource="&xsd;positiveInteger"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+    </owl:Class>
+    <owl:Axiom>
+        <note rdf:datatype="&xsd;string">test of annotation on datatype restriction subclass</note>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;Ras"/>
+        <owl:annotatedProperty rdf:resource="&owl;equivalentClass"/>
+        <owl:annotatedTarget>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="&owl2lexevs;C123"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="&owl2lexevs;has_physical_location"/>
+                        <owl:someValuesFrom rdf:resource="&xsd;positiveInteger"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:annotatedTarget>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SHH -->
+
+    <owl:Class rdf:about="&owl2lexevs;SHH">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="&owl2lexevs;C123"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="&owl2lexevs;gene_related_to_disease"/>
+                        <owl:allValuesFrom rdf:resource="&owl2lexevs;NeoplasticDisease"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+    </owl:Class>
+    <owl:Axiom>
+        <note rdf:datatype="&xsd;string">test of annotation on object restriction subclass</note>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;SHH"/>
+        <owl:annotatedProperty rdf:resource="&owl;equivalentClass"/>
+        <owl:annotatedTarget>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="&owl2lexevs;C123"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="&owl2lexevs;gene_related_to_disease"/>
+                        <owl:allValuesFrom rdf:resource="&owl2lexevs;NeoplasticDisease"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:annotatedTarget>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SOS -->
+
+    <owl:Class rdf:about="&owl2lexevs;SOS">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="&owl2lexevs;C123"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="&owl2lexevs;gene_related_to_disease"/>
+                        <owl:someValuesFrom rdf:resource="&owl2lexevs;NeoplasticDisease"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+    </owl:Class>
+    <owl:Axiom>
+        <note rdf:datatype="&xsd;string">test of annotation on object restriction subclass</note>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;SOS"/>
+        <owl:annotatedProperty rdf:resource="&owl;equivalentClass"/>
+        <owl:annotatedTarget>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="&owl2lexevs;C123"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="&owl2lexevs;gene_related_to_disease"/>
+                        <owl:someValuesFrom rdf:resource="&owl2lexevs;NeoplasticDisease"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:annotatedTarget>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SickPatient -->
+
+    <owl:Class rdf:about="&owl2lexevs;SickPatient">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="&owl2lexevs;Patient"/>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="&owl2lexevs;CancerPatient"/>
+                            <rdf:Description rdf:about="&owl2lexevs;MildlySickPatient"/>
+                            <rdf:Description rdf:about="&owl2lexevs;VerySickPatient"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+    </owl:Class>
+    <owl:Axiom>
+        <note rdf:datatype="&xsd;string">essentially the sum of subclasses</note>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;SickPatient"/>
+        <owl:annotatedProperty rdf:resource="&owl;equivalentClass"/>
+        <owl:annotatedTarget>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="&owl2lexevs;Patient"/>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="&owl2lexevs;CancerPatient"/>
+                            <rdf:Description rdf:about="&owl2lexevs;MildlySickPatient"/>
+                            <rdf:Description rdf:about="&owl2lexevs;VerySickPatient"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:annotatedTarget>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#TotalPerson -->
+
+    <owl:Class rdf:about="&owl2lexevs;TotalPerson">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="&owl2lexevs;Person"/>
+                    <rdf:Description rdf:about="&owl2lexevs;PersonRole"/>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+    </owl:Class>
+    <owl:Axiom>
+        <note rdf:datatype="&xsd;string">in real life, probably a union.</note>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;TotalPerson"/>
+        <owl:annotatedProperty rdf:resource="&owl;equivalentClass"/>
+        <owl:annotatedTarget>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="&owl2lexevs;Person"/>
+                    <rdf:Description rdf:about="&owl2lexevs;PersonRole"/>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:annotatedTarget>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#TumorBenign -->
+
+    <owl:Class rdf:about="&owl2lexevs;TumorBenign">
+        <rdfs:subClassOf rdf:resource="&owl2lexevs;NeoplasticDisease"/>
+    </owl:Class>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#TumorMalignant -->
+
+    <owl:Class rdf:about="&owl2lexevs;TumorMalignant">
+        <rdfs:subClassOf rdf:resource="&owl2lexevs;NeoplasticDisease"/>
+    </owl:Class>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#VerySickCancerPatient -->
+
+    <owl:Class rdf:about="&owl2lexevs;VerySickCancerPatient">
+    		<P108>very sick cancer patient</P108>
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="&owl2lexevs;VerySickPatient"/>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="&owl2lexevs;patient_has_finding"/>
+                                <owl:someValuesFrom rdf:resource="&owl2lexevs;TumorMalignant"/>
+                            </owl:Restriction>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="&owl2lexevs;patient_has_prognosis"/>
+                                <owl:someValuesFrom rdf:resource="&owl2lexevs;PrognosisBad"/>
+                            </owl:Restriction>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+    </owl:Class>
+    <owl:Axiom>
+        <source rdf:datatype="&xsd;string">NCI</source>
+        <term_type rdf:datatype="&xsd;string">PT</term_type>
+        <owl:annotatedTarget rdf:datatype="&xsd;string">very sick cancer patient</owl:annotatedTarget>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;VerySickCancerPatient"/>
+        <owl:annotatedProperty rdf:resource="&owl2lexevs;term"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <note rdf:datatype="&xsd;string">test of annotation on union of object restriction subclass</note>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;VerySickCancerPatient"/>
+        <owl:annotatedProperty rdf:resource="&owl;equivalentClass"/>
+        <owl:annotatedTarget>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="&owl2lexevs;VerySickPatient"/>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="&owl2lexevs;patient_has_finding"/>
+                                <owl:someValuesFrom rdf:resource="&owl2lexevs;TumorMalignant"/>
+                            </owl:Restriction>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="&owl2lexevs;patient_has_prognosis"/>
+                                <owl:someValuesFrom rdf:resource="&owl2lexevs;PrognosisBad"/>
+                            </owl:Restriction>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:annotatedTarget>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#VerySickPatient -->
+
+    <owl:Class rdf:about="&owl2lexevs;VerySickPatient">
+        <rdfs:subClassOf rdf:resource="&owl2lexevs;SickPatient"/>
+    </owl:Class>
+    <owl:Axiom>
+        <source rdf:datatype="&xsd;string">NCI</source>
+        <term_type rdf:datatype="&xsd;string">PT</term_type>
+        <owl:annotatedTarget rdf:datatype="&xsd;string">very sick patient</owl:annotatedTarget>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;VerySickPatient"/>
+        <owl:annotatedProperty rdf:resource="&owl2lexevs;term"/>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#actin -->
+
+    <owl:Class rdf:about="&owl2lexevs;actin">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="&owl2lexevs;C123"/>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="&owl2lexevs;gene_expressed_in"/>
+                                <owl:someValuesFrom rdf:resource="&owl2lexevs;EpithelialCell"/>
+                            </owl:Restriction>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="&owl2lexevs;in_organism"/>
+                                <owl:hasValue>all organisms</owl:hasValue>
+                            </owl:Restriction>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+    </owl:Class>
+    <owl:Axiom>
+        <note rdf:datatype="&xsd;string">test of annotation on union of datatype and object restriction subclass</note>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;actin"/>
+        <owl:annotatedProperty rdf:resource="&owl;equivalentClass"/>
+        <owl:annotatedTarget>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="&owl2lexevs;C123"/>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="&owl2lexevs;gene_expressed_in"/>
+                                <owl:someValuesFrom rdf:resource="&owl2lexevs;EpithelialCell"/>
+                            </owl:Restriction>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="&owl2lexevs;in_organism"/>
+                                <owl:hasValue>all organisms</owl:hasValue>
+                            </owl:Restriction>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:annotatedTarget>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#k-Ras -->
+
+    <owl:Class rdf:about="&owl2lexevs;k-Ras">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="&owl2lexevs;C123"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="&owl2lexevs;has_physical_location"/>
+                        <owl:allValuesFrom rdf:resource="&xsd;positiveInteger"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+    </owl:Class>
+    <owl:Axiom>
+        <note rdf:datatype="&xsd;string">test of annotation on datatype restriction subclass</note>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;k-Ras"/>
+        <owl:annotatedProperty rdf:resource="&owl;equivalentClass"/>
+        <owl:annotatedTarget>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="&owl2lexevs;C123"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="&owl2lexevs;has_physical_location"/>
+                        <owl:allValuesFrom rdf:resource="&xsd;positiveInteger"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:annotatedTarget>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CL_0000000 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_0000000">
+        <rdfs:label>Cell</rdfs:label>
+        <definition>external class from the cl.</definition>
+    </owl:Class>
+    <owl:Axiom>
+        <source>cl</source>
+        <provenance>lily librarian</provenance>
+        <owl:annotatedTarget>external class from the cl.</owl:annotatedTarget>
+        <owl:annotatedProperty rdf:resource="&owl2lexevs;definition"/>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_0000000"/>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CL_0000148 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_0000148">
+        <rdfs:label>melanocyte</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL_0000000"/>
+    </owl:Class>
+    
+        <!-- http://www.w3.org/2002/07/owl#Nothing -->
+
+    <owl:Class rdf:about="http://www.w3.org/2002/07/owl#Nothing">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Nothing"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.w3.org/2002/07/owl#Thing -->
+
+    <owl:Class rdf:about="http://www.w3.org/2002/07/owl#Thing"/>
+    
+
+    <!-- http://purl.obolibrary.org/obo/BFO_0000182 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000182"><!-- history -->
+        <rdfs:label xml:lang="en">history</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000015"/><!-- process -->
+        <obo:BFO_0000179>history</obo:BFO_0000179>
+        <obo:BFO_0000180>History</obo:BFO_0000180>
+        <obo:IAO_0000600 xml:lang="en">A history is a process that is the sum of the totality of processes taking place in the spatiotemporal region occupied by a material entity or site, including processes on the surface of the entity or within the cavities to which it serves as host. (axiom label in BFO2 Reference: [138-001])</obo:IAO_0000600>
+        <obo:IAO_0000111 xml:lang="en">history</obo:IAO_0000111>
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/bfo.owl"/>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedTarget xml:lang="en">A history is a process. (axiom label in BFO2 Reference: [138-001])</owl:annotatedTarget>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000182"/><!-- history -->
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000600"/><!-- elucidation -->
+        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/138-001"/>
+    </owl:Axiom>
+    
+    <!-- http://purl.obolibrary.org/obo/OBI_0100061 -->                                                                                                                                                                                                                                                                                                                                                          
+                                                                                                                                                                                                                                                                                                                                                                                                             
+    <!-- http://purl.obolibrary.org/obo/OBI_0100061 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0100061"><!-- primary cultured cell population -->
+        <rdfs:label xml:lang="en">primary cultured cell population</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0100060"/><!-- cultured cell population -->
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000643"/><!-- has grain -->
+                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CL_0000001"/><!-- primary cultured cell -->
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000643"/><!-- has grain -->
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CL_0000001"/><!-- primary cultured cell -->
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000312"/><!-- is_specified_output_of -->
+                <owl:onClass rdf:resource="http://purl.obolibrary.org/obo/OBI_0600037"/><!-- cell culture splitting -->
+                <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">0</owl:qualifiedCardinality>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A cultured cell population comprised of cells expanded directly from living tissue prior to being passaged.
+
+</obo:IAO_0000115>
+        <obo:IAO_0000119 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PERSON:Matthew Brush</obo:IAO_0000119>
+        <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PERSON:Matthew Brush</obo:IAO_0000117>
+        <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Spleen cells put directly into culture;  Cold storage of biopsies from wild endangered native Chilean species in field conditions and subsequent isolation of primary culture cell lines. In Vitro Cell Dev Biol Anim. 2008 Jul 2. PMID: 18594934</obo:IAO_0000112>
+        <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cells that have been isolated from some organismal source, expanded in culture, but not undergone a complete passaging (ie are still in culture, or have been lifted from culture and frozen in aliquots for future use)</obo:IAO_0000112>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">primary cell culture</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">primary cell culture sample</obo:IAO_0000118>
+        <obo:IAO_0000116>2013-6-5 MHB: This OBI class was formerly called 'primary cell culture', but label changed and definition updated following CLO alignment work.  Previous definition: 'a primary cell culture is a cell culture where the cells derive from a fresh tissue source.'</obo:IAO_0000116>
+        <obo:IAO_0000111 xml:lang="en">primary cultured cell population</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/><!-- metadata complete -->
+    </owl:Class>
+    <owl:Axiom>
+        <obo:IAO_0000116>consider if we really want to be so strict here . . . ie maybe we we say that they have not been output from an 'establishing cell line' process, but in some cases a passage or two may be allowed for a primary culture.  the establishing of a line requires some  procedss that attains a degree of homogeneity in the culture.</obo:IAO_0000116>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/OBI_0100061"/><!-- primary cultured cell population -->
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
+        <owl:annotatedTarget>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000312"/><!-- is_specified_output_of -->
+                <owl:onClass rdf:resource="http://purl.obolibrary.org/obo/OBI_0600037"/><!-- cell culture splitting -->
+                <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">0</owl:qualifiedCardinality>
+            </owl:Restriction>
+        </owl:annotatedTarget>
+    </owl:Axiom>                                                                                                                                                                                                                                                                                    
+                                                                                                                                                                                                                                                                                                              
+      <!-- http://purl.obolibrary.org/obo/CL_0000001 -->                                                                                                                                                                                                                                                                                                                    
+                                                                                                                                                                                                                                                                                                                                                                       
+ <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_0000001"><!-- primary cultured cell -->                                                                                                                                                                                                                                                                       
+     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">primary cultured cell</rdfs:label>                                                                                                                                                                                                                                                             
+     <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL_0000010"/><!-- cultured cell -->                                                                                                                                                                                                                                                                 
+     <rdfs:subClassOf>                                                                                                                                                                                                                                                                                                                                                 
+         <owl:Class>                                                                                                                                                                                                                                                                                                                                                   
+             <owl:complementOf>                                                                                                                                                                                                                                                                                                                                        
+                 <owl:Restriction>                                                                                                                                                                                                                                                                                                                                     
+                     <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000312"/><!-- is_specified_output_of -->                                                                                                                                                                                                                                        
+                     <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0600037"/><!-- cell culture splitting -->                                                                                                                                                                                                                                    
+                 </owl:Restriction>                                                                                                                                                                                                                                                                                                                                    
+             </owl:complementOf>                                                                                                                                                                                                                                                                                                                                       
+         </owl:Class>                                                                                                                                                                                                                                                                                                                                                  
+     </rdfs:subClassOf>                                                                                                                                                                                                                                                                                                                                                
+     <rdfs:subClassOf>                                                                                                                                                                                                                                                                                                                                                 
+         <owl:Class>                                                                                                                                                                                                                                                                                                                                                   
+             <owl:complementOf>                                                                                                                                                                                                                                                                                                                                        
+                 <owl:Restriction>                                                                                                                                                                                                                                                                                                                                     
+                     <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001000"/><!-- derives from -->                                                                                                                                                                                                                                                   
+                     <owl:someValuesFrom>                                                                                                                                                                                                                                                                                                                              
+                         <owl:Class>                                                                                                                                                                                                                                                                                                                                   
+                             <owl:intersectionOf rdf:parseType="Collection">                                                                                                                                                                                                                                                                                           
+                                 <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CL_0000010"/><!-- cultured cell -->                                                                                                                                                                                                                                        
+                                 <owl:Restriction>                                                                                                                                                                                                                                                                                                                     
+                                     <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000312"/><!-- is_specified_output_of -->                                                                                                                                                                                                                        
+                                     <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0600037"/><!-- cell culture splitting -->                                                                                                                                                                                                                    
+                                 </owl:Restriction>                                                                                                                                                                                                                                                                                                                    
+                             </owl:intersectionOf>                                                                                                                                                                                                                                                                                                                     
+                         </owl:Class>                                                                                                                                                                                                                                                                                                                                  
+                     </owl:someValuesFrom>                                                                                                                                                                                                                                                                                                                             
+                 </owl:Restriction>                                                                                                                                                                                                                                                                                                                                    
+             </owl:complementOf>                                                                                                                                                                                                                                                                                                                                       
+         </owl:Class>                                                                                                                                                                                                                                                                                                                                                  
+     </rdfs:subClassOf>                                                                                                                                                                                                                                                                                                                                                
+     <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A cultured cell that is freshly isolated from a organismal source, or derives in culture from such a cell prior to the culture being passaged.</obo:IAO_0000115>                                                                                                                          
+     <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">primary cultured cell</obo:IAO_0000111>                                                                                                                                                                                                                                                   
+     <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/cl.owl"/>                                                                                                                                                                                                                                                                                           
+ </owl:Class>                                                                                                                                                                                                                                                                                                                                                          
+         
+
+      
+      
+          <!-- http://purl.obolibrary.org/obo/OBI_0100063 -->                                                                                                                                                                              
+                                                                                                                                                                                                                                     
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0100063"><!-- cultured clonal cell population -->                                                                                                                       
+        <rdfs:label xml:lang="en">cultured clonal cell population</rdfs:label>                                                                                                                                                       
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0100060"/><!-- cultured cell population -->                                                                                                                
+        <obo:IAO_0000119 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GROUP: OBI Biomaterial Branch</obo:IAO_0000119>                                                                                                      
+        <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PERSON: Susanna Sansone</obo:IAO_0000117>                                                                                                            
+        <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PERSON:Matthew Brush</obo:IAO_0000117>                                                                                                               
+        <obo:IAO_0000115 xml:lang="en">A cultured cell population comprised of cells which can all be traced back to a single ancestor cell, and which therefore can be treated as identical.</obo:IAO_0000115>                      
+        <obo:IAO_0000118>clonal cell culture sample</obo:IAO_0000118>                                                                                                                                                                
+        <obo:IAO_0000112 xml:lang="en">cell cut                                                                                                                                                                                      
+Stem cell functions assessed in clonal culture. Soc Gen Physiol Ser. 1988;43:39-45. Review. PMID: 3077557</obo:IAO_0000112>                                                                                                          
+        <obo:IAO_0000111 xml:lang="en">cultured clonal cell population</obo:IAO_0000111>                                                                                                                                             
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/><!-- metadata complete -->                                                                                                                       
+    </owl:Class>                                                                                                                                                                                                                     
+                                                                                                                                                                                                                                     
+    <!-- http://purl.obolibrary.org/obo/OBI_0100060 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0100060"><!-- cultured cell population -->
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cultured cell population</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0000047"/><!-- processed material -->
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000643"/><!-- has grain -->
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CL_0000010"/><!-- cultured cell -->
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000643"/><!-- has grain -->
+                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CL_0000010"/><!-- cultured cell -->
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000312"/><!-- is_specified_output_of -->
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0600024"/><!-- maintaining cell culture -->
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A processed material comprised of a collection of cultured cells that has been continuously maintained together in culture and shares a common propagation history.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PERSON:Matthew Brush</obo:IAO_0000117>
+        <obo:IAO_0000119 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PERSON:Matthew Brush</obo:IAO_0000119>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The extent of a 'cultured cell population' is restricted only in that all cell members must share a propagation history (ie be derived through a common lineage of passages from an initial culture). In being defined in this way, this class can be used to refer to the populations that researchers actually use in the practice of science - ie are the inputs to culturing, experimentation, and sharing. The cells in such populations will be a relatively uniform population as they have experienced similar selective pressures due to their continuous co-propagation. And this population will also have a single passage number, again owing to their common passaging history. Cultured cell populations represent only a collection of cells (ie do not include media, culture dishes, etc), and include populations of cultured unicellular organisms or cultured multicellular organism cells. They can exist under active culture, stored in a quiescent state for future use, or applied experimentally.</rdfs:comment>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cultured cell population</obo:IAO_0000111>
+        <obo:IAO_0000112>A cultured cell population applied in an experiment: "293 cells expressing TrkA were serum-starved for 18 hours and then neurotrophins were added for 10 min before cell harvest."  (Lee, Ramee, et al. "Regulation of cell survival by secreted proneurotrophins." Science 294.5548 (2001): 1945-1948).
+
+A cultured cell population maintained in vitro: "Rat cortical neurons from 15 day embryos are grown in dissociated cell culture and maintained in vitro for 8–12 weeks" (Dichter, Marc A. "Rat cortical neurons in cell culture: culture methods, cell morphology, electrophysiology, and synapse formation." Brain Research 149.2 (1978): 279-293).</obo:IAO_0000112>
+        <obo:IAO_0000118>cell culture sample</obo:IAO_0000118>
+        <obo:IAO_0000116 xml:lang="en">2013-6-5 MHB: This OBI class was formerly called 'cell culture', but label changed and definition updated following CLO alignment efforts in spring 2013, during which the intent of this class was clarified to refer to portions of a culture or line rather than a complete cell culture or line.</obo:IAO_0000116>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/><!-- metadata complete -->
+    </owl:Class>
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_15956 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_15956"><!-- biotin -->
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">biotin</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/REO_0000280"/><!-- molecular label -->
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/><!-- has role -->
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/REO_0000171"/><!-- molecular label role -->
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An organic heterobicyclic compound that consists of 2-oxohexahydro-1H-thieno[3,4-d]imidazole having a valeric acid substituent attached to the tetrahydrothiophene ring. The parent of the class of biotins.</obo:IAO_0000115>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">biotin</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
+    </owl:Class>
+
+        <!-- http://purl.obolibrary.org/obo/REO_0000171 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/REO_0000171"><!-- molecular label role -->
+        <rdfs:label xml:lang="en">molecular label role</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000023"/><!-- role -->
+        <obo:IAO_0000118>molecular tracer role</obo:IAO_0000118>
+        <obo:IAO_0000119>OBI developer call, 3-12-12</obo:IAO_0000119>
+        <obo:IAO_0000115>a reagent role inhering in a molecular entity intended to associate with some molecular target to serve as a proxy for the presence, abundance, or location of this target in a detection of molecular label assay.</obo:IAO_0000115>
+        <obo:IAO_0000116>MHB (9-29-13): 'molecular label role' imported from the Reagent Ontology and replaced OBI:OBI_0000140 (label role)</obo:IAO_0000116>
+        <obo:IAO_0000111 xml:lang="en">molecular label role</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/reo.owl"/>
+    </owl:Class>
+
+    <!-- http://purl.obolibrary.org/obo/BFO_0000001 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000001"><!-- entity -->
+        <rdfs:label xml:lang="en">entity</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <owl:disjointWith rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/><!-- Obsolete Class -->
+        <obo:IAO_0000600 xml:lang="en">An entity is anything that exists or has existed or will exist. (axiom label in BFO2 Reference: [001-001])</obo:IAO_0000600>
+        <obo:IAO_0000116 xml:lang="en">BFO 2 Reference: In all areas of empirical inquiry we encounter general terms of two sorts. First are general terms which refer to universals or types:animaltuberculosissurgical procedurediseaseSecond, are general terms used to refer to groups of entities which instantiate a given universal but do not correspond to the extension of any subuniversal of that universal because there is nothing intrinsic to the entities in question by virtue of which they – and only they – are counted as belonging to the given group. Examples are: animal purchased by the Emperortuberculosis diagnosed on a Wednesdaysurgical procedure performed on a patient from Stockholmperson identified as candidate for clinical trial #2056-555person who is signatory of Form 656-PPVpainting by Leonardo da VinciSuch terms, which represent what are called ‘specializations’ in [81</obo:IAO_0000116>
+        <obo:BFO_0000180>Entity</obo:BFO_0000180>
+        <obo:IAO_0000112 xml:lang="en">Verdi’s Requiem</obo:IAO_0000112>
+        <obo:BFO_0000179>entity</obo:BFO_0000179>
+        <obo:IAO_0000116 xml:lang="en">Entity doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. For example Werner Ceusters 'portions of reality' include 4 sorts, entities (as BFO construes them), universals, configurations, and relations. It is an open question as to whether entities as construed in BFO will at some point also include these other portions of reality. See, for example, 'How to track absolutely everything' at http://www.referent-tracking.com/_RTU/papers/CeustersICbookRevised.pdf</obo:IAO_0000116>
+        <obo:IAO_0000112 xml:lang="en">Julius Caesar</obo:IAO_0000112>
+        <obo:IAO_0000111 xml:lang="en">entity</obo:IAO_0000111>
+        <obo:IAO_0000112 xml:lang="en">the Second World War</obo:IAO_0000112>
+        <obo:IAO_0000112 xml:lang="en">your body mass index</obo:IAO_0000112>
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/bfo.owl"/>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedTarget xml:lang="en">An entity is anything that exists or has existed or will exist. (axiom label in BFO2 Reference: [001-001])</owl:annotatedTarget>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000001"/><!-- entity -->
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000600"/><!-- elucidation -->
+        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/001-001"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <rdfs:comment>per discussion with Barry Smith</rdfs:comment>
+        <owl:annotatedTarget xml:lang="en">Entity doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. For example Werner Ceusters 'portions of reality' include 4 sorts, entities (as BFO construes them), universals, configurations, and relations. It is an open question as to whether entities as construed in BFO will at some point also include these other portions of reality. See, for example, 'How to track absolutely everything' at http://www.referent-tracking.com/_RTU/papers/CeustersICbookRevised.pdf</owl:annotatedTarget>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000001"/><!-- entity -->
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000116"/><!-- editor note -->
+        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/0000004"/>
+        <rdfs:seeAlso rdf:resource="http://www.referent-tracking.com/_RTU/papers/CeustersICbookRevised.pdf"/>
+    </owl:Axiom>
+    
+
+
+
+        <!-- http://purl.obolibrary.org/obo/BFO_0000002 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000002"><!-- continuant -->
+        <rdfs:label xml:lang="en">continuant</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000001"/><!-- entity -->
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000003"/><!-- occurrent -->
+        <obo:IAO_0000602>(forall (x y) (if (and (Continuant x) (exists (t) (hasContinuantPartOfAt y x t))) (Continuant y))) // axiom label in BFO2 CLIF: [126-001] </obo:IAO_0000602>
+        <obo:IAO_0000115 xml:lang="en">An entity that exists in full at any time in which it exists at all, persists through time while maintaining its identity and has no temporal parts.</obo:IAO_0000115>
+        <obo:IAO_0000116 xml:lang="en">BFO 2 Reference: Continuant entities are entities which can be sliced to yield parts only along the spatial dimension, yielding for example the parts of your table which we call its legs, its top, its nails. ‘My desk stretches from the window to the door. It has spatial parts, and can be sliced (in space) in two. With respect to time, however, a thing is a continuant.’ [60, p. 240</obo:IAO_0000116>
+        <obo:IAO_0000116 xml:lang="en">Continuant doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. For example, in an expansion involving bringing in some of Ceuster's other portions of reality, questions are raised as to whether universals are continuants</obo:IAO_0000116>
+        <obo:BFO_0000179>continuant</obo:BFO_0000179>
+        <obo:BFO_0000180>Continuant</obo:BFO_0000180>
+        <obo:IAO_0000602>(forall (x y) (if (and (Continuant x) (exists (t) (continuantPartOfAt y x t))) (Continuant y))) // axiom label in BFO2 CLIF: [009-002] </obo:IAO_0000602>
+        <obo:IAO_0000602>(forall (x) (if (Continuant x) (Entity x))) // axiom label in BFO2 CLIF: [008-002] </obo:IAO_0000602>
+        <obo:IAO_0000602>(forall (x) (if (Material Entity x) (exists (t) (and (TemporalRegion t) (existsAt x t))))) // axiom label in BFO2 CLIF: [011-002] </obo:IAO_0000602>
+        <obo:IAO_0000600 xml:lang="en">A continuant is an entity that persists, endures, or continues to exist through time while maintaining its identity. (axiom label in BFO2 Reference: [008-002])</obo:IAO_0000600>
+        <obo:IAO_0000111 xml:lang="en">continuant</obo:IAO_0000111>
+        <obo:IAO_0000601 xml:lang="en">if b is a continuant and if, for some t, c has_continuant_part b at t, then c is a continuant. (axiom label in BFO2 Reference: [126-001])</obo:IAO_0000601>
+        <obo:IAO_0000601 xml:lang="en">if b is a continuant and if, for some t, cis continuant_part of b at t, then c is a continuant. (axiom label in BFO2 Reference: [009-002])</obo:IAO_0000601>
+        <obo:IAO_0000601 xml:lang="en">if b is a material entity, then there is some temporal interval (referred to below as a one-dimensional temporal region) during which b exists. (axiom label in BFO2 Reference: [011-002])</obo:IAO_0000601>
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/bfo.owl"/>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedTarget>(forall (x) (if (Material Entity x) (exists (t) (and (TemporalRegion t) (existsAt x t))))) // axiom label in BFO2 CLIF: [011-002] </owl:annotatedTarget>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/><!-- continuant -->
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/><!-- has associated axiom(fol) -->
+        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/011-002"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedTarget>(forall (x y) (if (and (Continuant x) (exists (t) (continuantPartOfAt y x t))) (Continuant y))) // axiom label in BFO2 CLIF: [009-002] </owl:annotatedTarget>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/><!-- continuant -->
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/><!-- has associated axiom(fol) -->
+        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/009-002"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedTarget xml:lang="en">A continuant is an entity that persists, endures, or continues to exist through time while maintaining its identity. (axiom label in BFO2 Reference: [008-002])</owl:annotatedTarget>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/><!-- continuant -->
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000600"/><!-- elucidation -->
+        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/008-002"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedTarget xml:lang="en">Continuant doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. For example, in an expansion involving bringing in some of Ceuster's other portions of reality, questions are raised as to whether universals are continuants</owl:annotatedTarget>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/><!-- continuant -->
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000116"/><!-- editor note -->
+        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/0000007"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedTarget xml:lang="en">if b is a material entity, then there is some temporal interval (referred to below as a one-dimensional temporal region) during which b exists. (axiom label in BFO2 Reference: [011-002])</owl:annotatedTarget>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/><!-- continuant -->
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000601"/><!-- has associated axiom(nl) -->
+        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/011-002"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedTarget>(forall (x) (if (Continuant x) (Entity x))) // axiom label in BFO2 CLIF: [008-002] </owl:annotatedTarget>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/><!-- continuant -->
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/><!-- has associated axiom(fol) -->
+        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/008-002"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedTarget>(forall (x y) (if (and (Continuant x) (exists (t) (hasContinuantPartOfAt y x t))) (Continuant y))) // axiom label in BFO2 CLIF: [126-001] </owl:annotatedTarget>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/><!-- continuant -->
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/><!-- has associated axiom(fol) -->
+        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/126-001"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedTarget xml:lang="en">if b is a continuant and if, for some t, c has_continuant_part b at t, then c is a continuant. (axiom label in BFO2 Reference: [126-001])</owl:annotatedTarget>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/><!-- continuant -->
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000601"/><!-- has associated axiom(nl) -->
+        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/126-001"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedTarget xml:lang="en">if b is a continuant and if, for some t, cis continuant_part of b at t, then c is a continuant. (axiom label in BFO2 Reference: [009-002])</owl:annotatedTarget>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/><!-- continuant -->
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000601"/><!-- has associated axiom(nl) -->
+        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/009-002"/>
+    </owl:Axiom>
+
+
+    
+    <!-- http://purl.obolibrary.org/obo/IAO_0000033 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000033"><!-- directive information entity -->
+        <rdfs:label xml:lang="en">directive information entity</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000030"/><!-- information content entity -->
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/><!-- is about -->
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/BFO_0000017"/><!-- realizable entity -->
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <obo:IAO_0000116 xml:lang="en">2009-03-16: provenance: a term realizable information entity was proposed for OBI (OBI_0000337) , edited by the PlanAndPlannedProcess branch. Original definition was  "is the specification of a process that can be concretized and realized by an actor" with alternative term  "instruction".It has been subsequently moved to IAO where the objective for which the original term was defined was satisfied with the definitionof this, different, term.</obo:IAO_0000116>
+        <obo:IAO_0000116 xml:lang="en">2013-05-30 Alan Ruttenberg: What differentiates a directive information entity from an information concretization is that it can have concretizations that are either qualities or realizable entities. The concretizations that are realizable entities are created when an individual chooses to take up the direction, i.e. has the intention to (try to) realize it.</obo:IAO_0000116>
+        <obo:IAO_0000116 xml:lang="en">8/6/2009 Alan Ruttenberg: Changed label from "information entity about a realizable" after discussions at ICBO</obo:IAO_0000116>
+        <obo:IAO_0000115 xml:lang="en">An information content entity whose concretizations indicate to their bearer how to realize them in a process.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">PERSON: Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">PERSON: Bjoern Peters</obo:IAO_0000117>
+        <obo:IAO_0000116 xml:lang="en">Werner pushed back on calling it realizable information entity as it isn't realizable. However this name isn't right either. An example would be a recipe. The realizable entity would be a plan, but the information entity isn't about the plan, it, once concretized, *is* the plan. -Alan</obo:IAO_0000116>
+        <obo:IAO_0000111 xml:lang="en">directive information entity</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/><!-- ready for release -->
+    </owl:Class>
+
+       <!-- http://purl.obolibrary.org/obo/OBI_0500000 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0500000"><!-- study design -->
+        <rdfs:label xml:lang="en">study design</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000104"/><!-- plan specification -->
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/><!-- has part -->
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000272"/><!-- protocol -->
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A plan specification comprised of protocols (which may specify how and what kinds of data will be gathered) that are executed as part of an investigation and is realized during a study design execution.</obo:IAO_0000115>
+        <obo:IAO_0000116 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Editor note: there is at least an implicit restriction on the kind of data transformations that can be done based on the measured data available.</obo:IAO_0000116>
+        <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PERSON: Chris Stoeckert</obo:IAO_0000117>
+        <obo:IAO_0000112 xml:lang="en">a matched pairs study design describes criteria by which subjects are identified as pairs which then undergo the same protocols, and the data generated is analyzed by comparing the differences between the paired subjects, which constitute the results of the executed study design.</obo:IAO_0000112>
+        <obo:IAO_0000118 xml:lang="en">experimental design</obo:IAO_0000118>
+        <obo:IAO_0000232 xml:lang="en">rediscussed at length (MC/JF/BP). 12/9/08). The definition was clarified to differentiate it from protocol.</obo:IAO_0000232>
+        <obo:IAO_0000111 xml:lang="en">study design</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/><!-- ready for release -->
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+    </owl:Class>
+
+        <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Clinical_Infection -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Clinical_Infection">
+        <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Infectious_Disorder"/>
+        <FULL_SYN rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Clinical Infection</FULL_SYN>
+        <Preferred_Name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Clinical Infection</Preferred_Name>
+        <Semantic_Type rdf:datatype="http://www.w3.org/2001/XMLScheme#string">Disease of Syndrome</Semantic_Type>
+        <code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C128366</code>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Clinical Infection</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Clinical_Infection"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#FULL_SYN"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Clinical Infection</owl:annotatedTarget>
+        <term-group rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PT</term-group>
+        <term-source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NCI</term-source>
+    </owl:Axiom>
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0000699 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000699"><!-- survival assessment -->
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">survival assessment</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0000070"/><!-- assay -->
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000417"/><!-- achieves_planned_objective -->
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000441"/><!-- assay objective -->
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000293"/><!-- has_specified_input -->
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0100026"/><!-- organism -->
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000299"/><!-- has_specified_output -->
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000789"/><!-- survival rate -->
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/><!-- is about -->
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0100026"/><!-- organism -->
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <obo:OBI_9991118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string"/>
+        <obo:IAO_0000116 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Need to point out more specifically that survival / death is measured.</obo:IAO_0000116>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Survival assessment is an assay that measures the occurrence of death events in one or more organisms that are monitored over time</obo:IAO_0000115>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">survival assessment</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/><!-- metadata incomplete -->
+    </owl:Class>
+    
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C61410">
+        <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C54443"/>
+        <P90>CDISC</P90>
+        <P90>CDISC Terminology</P90>
+        <P90>Clinical Data Interchange Standards Consortium Terminology</P90>
+        <P376>&lt;p&gt;&lt;a href=&quot;http://www.cdisc.org/&quot;&gt;Clinical Data Interchange Standards Consortium (CDISC)&lt;/a&gt; is an international, non-profit organization that develops and supports global data standards for medical research. &lt;a href=&quot;http://www.cancer.gov/cancertopics/cancerlibrary/terminologyresources/cdisc&quot;&gt;CDISC collaborates with EVS&lt;/a&gt; to develop and support controlled terminology for a wide spectrum of clinical and nonclinical studies.  CDISC terminology goes through an extensive process of content development and public review before it is declared ready for release.&lt;/p&gt;&lt;p&gt;The value sets presented here represent the various CDISC codesets stored within the NCI Thesaurus.  These are also available for download from the &lt;a href=&quot;http://evs.nci.nih.gov/ftp1/CDISC&quot;&gt;EVS FTP site&lt;/a&gt;&lt;/p&gt;</P376>
+        <rdfs:label>Clinical Data Interchange Standards Consortium Terminology</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C61410"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97"/>
+        <owl:annotatedTarget>The terminology that includes terms relevant to the Clinical Data Interchange Standards Consortium.</owl:annotatedTarget>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C61410"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
+        <owl:annotatedTarget>CDISC</owl:annotatedTarget>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C61410"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
+        <owl:annotatedTarget>CDISC Terminology</owl:annotatedTarget>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C61410"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
+        <owl:annotatedTarget>Clinical Data Interchange Standards Consortium Terminology</owl:annotatedTarget>
+    </owl:Axiom>
+    
+       <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Color -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C37927">
+        <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C25377"/>
+        <A8 rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C117743</A8>
+        <P90>COLOR</P90>
+        <P90>Color</P90>
+        <rdfs:label>Color</rdfs:label>
+    </owl:Class>
+       <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C37927"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P325"/>
+        <owl:annotatedTarget>The appearance of objects (or light sources) described in terms of a person&apos;s perception of their hue and lightness (or brightness) and saturation. (NCI)</owl:annotatedTarget>
+    </owl:Axiom>
+    
+     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#CDISC_SDTM_Ophthalmic_Exam_Test_Code_Terminology -->
+     
     <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C117743">
-        <P106>Intellectual Product</P106>
-        <P325>Terminology relevant to the test codes that describe findings from ophthalmic examinations.</P325>
-        <P372>No</P372>
         <P90>CDISC SDTM Ophthalmic Exam Test Code Terminology</P90>
+        <P106>Intellectual Product</P106>
         <P90>OETESTCD</P90>
         <P90>Ophthalmic Exam Test Code</P90>
         <P90>SDTM-OETESTCD</P90>
+         <P372>No</P372>
         <rdfs:label>CDISC SDTM Ophthalmic Exam Test Code Terminology</rdfs:label>
     </owl:Class>
     <owl:Axiom>
@@ -1083,231 +2397,19 @@
         <P384>NCI</P384>
     </owl:Axiom>
     
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C12219 -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C12219"/>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123 -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123">
-        <owl:disjointUnionOf rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#BRaf"/>
-            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Erbb2"/>
-            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Mefv"/>
-            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Ras"/>
-            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SHH"/>
-            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SOS"/>
-            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#actin"/>
-            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#k-Ras"/>
-        </owl:disjointUnionOf>
-        <definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The fundamental unit of heredity.</definition>
-        <term>gene</term>
-        <rdfs:label>Gene</rdfs:label>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#disjointUnionOf"/>
-        <owl:annotatedTarget rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#BRaf"/>
-            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Erbb2"/>
-            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Mefv"/>
-            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Ras"/>
-            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SHH"/>
-            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SOS"/>
-            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#actin"/>
-            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#k-Ras"/>
-        </owl:annotatedTarget>
-        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">all genes are disjoint.  splicing variants are not considered individual genes.</note>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#definition"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The fundamental unit of heredity.</owl:annotatedTarget>
-        <provenance rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gregor Mendel</provenance>
-        <source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Encyclopedia</source>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term"/>
-        <owl:annotatedTarget>gene</owl:annotatedTarget>
-        <source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Wikipedia</source>
-        <term_type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PT</term_type>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C25377 -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C25377"/>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C37927 -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C37927">
-        <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C25377"/>
-        <A8 rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C117743</A8>
-        <P325>The appearance of objects (or light sources) described in terms of a person&apos;s perception of their hue and lightness (or brightness) and saturation. (NCI)</P325>
-        <P90>COLOR</P90>
-        <P90>Color</P90>
-        <rdfs:label>Color</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48323 -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48323">
-        <A8 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C117743"/>
-        <A8 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C54453"/>
-        <NHC0>C48323</NHC0>
-        <P106>Qualitative Concept</P106>
-        <P108>Black</P108>
-        <P322>FDA</P322>
-        <P322>TEST</P322>
-        <P372>Yes</P372>
-        <P90>BLACK</P90>
-        <P90>Black</P90>
-        <P97>Of darkest color; producing or reflecting comparatively little light and having no predominant hue; being the color of coal or carbon.</P97>
-        <rdfs:label>Black</rdfs:label>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48323"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
-        <owl:annotatedTarget>BLACK</owl:annotatedTarget>
-        <P383>PT</P383>
-        <P384>FDA</P384>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48323"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
-        <owl:annotatedTarget>Black</owl:annotatedTarget>
-        <P383>PT</P383>
-        <P384>NCI</P384>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48323"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97"/>
-        <owl:annotatedTarget>Of darkest color; producing or reflecting comparatively little light and having no predominant hue; being the color of coal or carbon.</owl:annotatedTarget>
-        <P378>NCI</P378>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48325 -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48325">
-        <A8 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C54453"/>
-        <NHC0>C48325</NHC0>
-        <P106>Qualitative Concept</P106>
-        <P108>White</P108>
-        <P322>FDA</P322>
-        <P325>rgb(255, 255, 255)</P325>
-        <P372>Yes</P372>
-        <P90>WHITE</P90>
-        <P90>White</P90>
-        <P90>White Color</P90>
-        <P97>The achromatic color of maximum lightness; the color of objects that reflect nearly all light of all visible wavelengths; the complement or antagonist of black, the other extreme of the neutral gray series.</P97>
-        <rdfs:label>White</rdfs:label>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48325"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P325"/>
-        <owl:annotatedTarget>rgb(255, 255, 255)</owl:annotatedTarget>
-        <P378>SPL</P378>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48325"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
-        <owl:annotatedTarget>WHITE</owl:annotatedTarget>
-        <P383>PT</P383>
-        <P384>FDA</P384>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48325"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
-        <owl:annotatedTarget>White</owl:annotatedTarget>
-        <P383>PT</P383>
-        <P384>NCI</P384>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48325"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
-        <owl:annotatedTarget>White Color</owl:annotatedTarget>
-        <P383>SY</P383>
-        <P384>NCI</P384>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48325"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97"/>
-        <owl:annotatedTarget>The achromatic color of maximum lightness; the color of objects that reflect nearly all light of all visible wavelengths; the complement or antagonist of black, the other extreme of the neutral gray series.</owl:annotatedTarget>
-        <P378>NCI</P378>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48333 -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48333">
-        <A8 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C54453"/>
-        <NHC0>C48333</NHC0>
-        <P106>Qualitative Concept</P106>
-        <P108>BLUE</P108>
-        <P207>C1260957</P207>
-        <P317>SPL Color (C-DRG-00927)</P317>
-        <P322>FDA</P322>
-        <P366>BLUE</P366>
-        <P372>Yes</P372>
-        <P90>BLUE</P90>
-        <P97>The hue of that portion of the visible spectrum lying between green and indigo.</P97>
-        <rdfs:label>BLUE</rdfs:label>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48333"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
-        <owl:annotatedTarget>BLUE</owl:annotatedTarget>
-        <P383>PT</P383>
-        <P384>FDA</P384>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48333"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
-        <owl:annotatedTarget>BLUE</owl:annotatedTarget>
-        <P383>PT</P383>
-        <P384>NCI</P384>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48333"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97"/>
-        <owl:annotatedTarget>The hue of that portion of the visible spectrum lying between green and indigo.</owl:annotatedTarget>
-        <P378>NCI</P378>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C54443 -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C54443"/>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C54453 -->
+        <!-- Structured Product Labeling Color Terminology -->
 
     <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C54453">
+        <rdfs:label>Structured Product Labeling Color Terminology</rdfs:label>
         <NHC0>C54453</NHC0>
         <P106>Intellectual Product</P106>
         <P108>Structured Product Labeling Color Terminology</P108>
-        <P322>FDA</P322>
         <P366>Labeling_Color_Terminology</P366>
         <P372>Yes</P372>
+        <P322>FDA</P322>
         <P90>SPL Color Terminology</P90>
         <P90>Structured Product Labeling Color Terminology</P90>
         <P97>Terminology used for representation of the information on pharmaceutical product color in the framework of the Structured Product Labeling documents.</P97>
-        <rdfs:label>Structured Product Labeling Color Terminology</rdfs:label>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C54453"/>
@@ -1330,1403 +2432,247 @@
         <P378>NCI</P378>
     </owl:Axiom>
     
+        <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48333 -->
 
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C61410 -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C61410">
-        <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C54443"/>
-        <P376>&lt;p&gt;&lt;a href=&quot;http://www.cdisc.org/&quot;&gt;Clinical Data Interchange Standards Consortium (CDISC)&lt;/a&gt; is an international, non-profit organization that develops and supports global data standards for medical research. &lt;a href=&quot;http://www.cancer.gov/cancertopics/cancerlibrary/terminologyresources/cdisc&quot;&gt;CDISC collaborates with EVS&lt;/a&gt; to develop and support controlled terminology for a wide spectrum of clinical and nonclinical studies.  CDISC terminology goes through an extensive process of content development and public review before it is declared ready for release.&lt;/p&gt;&lt;p&gt;The value sets presented here represent the various CDISC codesets stored within the NCI Thesaurus.  These are also available for download from the &lt;a href=&quot;http://evs.nci.nih.gov/ftp1/CDISC&quot;&gt;EVS FTP site&lt;/a&gt;&lt;/p&gt;</P376>
-        <P90>CDISC</P90>
-        <P90>CDISC Terminology</P90>
-        <P90>Clinical Data Interchange Standards Consortium Terminology</P90>
-        <P97>The terminology that includes terms relevant to the Clinical Data Interchange Standards Consortium.</P97>
-        <rdfs:label>Clinical Data Interchange Standards Consortium Terminology</rdfs:label>
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48333">
+        <A8 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C54453"/>
+        <NHC0>C48333</NHC0>
+        <P106>Qualitative Concept</P106>
+        <P108>BLUE</P108>
+        <P207>C1260957</P207>
+        <P317>SPL Color (C-DRG-00927)</P317>
+        <P322>FDA</P322>
+        <P366>BLUE</P366>
+        <P372>Yes</P372>
+        <P90>BLUE</P90>
+        <P90>BLUE</P90>
+        <P97>The hue of that portion of the visible spectrum lying between green and indigo.</P97>
+        <rdfs:label>BLUE</rdfs:label>
     </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48333"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
+        <owl:annotatedTarget>BLUE</owl:annotatedTarget>
+        <P383>PT</P383>
+        <P384>FDA</P384>
+        <P386>SPL</P386>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48333"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
+        <owl:annotatedTarget>BLUE</owl:annotatedTarget>
+        <P383>PT</P383>
+        <P384>NCI</P384>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48333"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97"/>
+        <owl:annotatedTarget>The hue of that portion of the visible spectrum lying between green and indigo.</owl:annotatedTarget>
+        <P378>NCI</P378>
+        <P381>American Heritage Dictionary - Bartelby.com</P381>
+    </owl:Axiom>
     
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C98989 -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C98989">
+        <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C98989">
         <A8 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48333"/>
+        <rdfs:label>Bluer than blue</rdfs:label>
         <P106>Qualitative Concept</P106>
         <P108>Bluer</P108>
-        <P322>FDA</P322>
         <P372>Yes</P372>
+        <P322>FDA</P322>
         <P90>BLACKER</P90>
         <P90>Bluer</P90>
         <P90>color characterized as dark</P90>
         <P97>Of even darker color</P97>
-        <rdfs:label>Bluer than blue</rdfs:label>
     </owl:Class>
     
+        <!-- Black -->
 
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C99988 -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C99988">
-        <A8 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C99999"/>
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48323">
+        <A8 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C54453"/>
+        <A8 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C117743"/>
+        <rdfs:label>Black</rdfs:label>
+        <NHC0>C48323</NHC0>
         <P106>Qualitative Concept</P106>
-        <P108>Ack</P108>
-        <P322>FDA</P322>
+        <P108>Black</P108>
         <P372>Yes</P372>
-        <P90>ACK</P90>
-        <P90>ack</P90>
-        <P90>color characterized as dark</P90>
-        <P97>Of even acker color</P97>
-        <rdfs:label>Ack</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C99989 -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C99989">
-        <A8 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C99999"/>
-        <P106>Qualitative Concept</P106>
-        <P108>Bla</P108>
         <P322>FDA</P322>
-        <P372>Yes</P372>
-        <P90>BLA</P90>
-        <P90>Bla</P90>
-        <P90>color characterized as dark</P90>
-        <P97>Of even bla color</P97>
-        <rdfs:label>Bla</rdfs:label>
+        <P322>TEST</P322>
+        <P90>BLACK</P90>
+        <P90>Black</P90>
+        <P97>Of darkest color; producing or reflecting comparatively little light and having no predominant hue; being the color of coal or carbon.</P97>
     </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48323"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
+        <owl:annotatedTarget>BLACK</owl:annotatedTarget>
+        <P383>PT</P383>
+        <P384>FDA</P384>
+        <P386>SPL</P386>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48323"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
+        <owl:annotatedTarget>Black</owl:annotatedTarget>
+        <P383>PT</P383>
+        <P384>NCI</P384>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48323"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97"/>
+        <owl:annotatedTarget>Of darkest color; producing or reflecting comparatively little light and having no predominant hue; being the color of coal or carbon.</owl:annotatedTarget>
+        <P378>NCI</P378>
+    </owl:Axiom>
     
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C99996 -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C99996">
-        <A8 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48325"/>
-        <NHC0>C48325</NHC0>
-        <P106>Qualitative Concept</P106>
-        <P108>BlindingWhite</P108>
-        <P322>FDA</P322>
-        <P372>Yes</P372>
-        <P90>BlindingWHITE</P90>
-        <P90>BlindingWhite</P90>
-        <P90>Blindingly White Color</P90>
-        <P97>The Blindingly achromatic color of maximum lightness; </P97>
-        <rdfs:label>BlindingWhite</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C99997 -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C99997">
-        <A8 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48325"/>
-        <NHC0>C48325</NHC0>
-        <P106>Qualitative Concept</P106>
-        <P108>ArchWhite</P108>
-        <P322>FDA</P322>
-        <P372>Yes</P372>
-        <P90>ARCHWHITE</P90>
-        <P90>ArchWhite</P90>
-        <P90>Archly White Color</P90>
-        <P97>The archly achromatic color of maximum lightness; </P97>
-        <rdfs:label>ArchWhite</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C99998 -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C99998">
-        <A8 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48323"/>
-        <P106>Qualitative Concept</P106>
-        <P108>UberBlack</P108>
-        <P322>FDA</P322>
-        <P372>Yes</P372>
-        <P90>BlackUber</P90>
-        <P90>UberBLACKER</P90>
-        <P90>color characterized as dark</P90>
-        <P97>Uber dark color</P97>
-        <rdfs:label>UberBlack</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C99999 -->
-
     <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C99999">
         <A8 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48323"/>
+        <rdfs:label>Blacker</rdfs:label>
         <P106>Qualitative Concept</P106>
         <P108>Blacker</P108>
-        <P322>FDA</P322>
         <P372>Yes</P372>
+        <P322>FDA</P322>
         <P90>BLACKER</P90>
         <P90>Blacker</P90>
         <P90>color characterized as dark</P90>
         <P97>Of even darker color</P97>
-        <rdfs:label>Blacker</rdfs:label>
     </owl:Class>
     
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#CancerPatient -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#CancerPatient">
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SickPatient"/>
-                    <owl:Class>
-                        <owl:unionOf rdf:parseType="Collection">
-                            <owl:Class>
-                                <owl:intersectionOf rdf:parseType="Collection">
-                                    <owl:Restriction>
-                                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_finding"/>
-                                        <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#TumorBenign"/>
-                                    </owl:Restriction>
-                                    <owl:Restriction>
-                                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_prognosis"/>
-                                        <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood"/>
-                                    </owl:Restriction>
-                                </owl:intersectionOf>
-                            </owl:Class>
-                            <owl:Class>
-                                <owl:intersectionOf rdf:parseType="Collection">
-                                    <owl:Restriction>
-                                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_finding"/>
-                                        <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#TumorMalignant"/>
-                                    </owl:Restriction>
-                                    <owl:Restriction>
-                                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_prognosis"/>
-                                        <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisBad"/>
-                                    </owl:Restriction>
-                                </owl:intersectionOf>
-                            </owl:Class>
-                        </owl:unionOf>
-                    </owl:Class>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#CancerPatient"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
-        <owl:annotatedTarget>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SickPatient"/>
-                    <owl:Class>
-                        <owl:unionOf rdf:parseType="Collection">
-                            <owl:Class>
-                                <owl:intersectionOf rdf:parseType="Collection">
-                                    <owl:Restriction>
-                                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_finding"/>
-                                        <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#TumorBenign"/>
-                                    </owl:Restriction>
-                                    <owl:Restriction>
-                                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_prognosis"/>
-                                        <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood"/>
-                                    </owl:Restriction>
-                                </owl:intersectionOf>
-                            </owl:Class>
-                            <owl:Class>
-                                <owl:intersectionOf rdf:parseType="Collection">
-                                    <owl:Restriction>
-                                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_finding"/>
-                                        <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#TumorMalignant"/>
-                                    </owl:Restriction>
-                                    <owl:Restriction>
-                                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_prognosis"/>
-                                        <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisBad"/>
-                                    </owl:Restriction>
-                                </owl:intersectionOf>
-                            </owl:Class>
-                        </owl:unionOf>
-                    </owl:Class>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:annotatedTarget>
-        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">test of annotation on role group subclass</note>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Clinical_Infection -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Clinical_Infection">
-        <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Infectious_Disorder"/>
-        <FULL_SYN rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Clinical Infection</FULL_SYN>
-        <Preferred_Name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Clinical Infection</Preferred_Name>
-        <Semantic_Type rdf:datatype="http://www.w3.org/2001/XMLScheme#string">Disease of Syndrome</Semantic_Type>
-        <code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C128366</code>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Clinical Infection</rdfs:label>
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C99989">
+        <A8 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C99999"/>
+        <rdfs:label>Bla</rdfs:label>
+        <P106>Qualitative Concept</P106>
+        <P108>Bla</P108>
+		<P372>Yes</P372>
+        <P322>FDA</P322>
+        <P90>BLA</P90>
+        <P90>Bla</P90>
+        <P90>color characterized as dark</P90>
+        <P97>Of even bla color</P97>
     </owl:Class>
     
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Cold -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Cold">
-        <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Disease"/>
+   <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C99988">
+        <A8 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C99999"/>
+        <rdfs:label>Ack</rdfs:label>
+        <P106>Qualitative Concept</P106>
+        <P108>Ack</P108>
+        <P372>Yes</P372>
+        <P322>FDA</P322>
+        <P90>ACK</P90>
+        <P90>ack</P90>
+         <P90>color characterized as dark</P90>
+        <P97>Of even acker color</P97>
     </owl:Class>
     
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Disease -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Disease">
-        <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#DiseasesDisordersFindings"/>
-        <definition>any entity that impacts the health of a patient.</definition>
-        <term>disease</term>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Disease"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#DiseasesDisordersFindings"/>
-        <definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">One of the three entities in the parent covering partition.</definition>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Disease"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#definition"/>
-        <owl:annotatedTarget>any entity that impacts the health of a patient.</owl:annotatedTarget>
-        <provenance>joe blow via lily librarian</provenance>
-        <source>nih</source>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Disease"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term"/>
-        <owl:annotatedTarget>disease</owl:annotatedTarget>
-        <source>nci</source>
-        <term_type>pt</term_type>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#DiseasesDisordersFindings -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#DiseasesDisordersFindings">
-        <owl:disjointWith rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Person"/>
-        <definition>any entitie categorized as a disease, a disorder, or a finding.</definition>
-        <term>diseases, disorders, and findings</term>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#DiseasesDisordersFindings"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#disjointWith"/>
-        <owl:annotatedTarget rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Person"/>
-        <note>treat disorders as always disjoint with people.</note>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#DiseasesDisordersFindings"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#definition"/>
-        <owl:annotatedTarget>any entitie categorized as a disease, a disorder, or a finding.</owl:annotatedTarget>
-        <provenance>pers. comm.</provenance>
-        <source>ctep</source>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#DiseasesDisordersFindings"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term"/>
-        <owl:annotatedTarget>diseases, disorders, and findings</owl:annotatedTarget>
-        <source>nci</source>
-        <term_type>sy</term_type>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#EpithelialCell -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#EpithelialCell">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL_0000000"/>
-        <definition>a cell located in an epithelial surface.</definition>
-        <term>epithelial cell</term>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#EpithelialCell"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/CL_0000000"/>
-        <definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">an isa relation to an external entity.</definition>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#EpithelialCell"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#definition"/>
-        <owl:annotatedTarget>a cell located in an epithelial surface.</owl:annotatedTarget>
-        <provenance rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NLM</provenance>
-        <source>nci</source>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#EpithelialCell"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term"/>
-        <owl:annotatedTarget>epithelial cell</owl:annotatedTarget>
-        <source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">caDSR</source>
-        <term_type>pt</term_type>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Erbb2 -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Erbb2">
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#gene_expressed_in"/>
-                        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CL_0000148"/>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Erbb2"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
-        <owl:annotatedTarget>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#gene_expressed_in"/>
-                        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CL_0000148"/>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:annotatedTarget>
-        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">test of annotation on object restriction subclass to external class</note>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Finding -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Finding">
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#DiseasesDisordersFindings"/>
-                    <owl:Class>
-                        <owl:oneOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Fever"/>
-                            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PaleSkin"/>
-                            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#ShallowBreathing"/>
-                        </owl:oneOf>
-                    </owl:Class>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
-        <semanticType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Disease</semanticType>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Finding"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
-        <owl:annotatedTarget>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#DiseasesDisordersFindings"/>
-                    <owl:Class>
-                        <owl:oneOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Fever"/>
-                            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PaleSkin"/>
-                            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#ShallowBreathing"/>
-                        </owl:oneOf>
-                    </owl:Class>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:annotatedTarget>
-        <definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">One of the three entities in the parent covering partition.</definition>
-        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">the extension of the class</note>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientDrivingAround -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientDrivingAround">
-        <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Patient"/>
+     <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C99998">
+        <A8 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48323"/>
+        <rdfs:label>UberBlack</rdfs:label>
+        <P106>Qualitative Concept</P106>
+        <P108>UberBlack</P108>
+        <P372>Yes</P372>
+        <P322>FDA</P322>
+        <P90>UberBLACKER</P90>
+        <P90>BlackUber</P90>
+        <P90>color characterized as dark</P90>
+        <P97>Uber dark color</P97>
     </owl:Class>
     
+       <!-- White -->
 
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientWalkingAround -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientWalkingAround">
-        <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Patient"/>
-    </owl:Class>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HealthyPatient -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HealthyPatient">
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Patient"/>
-                    <owl:Class>
-                        <owl:complementOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SickPatient"/>
-                    </owl:Class>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48325">
+        <rdfs:label>White</rdfs:label>
+        <A8 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C54453"/>
+        <NHC0>C48325</NHC0>
+        <P106>Qualitative Concept</P106>
+        <P108>White</P108>
+        <P372>Yes</P372>
+        <P322>FDA</P322>
+        <P90>WHITE</P90>
+        <P90>White</P90>
+        <P90>White Color</P90>
+        <P97>The achromatic color of maximum lightness; the color of objects that reflect nearly all light of all visible wavelengths; the complement or antagonist of black, the other extreme of the neutral gray series.</P97>
     </owl:Class>
     <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HealthyPatient"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
-        <owl:annotatedTarget>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Patient"/>
-                    <owl:Class>
-                        <owl:complementOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SickPatient"/>
-                    </owl:Class>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:annotatedTarget>
-        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">definitely you are healthy if you are not sick.</note>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48325"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P325"/>
+        <owl:annotatedTarget>rgb(255, 255, 255)</owl:annotatedTarget>
+        <P378>SPL</P378>
+        <P379>DEFAULT_Review</P379>
+        <P380>060127</P380>
     </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Infectious_Disorder -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Infectious_Disorder"/>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Mefv -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Mefv">
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#gene_related_to_disease"/>
-                        <owl:hasValue rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Fever"/>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
-    </owl:Class>
     <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Mefv"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
-        <owl:annotatedTarget>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#gene_related_to_disease"/>
-                        <owl:hasValue rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Fever"/>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:annotatedTarget>
-        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">test of annotation on object restriction value subclass</note>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48325"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
+        <owl:annotatedTarget>WHITE</owl:annotatedTarget>
+        <P383>PT</P383>
+        <P384>FDA</P384>
+        <P386>SPL</P386>
     </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#MildlySickCancerPatient -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#MildlySickCancerPatient">
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#MildlySickPatient"/>
-                    <owl:Class>
-                        <owl:intersectionOf rdf:parseType="Collection">
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_finding"/>
-                                <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#TumorBenign"/>
-                            </owl:Restriction>
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_prognosis"/>
-                                <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood"/>
-                            </owl:Restriction>
-                        </owl:intersectionOf>
-                    </owl:Class>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
-        <P108>slightly sick cancer patient</P108>
-    </owl:Class>
     <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#MildlySickCancerPatient"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
-        <owl:annotatedTarget>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#MildlySickPatient"/>
-                    <owl:Class>
-                        <owl:intersectionOf rdf:parseType="Collection">
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_finding"/>
-                                <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#TumorBenign"/>
-                            </owl:Restriction>
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_prognosis"/>
-                                <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood"/>
-                            </owl:Restriction>
-                        </owl:intersectionOf>
-                    </owl:Class>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:annotatedTarget>
-        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">test of annotation on intersection of object restriction subclass</note>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48325"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
+        <owl:annotatedTarget>White</owl:annotatedTarget>
+        <P383>PT</P383>
+        <P384>NCI</P384>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48325"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
+        <owl:annotatedTarget>White Color</owl:annotatedTarget>
+        <P383>SY</P383>
+        <P384>NCI</P384>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48325"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97"/>
+        <owl:annotatedTarget>The achromatic color of maximum lightness; the color of objects that reflect nearly all light of all visible wavelengths; the complement or antagonist of black, the other extreme of the neutral gray series.</owl:annotatedTarget>
+        <P378>NCI</P378>
+        <P379>Nicole Thomas</P379>
+        <P380>060724</P380>
+        <P381>American Heritage Dictionary - Bartelby.com</P381>
     </owl:Axiom>
     
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#MildlySickPatient -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#MildlySickPatient">
-        <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SickPatient"/>
+    
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C99997">
+        <rdfs:label>ArchWhite</rdfs:label>
+        <A8 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48325"/>
+        <NHC0>C48325</NHC0>
+        <P106>Qualitative Concept</P106>
+        <P108>ArchWhite</P108>
+        <P372>Yes</P372>
+        <P322>FDA</P322>
+        <P90>ARCHWHITE</P90>
+        <P90>ArchWhite</P90>
+        <P90>Archly White Color</P90>
+        <P97>The archly achromatic color of maximum lightness; </P97>
     </owl:Class>
     
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#NeoplasticDisease -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#NeoplasticDisease">
-        <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Disease"/>
-        <semanticType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Disease</semanticType>
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C99996">
+        <rdfs:label>BlindingWhite</rdfs:label>
+        <A8 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48325"/>
+        <NHC0>C48325</NHC0>
+        <P106>Qualitative Concept</P106>
+        <P108>BlindingWhite</P108>
+        <P372>Yes</P372>
+        <P322>FDA</P322>
+        <P90>BlindingWHITE</P90>
+        <P90>BlindingWhite</P90>
+        <P90>Blindingly White Color</P90>
+        <P97>The Blindingly achromatic color of maximum lightness; </P97>
     </owl:Class>
     
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#OncogeneTim -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#OncogeneTim">
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#has_physical_location"/>
-                        <owl:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12345</owl:hasValue>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#OncogeneTim"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
-        <owl:annotatedTarget>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#has_physical_location"/>
-                        <owl:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12345</owl:hasValue>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:annotatedTarget>
-        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">test of annotation on datatype restriction value subclass</note>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Patient -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Patient">
-        <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Person"/>
-        <semanticType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Organism</semanticType>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Patient"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Person"/>
-        <definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a role taken by a person on a health care provider visit.</definition>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PatientWithCold -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PatientWithCold">
-        <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#MildlySickPatient"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_finding"/>
-                <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Cold"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <P108>Patient With Cold</P108>
-        <P90>slightly sick patient</P90>
-        <term>slightly sick patient</term>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PatientWithCold"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term"/>
-        <owl:annotatedTarget>slightly sick patient</owl:annotatedTarget>
-        <source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CDISC</source>
-        <term_type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PT</term_type>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Person -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Person">
-        <definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Any human being.</definition>
-        <term rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human</term>
-        <term rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Person</term>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Person"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#definition"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Any human being.</owl:annotatedTarget>
-        <source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">common knowledge</source>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Person"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human</owl:annotatedTarget>
-        <source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LOC</source>
-        <term_type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SY</term_type>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Person"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Person</owl:annotatedTarget>
-        <source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NCI</source>
-        <term_type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PT</term_type>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#DiseasesDisordersFindings"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#disjointWith"/>
-        <owl:annotatedTarget rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Person"/>
-        <note>treat disorders as always disjoint with people.</note>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PersonRole -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PersonRole">
-        <definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Any role adopted by a person.</definition>
-        <term rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Personal Role</term>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PersonRole"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#definition"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Any role adopted by a person.</owl:annotatedTarget>
-        <provenance rdf:datatype="http://www.w3.org/2001/XMLSchema#string">JQ Public</provenance>
-        <source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ONC</source>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PersonRole"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Personal Role</owl:annotatedTarget>
-        <source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NCI</source>
-        <term_type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SY</term_type>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Prognosis -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Prognosis">
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#DiseasesDisordersFindings"/>
-                    <owl:Class>
-                        <owl:unionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisBad"/>
-                            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood"/>
-                        </owl:unionOf>
-                    </owl:Class>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
-        <semanticType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Disease</semanticType>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Prognosis"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
-        <owl:annotatedTarget>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#DiseasesDisordersFindings"/>
-                    <owl:Class>
-                        <owl:unionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisBad"/>
-                            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood"/>
-                        </owl:unionOf>
-                    </owl:Class>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:annotatedTarget>
-        <definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">One of the three entities in the parent covering partition.</definition>
-        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">essentially the sum of subclasses</note>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisBad -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisBad">
-        <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Prognosis"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisBad"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Prognosis"/>
-        <definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">One of the two entities in the parent undeclared covering partition.</definition>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood">
-        <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Prognosis"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Prognosis"/>
-        <definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">One of the two entities in the parent undeclared covering partition.</definition>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Ras -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Ras">
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#has_physical_location"/>
-                        <owl:someValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#positiveInteger"/>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Ras"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
-        <owl:annotatedTarget>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#has_physical_location"/>
-                        <owl:someValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#positiveInteger"/>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:annotatedTarget>
-        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">test of annotation on datatype restriction subclass</note>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SHH -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SHH">
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#gene_related_to_disease"/>
-                        <owl:allValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#NeoplasticDisease"/>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SHH"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
-        <owl:annotatedTarget>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#gene_related_to_disease"/>
-                        <owl:allValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#NeoplasticDisease"/>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:annotatedTarget>
-        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">test of annotation on object restriction subclass</note>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SOS -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SOS">
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#gene_related_to_disease"/>
-                        <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#NeoplasticDisease"/>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SOS"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
-        <owl:annotatedTarget>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#gene_related_to_disease"/>
-                        <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#NeoplasticDisease"/>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:annotatedTarget>
-        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">test of annotation on object restriction subclass</note>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SickPatient -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SickPatient">
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Patient"/>
-                    <owl:Class>
-                        <owl:unionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#CancerPatient"/>
-                            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#MildlySickPatient"/>
-                            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#VerySickPatient"/>
-                        </owl:unionOf>
-                    </owl:Class>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SickPatient"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
-        <owl:annotatedTarget>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Patient"/>
-                    <owl:Class>
-                        <owl:unionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#CancerPatient"/>
-                            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#MildlySickPatient"/>
-                            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#VerySickPatient"/>
-                        </owl:unionOf>
-                    </owl:Class>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:annotatedTarget>
-        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">essentially the sum of subclasses</note>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#TotalPerson -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#TotalPerson">
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Person"/>
-                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PersonRole"/>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#TotalPerson"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
-        <owl:annotatedTarget>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Person"/>
-                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PersonRole"/>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:annotatedTarget>
-        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">in real life, probably a union.</note>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#TumorBenign -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#TumorBenign">
-        <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#NeoplasticDisease"/>
-    </owl:Class>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#TumorMalignant -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#TumorMalignant">
-        <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#NeoplasticDisease"/>
-    </owl:Class>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#VerySickCancerPatient -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#VerySickCancerPatient">
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#VerySickPatient"/>
-                    <owl:Class>
-                        <owl:unionOf rdf:parseType="Collection">
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_finding"/>
-                                <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#TumorMalignant"/>
-                            </owl:Restriction>
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_prognosis"/>
-                                <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisBad"/>
-                            </owl:Restriction>
-                        </owl:unionOf>
-                    </owl:Class>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
-        <P108>very sick cancer patient</P108>
-        <term>very sick cancer patient</term>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#VerySickCancerPatient"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
-        <owl:annotatedTarget>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#VerySickPatient"/>
-                    <owl:Class>
-                        <owl:unionOf rdf:parseType="Collection">
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_finding"/>
-                                <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#TumorMalignant"/>
-                            </owl:Restriction>
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_prognosis"/>
-                                <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisBad"/>
-                            </owl:Restriction>
-                        </owl:unionOf>
-                    </owl:Class>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:annotatedTarget>
-        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">test of annotation on union of object restriction subclass</note>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#VerySickCancerPatient"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term"/>
-        <owl:annotatedTarget>very sick cancer patient</owl:annotatedTarget>
-        <source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NCI</source>
-        <term_type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PT</term_type>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#VerySickPatient -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#VerySickPatient">
-        <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SickPatient"/>
-        <term rdf:datatype="http://www.w3.org/2001/XMLSchema#string">very sick patient</term>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#VerySickPatient"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">very sick patient</owl:annotatedTarget>
-        <source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NCI</source>
-        <term_type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PT</term_type>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#actin -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#actin">
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
-                    <owl:Class>
-                        <owl:unionOf rdf:parseType="Collection">
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#gene_expressed_in"/>
-                                <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#EpithelialCell"/>
-                            </owl:Restriction>
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#in_organism"/>
-                                <owl:hasValue>all organisms</owl:hasValue>
-                            </owl:Restriction>
-                        </owl:unionOf>
-                    </owl:Class>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#actin"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
-        <owl:annotatedTarget>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
-                    <owl:Class>
-                        <owl:unionOf rdf:parseType="Collection">
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#gene_expressed_in"/>
-                                <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#EpithelialCell"/>
-                            </owl:Restriction>
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#in_organism"/>
-                                <owl:hasValue>all organisms</owl:hasValue>
-                            </owl:Restriction>
-                        </owl:unionOf>
-                    </owl:Class>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:annotatedTarget>
-        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">test of annotation on union of datatype and object restriction subclass</note>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#k-Ras -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#k-Ras">
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#has_physical_location"/>
-                        <owl:allValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#positiveInteger"/>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#k-Ras"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
-        <owl:annotatedTarget>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#has_physical_location"/>
-                        <owl:allValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#positiveInteger"/>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:annotatedTarget>
-        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">test of annotation on datatype restriction subclass</note>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#112233 -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#112233">
-        <rdfs:label>NumericalID</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://org.semanticweb.owlapi/error#Error1 -->
-
-    <owl:Class rdf:about="http://org.semanticweb.owlapi/error#Error1"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/BFO_0000001 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000001">
-        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
-        <owl:disjointWith rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
-        <obo:BFO_0000179>entity</obo:BFO_0000179>
-        <obo:BFO_0000180>Entity</obo:BFO_0000180>
-        <obo:IAO_0000111 xml:lang="en">entity</obo:IAO_0000111>
-        <obo:IAO_0000112 xml:lang="en">Julius Caesar</obo:IAO_0000112>
-        <obo:IAO_0000112 xml:lang="en">Verdi’s Requiem</obo:IAO_0000112>
-        <obo:IAO_0000112 xml:lang="en">the Second World War</obo:IAO_0000112>
-        <obo:IAO_0000112 xml:lang="en">your body mass index</obo:IAO_0000112>
-        <obo:IAO_0000116 xml:lang="en">BFO 2 Reference: In all areas of empirical inquiry we encounter general terms of two sorts. First are general terms which refer to universals or types:animaltuberculosissurgical procedurediseaseSecond, are general terms used to refer to groups of entities which instantiate a given universal but do not correspond to the extension of any subuniversal of that universal because there is nothing intrinsic to the entities in question by virtue of which they – and only they – are counted as belonging to the given group. Examples are: animal purchased by the Emperortuberculosis diagnosed on a Wednesdaysurgical procedure performed on a patient from Stockholmperson identified as candidate for clinical trial #2056-555person who is signatory of Form 656-PPVpainting by Leonardo da VinciSuch terms, which represent what are called ‘specializations’ in [81</obo:IAO_0000116>
-        <obo:IAO_0000116 xml:lang="en">Entity doesn&apos;t have a closure axiom because the subclasses don&apos;t necessarily exhaust all possibilites. For example Werner Ceusters &apos;portions of reality&apos; include 4 sorts, entities (as BFO construes them), universals, configurations, and relations. It is an open question as to whether entities as construed in BFO will at some point also include these other portions of reality. See, for example, &apos;How to track absolutely everything&apos; at http://www.referent-tracking.com/_RTU/papers/CeustersICbookRevised.pdf</obo:IAO_0000116>
-        <obo:IAO_0000600 xml:lang="en">An entity is anything that exists or has existed or will exist. (axiom label in BFO2 Reference: [001-001])</obo:IAO_0000600>
-        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/bfo.owl"/>
-        <rdfs:label xml:lang="en">entity</rdfs:label>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000001"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000116"/>
-        <owl:annotatedTarget xml:lang="en">Entity doesn&apos;t have a closure axiom because the subclasses don&apos;t necessarily exhaust all possibilites. For example Werner Ceusters &apos;portions of reality&apos; include 4 sorts, entities (as BFO construes them), universals, configurations, and relations. It is an open question as to whether entities as construed in BFO will at some point also include these other portions of reality. See, for example, &apos;How to track absolutely everything&apos; at http://www.referent-tracking.com/_RTU/papers/CeustersICbookRevised.pdf</owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/0000004"/>
-        <rdfs:comment>per discussion with Barry Smith</rdfs:comment>
-        <rdfs:seeAlso rdf:resource="http://www.referent-tracking.com/_RTU/papers/CeustersICbookRevised.pdf"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000001"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000600"/>
-        <owl:annotatedTarget xml:lang="en">An entity is anything that exists or has existed or will exist. (axiom label in BFO2 Reference: [001-001])</owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/001-001"/>
-    </owl:Axiom>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/BFO_0000002 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000002">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000001"/>
-        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000003"/>
-        <obo:BFO_0000179>continuant</obo:BFO_0000179>
-        <obo:BFO_0000180>Continuant</obo:BFO_0000180>
-        <obo:IAO_0000111 xml:lang="en">continuant</obo:IAO_0000111>
-        <obo:IAO_0000115 xml:lang="en">An entity that exists in full at any time in which it exists at all, persists through time while maintaining its identity and has no temporal parts.</obo:IAO_0000115>
-        <obo:IAO_0000116 xml:lang="en">BFO 2 Reference: Continuant entities are entities which can be sliced to yield parts only along the spatial dimension, yielding for example the parts of your table which we call its legs, its top, its nails. ‘My desk stretches from the window to the door. It has spatial parts, and can be sliced (in space) in two. With respect to time, however, a thing is a continuant.’ [60, p. 240</obo:IAO_0000116>
-        <obo:IAO_0000116 xml:lang="en">Continuant doesn&apos;t have a closure axiom because the subclasses don&apos;t necessarily exhaust all possibilites. For example, in an expansion involving bringing in some of Ceuster&apos;s other portions of reality, questions are raised as to whether universals are continuants</obo:IAO_0000116>
-        <obo:IAO_0000600 xml:lang="en">A continuant is an entity that persists, endures, or continues to exist through time while maintaining its identity. (axiom label in BFO2 Reference: [008-002])</obo:IAO_0000600>
-        <obo:IAO_0000601 xml:lang="en">if b is a continuant and if, for some t, c has_continuant_part b at t, then c is a continuant. (axiom label in BFO2 Reference: [126-001])</obo:IAO_0000601>
-        <obo:IAO_0000601 xml:lang="en">if b is a continuant and if, for some t, cis continuant_part of b at t, then c is a continuant. (axiom label in BFO2 Reference: [009-002])</obo:IAO_0000601>
-        <obo:IAO_0000601 xml:lang="en">if b is a material entity, then there is some temporal interval (referred to below as a one-dimensional temporal region) during which b exists. (axiom label in BFO2 Reference: [011-002])</obo:IAO_0000601>
-        <obo:IAO_0000602>(forall (x y) (if (and (Continuant x) (exists (t) (continuantPartOfAt y x t))) (Continuant y))) // axiom label in BFO2 CLIF: [009-002] </obo:IAO_0000602>
-        <obo:IAO_0000602>(forall (x y) (if (and (Continuant x) (exists (t) (hasContinuantPartOfAt y x t))) (Continuant y))) // axiom label in BFO2 CLIF: [126-001] </obo:IAO_0000602>
-        <obo:IAO_0000602>(forall (x) (if (Continuant x) (Entity x))) // axiom label in BFO2 CLIF: [008-002] </obo:IAO_0000602>
-        <obo:IAO_0000602>(forall (x) (if (Material Entity x) (exists (t) (and (TemporalRegion t) (existsAt x t))))) // axiom label in BFO2 CLIF: [011-002] </obo:IAO_0000602>
-        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/bfo.owl"/>
-        <rdfs:label xml:lang="en">continuant</rdfs:label>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000116"/>
-        <owl:annotatedTarget xml:lang="en">Continuant doesn&apos;t have a closure axiom because the subclasses don&apos;t necessarily exhaust all possibilites. For example, in an expansion involving bringing in some of Ceuster&apos;s other portions of reality, questions are raised as to whether universals are continuants</owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/0000007"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000600"/>
-        <owl:annotatedTarget xml:lang="en">A continuant is an entity that persists, endures, or continues to exist through time while maintaining its identity. (axiom label in BFO2 Reference: [008-002])</owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/008-002"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000601"/>
-        <owl:annotatedTarget xml:lang="en">if b is a continuant and if, for some t, c has_continuant_part b at t, then c is a continuant. (axiom label in BFO2 Reference: [126-001])</owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/126-001"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000601"/>
-        <owl:annotatedTarget xml:lang="en">if b is a continuant and if, for some t, cis continuant_part of b at t, then c is a continuant. (axiom label in BFO2 Reference: [009-002])</owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/009-002"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000601"/>
-        <owl:annotatedTarget xml:lang="en">if b is a material entity, then there is some temporal interval (referred to below as a one-dimensional temporal region) during which b exists. (axiom label in BFO2 Reference: [011-002])</owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/011-002"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/>
-        <owl:annotatedTarget>(forall (x y) (if (and (Continuant x) (exists (t) (continuantPartOfAt y x t))) (Continuant y))) // axiom label in BFO2 CLIF: [009-002] </owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/009-002"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/>
-        <owl:annotatedTarget>(forall (x y) (if (and (Continuant x) (exists (t) (hasContinuantPartOfAt y x t))) (Continuant y))) // axiom label in BFO2 CLIF: [126-001] </owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/126-001"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/>
-        <owl:annotatedTarget>(forall (x) (if (Continuant x) (Entity x))) // axiom label in BFO2 CLIF: [008-002] </owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/008-002"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/>
-        <owl:annotatedTarget>(forall (x) (if (Material Entity x) (exists (t) (and (TemporalRegion t) (existsAt x t))))) // axiom label in BFO2 CLIF: [011-002] </owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/011-002"/>
-    </owl:Axiom>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/BFO_0000003 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000003"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/BFO_0000004 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000004"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/BFO_0000015 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000015"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/BFO_0000017 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000017"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/BFO_0000023 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000023"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/BFO_0000182 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000182">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000015"/>
-        <obo:BFO_0000179>history</obo:BFO_0000179>
-        <obo:BFO_0000180>History</obo:BFO_0000180>
-        <obo:IAO_0000111 xml:lang="en">history</obo:IAO_0000111>
-        <obo:IAO_0000600 xml:lang="en">A history is a process that is the sum of the totality of processes taking place in the spatiotemporal region occupied by a material entity or site, including processes on the surface of the entity or within the cavities to which it serves as host. (axiom label in BFO2 Reference: [138-001])</obo:IAO_0000600>
-        <obo:IAO_0000600 xml:lang="en">A history is a process. (axiom label in BFO2 Reference: [138-001])</obo:IAO_0000600>
-        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/bfo.owl"/>
-        <rdfs:label xml:lang="en">history</rdfs:label>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000182"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000600"/>
-        <owl:annotatedTarget xml:lang="en">A history is a process. (axiom label in BFO2 Reference: [138-001])</owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/138-001"/>
-    </owl:Axiom>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/CHEBI_15956 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_15956">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/REO_0000280"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/REO_0000171"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">biotin</obo:IAO_0000111>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An organic heterobicyclic compound that consists of 2-oxohexahydro-1H-thieno[3,4-d]imidazole having a valeric acid substituent attached to the tetrahydrothiophene ring. The parent of the class of biotins.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">biotin</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/CL_0000000 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_0000000">
-        <definition>external class from the cl.</definition>
-        <rdfs:label>Cell</rdfs:label>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_0000000"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#definition"/>
-        <owl:annotatedTarget>external class from the cl.</owl:annotatedTarget>
-        <provenance>lily librarian</provenance>
-        <source>cl</source>
-    </owl:Axiom>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/CL_0000001 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_0000001">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL_0000010"/>
-        <rdfs:subClassOf>
-            <owl:Class>
-                <owl:complementOf>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000312"/>
-                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0600037"/>
-                    </owl:Restriction>
-                </owl:complementOf>
-            </owl:Class>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Class>
-                <owl:complementOf>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001000"/>
-                        <owl:someValuesFrom>
-                            <owl:Class>
-                                <owl:intersectionOf rdf:parseType="Collection">
-                                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CL_0000010"/>
-                                    <owl:Restriction>
-                                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000312"/>
-                                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0600037"/>
-                                    </owl:Restriction>
-                                </owl:intersectionOf>
-                            </owl:Class>
-                        </owl:someValuesFrom>
-                    </owl:Restriction>
-                </owl:complementOf>
-            </owl:Class>
-        </rdfs:subClassOf>
-        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">primary cultured cell</obo:IAO_0000111>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A cultured cell that is freshly isolated from a organismal source, or derives in culture from such a cell prior to the culture being passaged.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/cl.owl"/>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">primary cultured cell</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/CL_0000010 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_0000010"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/CL_0000148 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_0000148">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL_0000000"/>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000027 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000027"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000030 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000030"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000032 -->
+      <!-- http://purl.obolibrary.org/obo/IAO_0000032 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000032">
-        <rdfs:subClassOf rdf:resource="http://org.semanticweb.owlapi/error#Error1"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000109"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0001938"/>
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0001931"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000039"/>
+                <owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minCardinality>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
@@ -2746,129 +2692,7 @@ this case we explicitly refer to the singular form</obo:IAO_0000116>
         <rdfs:label xml:lang="en">scalar measurement datum</rdfs:label>
     </owl:Class>
     
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000033 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000033">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000030"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/BFO_0000017"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <obo:IAO_0000111 xml:lang="en">directive information entity</obo:IAO_0000111>
-        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
-        <obo:IAO_0000115 xml:lang="en">An information content entity whose concretizations indicate to their bearer how to realize them in a process.</obo:IAO_0000115>
-        <obo:IAO_0000116 xml:lang="en">2009-03-16: provenance: a term realizable information entity was proposed for OBI (OBI_0000337) , edited by the PlanAndPlannedProcess branch. Original definition was  &quot;is the specification of a process that can be concretized and realized by an actor&quot; with alternative term  &quot;instruction&quot;.It has been subsequently moved to IAO where the objective for which the original term was defined was satisfied with the definitionof this, different, term.</obo:IAO_0000116>
-        <obo:IAO_0000116 xml:lang="en">2013-05-30 Alan Ruttenberg: What differentiates a directive information entity from an information concretization is that it can have concretizations that are either qualities or realizable entities. The concretizations that are realizable entities are created when an individual chooses to take up the direction, i.e. has the intention to (try to) realize it.</obo:IAO_0000116>
-        <obo:IAO_0000116 xml:lang="en">8/6/2009 Alan Ruttenberg: Changed label from &quot;information entity about a realizable&quot; after discussions at ICBO</obo:IAO_0000116>
-        <obo:IAO_0000116 xml:lang="en">Werner pushed back on calling it realizable information entity as it isn&apos;t realizable. However this name isn&apos;t right either. An example would be a recipe. The realizable entity would be a plan, but the information entity isn&apos;t about the plan, it, once concretized, *is* the plan. -Alan</obo:IAO_0000116>
-        <obo:IAO_0000117 xml:lang="en">PERSON: Alan Ruttenberg</obo:IAO_0000117>
-        <obo:IAO_0000117 xml:lang="en">PERSON: Bjoern Peters</obo:IAO_0000117>
-        <rdfs:label xml:lang="en">directive information entity</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000078 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000078"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000104 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000104"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000109 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000109"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0000011 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000011"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0000047 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000047"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0000070 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000070"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0000272 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000272"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0000441 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000441"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0000699 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000699">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0000070"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000293"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0100026"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000299"/>
-                <owl:someValuesFrom>
-                    <owl:Class>
-                        <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000789"/>
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
-                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0100026"/>
-                            </owl:Restriction>
-                        </owl:intersectionOf>
-                    </owl:Class>
-                </owl:someValuesFrom>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000417"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000441"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">survival assessment</obo:IAO_0000111>
-        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Survival assessment is an assay that measures the occurrence of death events in one or more organisms that are monitored over time</obo:IAO_0000115>
-        <obo:IAO_0000116 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Need to point out more specifically that survival / death is measured.</obo:IAO_0000116>
-        <obo:OBI_9991118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></obo:OBI_9991118>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">survival assessment</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0000789 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000789"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0001873 -->
+        <!-- http://purl.obolibrary.org/obo/OBI_0001873 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0001873">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000027"/>
@@ -2896,199 +2720,7 @@ PMID: 23587118. see table2</obo:IAO_0000112>
         <rdfs:label xml:lang="en">number of errors</rdfs:label>
     </owl:Class>
     
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0001931 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0001931"/>
     
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0001933 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0001933"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0100026 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0100026"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0100060 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0100060">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0000047"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000312"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0600024"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000643"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CL_0000010"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000643"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CL_0000010"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cultured cell population</obo:IAO_0000111>
-        <obo:IAO_0000112>A cultured cell population applied in an experiment: &quot;293 cells expressing TrkA were serum-starved for 18 hours and then neurotrophins were added for 10 min before cell harvest.&quot;  (Lee, Ramee, et al. &quot;Regulation of cell survival by secreted proneurotrophins.&quot; Science 294.5548 (2001): 1945-1948).
-
-A cultured cell population maintained in vitro: &quot;Rat cortical neurons from 15 day embryos are grown in dissociated cell culture and maintained in vitro for 8–12 weeks&quot; (Dichter, Marc A. &quot;Rat cortical neurons in cell culture: culture methods, cell morphology, electrophysiology, and synapse formation.&quot; Brain Research 149.2 (1978): 279-293).</obo:IAO_0000112>
-        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A processed material comprised of a collection of cultured cells that has been continuously maintained together in culture and shares a common propagation history.</obo:IAO_0000115>
-        <obo:IAO_0000116 xml:lang="en">2013-6-5 MHB: This OBI class was formerly called &apos;cell culture&apos;, but label changed and definition updated following CLO alignment efforts in spring 2013, during which the intent of this class was clarified to refer to portions of a culture or line rather than a complete cell culture or line.</obo:IAO_0000116>
-        <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PERSON:Matthew Brush</obo:IAO_0000117>
-        <obo:IAO_0000118>cell culture sample</obo:IAO_0000118>
-        <obo:IAO_0000119 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PERSON:Matthew Brush</obo:IAO_0000119>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The extent of a &apos;cultured cell population&apos; is restricted only in that all cell members must share a propagation history (ie be derived through a common lineage of passages from an initial culture). In being defined in this way, this class can be used to refer to the populations that researchers actually use in the practice of science - ie are the inputs to culturing, experimentation, and sharing. The cells in such populations will be a relatively uniform population as they have experienced similar selective pressures due to their continuous co-propagation. And this population will also have a single passage number, again owing to their common passaging history. Cultured cell populations represent only a collection of cells (ie do not include media, culture dishes, etc), and include populations of cultured unicellular organisms or cultured multicellular organism cells. They can exist under active culture, stored in a quiescent state for future use, or applied experimentally.</rdfs:comment>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cultured cell population</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0100061 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0100061">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0100060"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000643"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CL_0000001"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000643"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CL_0000001"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000312"/>
-                <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">0</owl:qualifiedCardinality>
-                <owl:onClass rdf:resource="http://purl.obolibrary.org/obo/OBI_0600037"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <obo:IAO_0000111 xml:lang="en">primary cultured cell population</obo:IAO_0000111>
-        <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Spleen cells put directly into culture;  Cold storage of biopsies from wild endangered native Chilean species in field conditions and subsequent isolation of primary culture cell lines. In Vitro Cell Dev Biol Anim. 2008 Jul 2. PMID: 18594934</obo:IAO_0000112>
-        <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cells that have been isolated from some organismal source, expanded in culture, but not undergone a complete passaging (ie are still in culture, or have been lifted from culture and frozen in aliquots for future use)</obo:IAO_0000112>
-        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A cultured cell population comprised of cells expanded directly from living tissue prior to being passaged.
-
-</obo:IAO_0000115>
-        <obo:IAO_0000116>2013-6-5 MHB: This OBI class was formerly called &apos;primary cell culture&apos;, but label changed and definition updated following CLO alignment work.  Previous definition: &apos;a primary cell culture is a cell culture where the cells derive from a fresh tissue source.&apos;</obo:IAO_0000116>
-        <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PERSON:Matthew Brush</obo:IAO_0000117>
-        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">primary cell culture</obo:IAO_0000118>
-        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">primary cell culture sample</obo:IAO_0000118>
-        <obo:IAO_0000119 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PERSON:Matthew Brush</obo:IAO_0000119>
-        <rdfs:label xml:lang="en">primary cultured cell population</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0100063 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0100063">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0100060"/>
-        <obo:IAO_0000111 xml:lang="en">cultured clonal cell population</obo:IAO_0000111>
-        <obo:IAO_0000112 xml:lang="en">cell cut                                                                                                                                                                                      
-Stem cell functions assessed in clonal culture. Soc Gen Physiol Ser. 1988;43:39-45. Review. PMID: 3077557</obo:IAO_0000112>
-        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
-        <obo:IAO_0000115 xml:lang="en">A cultured cell population comprised of cells which can all be traced back to a single ancestor cell, and which therefore can be treated as identical.</obo:IAO_0000115>
-        <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PERSON: Susanna Sansone</obo:IAO_0000117>
-        <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PERSON:Matthew Brush</obo:IAO_0000117>
-        <obo:IAO_0000118>clonal cell culture sample</obo:IAO_0000118>
-        <obo:IAO_0000119 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GROUP: OBI Biomaterial Branch</obo:IAO_0000119>
-        <rdfs:label xml:lang="en">cultured clonal cell population</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0500000 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0500000">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000104"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000272"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <obo:IAO_0000111 xml:lang="en">study design</obo:IAO_0000111>
-        <obo:IAO_0000112 xml:lang="en">a matched pairs study design describes criteria by which subjects are identified as pairs which then undergo the same protocols, and the data generated is analyzed by comparing the differences between the paired subjects, which constitute the results of the executed study design.</obo:IAO_0000112>
-        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A plan specification comprised of protocols (which may specify how and what kinds of data will be gathered) that are executed as part of an investigation and is realized during a study design execution.</obo:IAO_0000115>
-        <obo:IAO_0000116 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Editor note: there is at least an implicit restriction on the kind of data transformations that can be done based on the measured data available.</obo:IAO_0000116>
-        <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PERSON: Chris Stoeckert</obo:IAO_0000117>
-        <obo:IAO_0000118 xml:lang="en">experimental design</obo:IAO_0000118>
-        <obo:IAO_0000232 xml:lang="en">rediscussed at length (MC/JF/BP). 12/9/08). The definition was clarified to differentiate it from protocol.</obo:IAO_0000232>
-        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
-        <rdfs:label xml:lang="en">study design</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0600024 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0600024"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0600037 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0600037"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/REO_0000171 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/REO_0000171">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000023"/>
-        <obo:IAO_0000111 xml:lang="en">molecular label role</obo:IAO_0000111>
-        <obo:IAO_0000115>a reagent role inhering in a molecular entity intended to associate with some molecular target to serve as a proxy for the presence, abundance, or location of this target in a detection of molecular label assay.</obo:IAO_0000115>
-        <obo:IAO_0000116>MHB (9-29-13): &apos;molecular label role&apos; imported from the Reagent Ontology and replaced OBI:OBI_0000140 (label role)</obo:IAO_0000116>
-        <obo:IAO_0000118>molecular tracer role</obo:IAO_0000118>
-        <obo:IAO_0000119>OBI developer call, 3-12-12</obo:IAO_0000119>
-        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/reo.owl"/>
-        <rdfs:label xml:lang="en">molecular label role</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/REO_0000280 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/REO_0000280"/>
-    
-
-
-    <!-- http://www.geneontology.org/formats/oboInOwl#ObsoleteClass -->
-
-    <owl:Class rdf:about="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
-    
-
-
-    <!-- http://www.w3.org/2002/07/owl#Nothing -->
-
-    <owl:Class rdf:about="http://www.w3.org/2002/07/owl#Nothing">
-        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Nothing"/>
-    </owl:Class>
-    
-
-
-    <!-- http://www.w3.org/2002/07/owl#Thing -->
-
-    <owl:Class rdf:about="http://www.w3.org/2002/07/owl#Thing"/>
-    
-
-
     <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //
@@ -3102,65 +2734,66 @@ Stem cell functions assessed in clonal culture. Soc Gen Physiol Ser. 1988;43:39-
 
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Fever -->
 
-    <owl:NamedIndividual rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Fever">
-        <rdf:type rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Finding"/>
-        <term rdf:datatype="http://www.w3.org/2001/XMLSchema#string">High Temperature</term>
+    <owl:NamedIndividual rdf:about="&owl2lexevs;Fever">
+        <rdf:type rdf:resource="&owl2lexevs;Finding"/>
+        <term rdf:datatype="&xsd;string">High Temperature</term>
     </owl:NamedIndividual>
     <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Fever"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">High Temperature</owl:annotatedTarget>
-        <term_type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SY</term_type>
+        <owl:annotatedTarget rdf:datatype="&xsd;string">High Temperature</owl:annotatedTarget>
+        <term_type rdf:datatype="&xsd;string">SY</term_type>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;Fever"/>
+        <owl:annotatedProperty rdf:resource="&owl2lexevs;term"/>
     </owl:Axiom>
     
 
 
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientDrivingAround -->
 
-    <owl:NamedIndividual rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientDrivingAround">
-        <AssociationV1 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood"/>
+    <owl:NamedIndividual rdf:about="&owl2lexevs;HappyPatientDrivingAround">
+        <AssociationV1 rdf:resource="&owl2lexevs;PrognosisGood"/>
     </owl:NamedIndividual>
     <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientDrivingAround"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationV1"/>
-        <owl:annotatedTarget rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood"/>
-        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">annotation on an AssociationV1 of a class.</note>
+        <note rdf:datatype="&xsd;string">annotation on an AssociationV1 of a class.</note>
+        <owl:annotatedProperty rdf:resource="&owl2lexevs;AssociationV1"/>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;HappyPatientDrivingAround"/>
+        <owl:annotatedTarget rdf:resource="&owl2lexevs;PrognosisGood"/>
     </owl:Axiom>
+    
     
 
 
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientWalkingAround -->
 
-    <owl:NamedIndividual rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientWalkingAround">
+    <owl:NamedIndividual rdf:about="&owl2lexevs;HappyPatientWalkingAround">
         <AssociationV1 rdf:resource="http://purl.obolibrary.org/obo/CL_0000148"/>
     </owl:NamedIndividual>
     <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientWalkingAround"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationV1"/>
+        <note rdf:datatype="&xsd;string">annotation on an AssociationV! of external.class (rdf:resource).</note>
+        <owl:annotatedProperty rdf:resource="&owl2lexevs;AssociationV1"/>
+        <owl:annotatedSource rdf:resource="&owl2lexevs;HappyPatientWalkingAround"/>
         <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/CL_0000148"/>
-        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">annotation on an AssociationV! of external.class (rdf:resource).</note>
     </owl:Axiom>
     
 
 
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PaleSkin -->
 
-    <owl:NamedIndividual rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PaleSkin">
-        <rdf:type rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Finding"/>
+    <owl:NamedIndividual rdf:about="&owl2lexevs;PaleSkin">
+        <rdf:type rdf:resource="&owl2lexevs;Finding"/>
     </owl:NamedIndividual>
     
 
 
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood -->
 
-    <owl:NamedIndividual rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood"/>
+    <owl:NamedIndividual rdf:about="&owl2lexevs;PrognosisGood"/>
     
 
 
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#ShallowBreathing -->
 
-    <owl:NamedIndividual rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#ShallowBreathing">
-        <rdf:type rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Finding"/>
+    <owl:NamedIndividual rdf:about="&owl2lexevs;ShallowBreathing">
+        <rdf:type rdf:resource="&owl2lexevs;Finding"/>
     </owl:NamedIndividual>
     
 
@@ -3169,105 +2802,19 @@ Stem cell functions assessed in clonal culture. Soc Gen Physiol Ser. 1988;43:39-
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/CL_0000148"/>
     
-
-
     <!-- http://purl.obolibrary.org/obo/IAO_0000122 -->
 
-    <owl:Thing rdf:about="http://purl.obolibrary.org/obo/IAO_0000122">
+    <owl:Thing rdf:about="http://purl.obolibrary.org/obo/IAO_0000122"><!-- ready for release -->
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/IAO_0000078"/><!-- curation status specification -->
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/IAO_0000078"/>
-        <obo:IAO_0000111 xml:lang="en">ready for release</obo:IAO_0000111>
-        <obo:IAO_0000115 xml:lang="en">Class has undergone final review, is ready for use, and will be included in the next release. Any class lacking &quot;ready_for_release&quot; should be considered likely to change place in hierarchy, have its definition refined, or be obsoleted in the next release.  Those classes deemed &quot;ready_for_release&quot; will also derived from a chain of ancestor classes that are also &quot;ready_for_release.&quot;</obo:IAO_0000115>
         <rdfs:label xml:lang="en">ready for release</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">Class has undergone final review, is ready for use, and will be included in the next release. Any class lacking "ready_for_release" should be considered likely to change place in hierarchy, have its definition refined, or be obsoleted in the next release.  Those classes deemed "ready_for_release" will also derived from a chain of ancestor classes that are also "ready_for_release."</obo:IAO_0000115>
+        <obo:IAO_0000111 xml:lang="en">ready for release</obo:IAO_0000111>
     </owl:Thing>
-    
 
-
-    <!-- http://purl.obolibrary.org/obo/obi.owl -->
+        <!-- http://purl.obolibrary.org/obo/obi.owl -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/obi.owl"/>
-    <rdf:Description>
-        <owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minCardinality>
-    </rdf:Description>
-    
-
-
-    <!-- 
-    ///////////////////////////////////////////////////////////////////////////////////////
-    //
-    // Annotations
-    //
-    ///////////////////////////////////////////////////////////////////////////////////////
-     -->
-
-    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationV1">
-        <term rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Association</term>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientDrivingAround">
-        <AssociationSTR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood</AssociationSTR>
-        <AssociationLIT>http://ncicb.nci.nih.gov/xml/owl/evs/owl2lexevs.owl#PrognosisGood</AssociationLIT>
-        <InvalidAssociationURIAsResource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood"/>
-        <AssociationV1 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood"/>
-        <AssociationURIAsResource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood"/>
-        <AssociationURI rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood"/>
-    </rdf:Description>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientDrivingAround"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationSTR"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood</owl:annotatedTarget>
-        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">annotation on an AssociationSTR.</note>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientDrivingAround"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationLIT"/>
-        <owl:annotatedTarget>http://ncicb.nci.nih.gov/xml/owl/evs/owl2lexevs.owl#PrognosisGood</owl:annotatedTarget>
-        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">annotation on an AssociationLIT.</note>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientDrivingAround"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationURI"/>
-        <owl:annotatedTarget rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood"/>
-        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">annotation on an AssociationURI of a class (rdf:resource).</note>
-    </owl:Axiom>
-    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientWalkingAround">
-        <AssociationLIT>http://purl.obolibrary.org/obo/cl_0000148</AssociationLIT>
-        <AssociationV1 rdf:resource="http://purl.obolibrary.org/obo/CL_0000148"/>
-        <AssociationURI rdf:resource="http://purl.obolibrary.org/obo/CL_0000148"/>
-        <AssociationURI rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://purl.obolibrary.org/obo/CL_0000148</AssociationURI>
-        <AssociationSTR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.obolibrary.org/obo/CL_0000148</AssociationSTR>
-    </rdf:Description>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientWalkingAround"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationLIT"/>
-        <owl:annotatedTarget>http://purl.obolibrary.org/obo/cl_0000148</owl:annotatedTarget>
-        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">annotation on an AssociationLIT of external.</note>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientWalkingAround"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationURI"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/CL_0000148"/>
-        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">annotation on an AssociationURI of external class (rdf:resource)</note>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientWalkingAround"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationURI"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://purl.obolibrary.org/obo/CL_0000148</owl:annotatedTarget>
-        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">annotation on an AssociationURI of external.</note>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientWalkingAround"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationSTR"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.obolibrary.org/obo/CL_0000148</owl:annotatedTarget>
-        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">annotation on an AssociationSTR of external.</note>
-    </owl:Axiom>
-    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#semanticType">
-        <semanticType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Conceptual</semanticType>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CL_0000148">
-        <rdfs:label>melanocyte</rdfs:label>
-    </rdf:Description>
-    
-
 
     <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
@@ -3278,22 +2825,22 @@ Stem cell functions assessed in clonal culture. Soc Gen Physiol Ser. 1988;43:39-
      -->
 
     <owl:Axiom>
+        <provenance>joe blow</provenance>
+        <note>gci testing</note>
+        <source>nci</source>
+        <owl:annotatedTarget rdf:resource="&owl2lexevs;SickPatient"/>
+        <owl:annotatedProperty rdf:resource="&rdfs;subClassOf"/>
         <owl:annotatedSource>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_finding"/>
-                <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Finding"/>
-                <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SickPatient"/>
+                <rdfs:subClassOf rdf:resource="&owl2lexevs;SickPatient"/>
+                <owl:onProperty rdf:resource="&owl2lexevs;patient_has_finding"/>
+                <owl:someValuesFrom rdf:resource="&owl2lexevs;Finding"/>
             </owl:Restriction>
         </owl:annotatedSource>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SickPatient"/>
-        <note>gci testing</note>
-        <provenance>joe blow</provenance>
-        <source>nci</source>
     </owl:Axiom>
 </rdf:RDF>
 
 
 
-<!-- Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi -->
+<!-- Generated by the OWL API (version 3.5.0) http://owlapi.sourceforge.net -->
 

--- a/lbTest/resources/testData/owl2/owl2-special-cases-Defined-Annotated.owl
+++ b/lbTest/resources/testData/owl2/owl2-special-cases-Defined-Annotated.owl
@@ -1,33 +1,24 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE rdf:RDF [
-    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
-    <!ENTITY dc "http://purl.org/dc/elements/1.1/" >
-    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
-    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
-    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
-    <!ENTITY owl2lexevs "http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#" >
-]>
-
-
+<?xml version="1.0"?>
 <rdf:RDF xmlns="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#"
      xml:base="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl"
      xmlns:dc="http://purl.org/dc/elements/1.1/"
-     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-     xmlns:owl2lexevs="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#"
-     xmlns:owl="http://www.w3.org/2002/07/owl#"
-     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
-     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:obo="http://purl.obolibrary.org/obo/"
-     xmlns:doap="http://usefulinc.com/ns/doap#" 
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:doap="http://usefulinc.com/ns/doap#"
      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:protege="http://protege.stanford.edu/plugins/owl/protege#"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#"
-     xmlns:protege="http://protege.stanford.edu/plugins/owl/protege#">
+     xmlns:owl2lexevs="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#">
     <owl:Ontology rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl">
+        <owl:versionIRI rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl/0.1.5"/>
+        <note xml:lang="en">Test of OWL2 constructions for import into LexEVS.  This file contains defines with annotations.</note>
         <source>nci evs</source>
         <dc:date>august 8, 2014</dc:date>
         <owl:versionInfo>0.1.5</owl:versionInfo>
-        <note xml:lang="en">Test of OWL2 constructions for import into LexEVS.  This file contains defines with annotations.</note>
-        <owl:versionIRI rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl/0.1.5"/>
     </owl:Ontology>
     
 
@@ -43,219 +34,140 @@
     
 
 
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#A8 -->
+
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#A8">
+        <P90>Concept_In_Subset</P90>
+        <P97>Used to associate the concept defining a particular terminology subset with concepts that belong to this subset.</P97>
+        <rdfs:label>Concept_In_Subset</rdfs:label>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#anyURI"/>
+    </owl:AnnotationProperty>
+    
+
+
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationLIT -->
 
-    <owl:AnnotationProperty rdf:about="&owl2lexevs;AssociationLIT">
-        <term rdf:datatype="&xsd;string">Association</term>
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationLIT">
+        <term rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Association</term>
     </owl:AnnotationProperty>
     
 
 
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationSTR -->
 
-    <owl:AnnotationProperty rdf:about="&owl2lexevs;AssociationSTR">
-        <term rdf:datatype="&xsd;string">Association</term>
-        <rdfs:range rdf:resource="&xsd;string"/>
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationSTR">
+        <term rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Association</term>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
     </owl:AnnotationProperty>
     
 
 
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationURI -->
 
-    <owl:AnnotationProperty rdf:about="&owl2lexevs;AssociationURI">
-        <term rdf:datatype="&xsd;string">Association</term>
-        <rdfs:range rdf:resource="&xsd;anyURI"/>
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationURI">
+        <term rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Association</term>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#anyURI"/>
     </owl:AnnotationProperty>
     
-     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationURIAsResource -->
-     
-   <owl:AnnotationProperty rdf:about="&owl2lexevs;AssociationURIAsResource">
-        <term rdf:datatype="&xsd;string">Association</term>
-        <rdfs:range rdf:resource="&xsd;anyURI"/>
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationURIAsResource -->
+
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationURIAsResource">
+        <term rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Association</term>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#anyURI"/>
     </owl:AnnotationProperty>
     
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#InvalideAssociationURIAsResource -->
- 	<owl:AnnotationProperty rdf:about="&owl2lexevs;InvalidAssociationURIAsResource"/>
+
 
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationV1 -->
 
-    <owl:AnnotationProperty rdf:about="&owl2lexevs;AssociationV1">
-        <term rdf:datatype="&xsd;string">Association</term>
-    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationV1"/>
     
 
 
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#definition -->
-
-    <owl:AnnotationProperty rdf:about="&owl2lexevs;definition"/>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#note -->
-
-    <owl:AnnotationProperty rdf:about="&owl2lexevs;note"/>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#provenance -->
-
-    <owl:AnnotationProperty rdf:about="&owl2lexevs;provenance"/>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#semanticType -->
-
-    <owl:AnnotationProperty rdf:about="&owl2lexevs;semanticType">
-        <semanticType rdf:datatype="&xsd;string">Conceptual</semanticType>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#source -->
-
-    <owl:AnnotationProperty rdf:about="&owl2lexevs;source"/>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term -->
-
-    <owl:AnnotationProperty rdf:about="&owl2lexevs;term"/>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term_type -->
-
-    <owl:AnnotationProperty rdf:about="&owl2lexevs;term_type"/>
-    
-
-
-    <!-- http://purl.org/dc/elements/1.1/date -->
-
-    <owl:AnnotationProperty rdf:about="&dc;date"/>
-    
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0010000"><!-- has axiom label -->
-        <rdfs:label xml:lang="en">has axiom label</rdfs:label>
-        <obo:IAO_0000600 xml:lang="en">A URI that is intended to be unique label for an axiom used for tracking change to the ontology. For an axiom expressed in different languages, each expression is given the same URI</obo:IAO_0000600>
-        <obo:IAO_0000117 xml:lang="en">Person:Alan Ruttenberg</obo:IAO_0000117>
-        <obo:IAO_0000119 xml:lang="en">Person:Alan Ruttenberg</obo:IAO_0000119>
-        <obo:IAO_0000111 xml:lang="en">has axiom label</obo:IAO_0000111>
-        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
-    </owl:AnnotationProperty>
-
-
-      <!-- http://purl.obolibrary.org/obo/IAO_0000114 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000114"><!-- has curation status -->
-        <rdfs:label xml:lang="en">has curation status</rdfs:label>
-        <obo:IAO_0000119 xml:lang="en">OBI_0000281</obo:IAO_0000119>
-        <obo:IAO_0000117 xml:lang="en">PERSON:Alan Ruttenberg</obo:IAO_0000117>
-        <obo:IAO_0000117 xml:lang="en">PERSON:Bill Bug</obo:IAO_0000117>
-        <obo:IAO_0000117 xml:lang="en">PERSON:Melanie Courtot</obo:IAO_0000117>
-        <obo:IAO_0000111 xml:lang="en">has curation status</obo:IAO_0000111>
-    </owl:AnnotationProperty>
-
-        <!-- http://purl.obolibrary.org/obo/IAO_0000412 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000412"><!-- imported from -->
-        <rdfs:label xml:lang="en">imported from</rdfs:label>
-        <obo:IAO_0000115 xml:lang="en">For external terms/classes, the ontology from which the term was imported</obo:IAO_0000115>
-        <obo:IAO_0000119 xml:lang="en">GROUP:OBI:&lt;http://purl.obolibrary.org/obo/obi></obo:IAO_0000119>
-        <obo:IAO_0000117 xml:lang="en">PERSON:Alan Ruttenberg</obo:IAO_0000117>
-        <obo:IAO_0000117 xml:lang="en">PERSON:Melanie Courtot</obo:IAO_0000117>
-        <obo:IAO_0000111 xml:lang="en">imported from</obo:IAO_0000111>
-        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/><!-- pending final vetting -->
-        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
-    </owl:AnnotationProperty>
-
-        <!-- http://purl.obolibrary.org/obo/IAO_0100001 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0100001"><!-- term replaced by -->
-        <rdfs:label xml:lang="en">term replaced by</rdfs:label>
-        <obo:IAO_0000115 xml:lang="en">Add as annotation triples in the granting ontology</obo:IAO_0000115>
-        <obo:IAO_0000119 xml:lang="en">Person:Alan Ruttenberg</obo:IAO_0000119>
-        <obo:IAO_0000117 xml:lang="en">Person:Alan Ruttenberg</obo:IAO_0000117>
-        <obo:IAO_0000115 xml:lang="en">Use on obsolete terms, relating the term to another term that can be used as a substitute</obo:IAO_0000115>
-        <obo:IAO_0000111 xml:lang="en">term replaced by</obo:IAO_0000111>
-        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/><!-- pending final vetting -->
-    </owl:AnnotationProperty>
-    
-    
-        <!-- http://purl.obolibrary.org/obo/IAO_0000111 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000111"><!-- editor preferred label -->
-        <rdfs:label>editor preferred term</rdfs:label>
-        <rdfs:label>editor preferred term~editor preferred label</rdfs:label>
-        <rdfs:label>editor preferred label</rdfs:label>
-        <rdfs:label xml:lang="en">editor preferred label</rdfs:label>
-        <rdfs:label xml:lang="en">editor preferred term</rdfs:label>
-        <obo:IAO_0000119 xml:lang="en">GROUP:OBI:&lt;http://purl.obolibrary.org/obo/obi></obo:IAO_0000119>
-        <obo:IAO_0000117 xml:lang="en">PERSON:Daniel Schober</obo:IAO_0000117>
-        <obo:IAO_0000115 xml:lang="en">The concise, meaningful, and human-friendly name for a class or property preferred by the ontology developers. (US-English)</obo:IAO_0000115>
-        <obo:IAO_0000111 xml:lang="en">editor preferred label</obo:IAO_0000111>
-        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/><!-- ready for release -->
-        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
-    </owl:AnnotationProperty>
-    
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#FULL_SYN -->
 
-    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90">
-        <P90>FULL_SYN</P90>
-        <P90>Synonym with Source Data</P90>
-        <rdfs:label>FULL_SYN</rdfs:label>
-    </owl:AnnotationProperty>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97"/>
-        <owl:annotatedTarget>Fully qualified synonym, contains the string, term type, source, and an optional source code if appropriate. Each subfield is deliniated to facilitate interpretation by software.</owl:annotatedTarget>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
-        <owl:annotatedTarget>FULL_SYN</owl:annotatedTarget>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
-        <owl:annotatedTarget>Synonym with Source Data</owl:annotatedTarget>
-    </owl:Axiom>
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#FULL_SYN"/>
     
-    
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#DEFINITION -->
 
-    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97">
-        <P97>English language definitions of what NCI means by the concept. These are limited to 1024 characters. They may also include information about the definition&apos;s source and attribution in a form that can easily be interpreted by software.</P97>
-        <P90>DEFINITION</P90>
-        <P108>DEFINITION</P108>
-        <P106>Conceptual Entity</P106>
-        <NHC0>P97</NHC0>
-        <rdfs:label>DEFINITION</rdfs:label>
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#InvalidAssociationURIAsResource -->
+
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#InvalidAssociationURIAsResource"/>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#NHC0 -->
+
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#NHC0">
+        <NHC0>NHC0</NHC0>
+        <P108>code</P108>
+        <P90>code</P90>
+        <protege:readOnly rdf:datatype="http://www.w3.org/2001/XMLSchema#string">true</protege:readOnly>
+        <rdfs:label>code</rdfs:label>
     </owl:AnnotationProperty>
     <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97"/>
-        <owl:annotatedTarget>English language definitions of what NCI means by the concept. These are limited to 1024 characters. They may also include information about the definition&apos;s source and attribution in a form that can easily be interpreted by software.</owl:annotatedTarget>
-        <P380>060127</P380>
-        <P379>DEFAULT_Review</P379>
-        <P378>NCI</P378>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97"/>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#NHC0"/>
         <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
-        <owl:annotatedTarget>DEFINITION</owl:annotatedTarget>
+        <owl:annotatedTarget>code</owl:annotatedTarget>
+        <P383>PT</P383>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P106 -->
+
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P106">
+        <P108>Semantic_Type</P108>
+        <P90>Semantic_Type</P90>
+        <rdfs:label>Semantic_Type</rdfs:label>
+    </owl:AnnotationProperty>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P106"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
+        <owl:annotatedTarget>Semantic_Type</owl:annotatedTarget>
         <P383>PT</P383>
         <P384>NCI</P384>
     </owl:Axiom>
     
-    <!-- Contributing_Source -->
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P108 -->
+
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P108">
+        <NHC0>P108</NHC0>
+        <P108>Preferred_Name</P108>
+        <P90>Preferred Name</P90>
+        <P90>Preferred Term</P90>
+        <P90>Preferred_Name</P90>
+        <rdfs:label>Preferred_Name</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P207 -->
+
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P207"/>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P317 -->
+
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P317"/>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P322 -->
 
     <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P322">
-        <rdfs:label>Contributing_Source</rdfs:label>
-        <rdfs:range rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Contributing_Source-enum"/>
         <NHC0>P322</NHC0>
         <P106>Conceptual Entity</P106>
         <P108>Contributing_Source</P108>
         <P90>Contributing_Source</P90>
         <P97>This property is used to indicate when a non-EVS entity has contributed to, and has a stake in, a concept.  This is used where such entities, within or outside NCI, have indicated the need to be able to track their own concepts. A single concept can have multiple instances of this property if multiple entities have such a defined stake.</P97>
+        <rdfs:label>Contributing_Source</rdfs:label>
+        <rdfs:range rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Contributing_Source-enum"/>
     </owl:AnnotationProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P322"/>
@@ -269,24 +181,18 @@
         <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97"/>
         <owl:annotatedTarget>This property is used to indicate when a non-EVS entity has contributed to, and has a stake in, a concept.  This is used where such entities, within or outside NCI, have indicated the need to be able to track their own concepts. A single concept can have multiple instances of this property if multiple entities have such a defined stake.</owl:annotatedTarget>
         <P378>NCI</P378>
-        <P379>DEFAULT_Review</P379>
-        <P380>060127</P380>
     </owl:Axiom>
-      
-       <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#ALT_DEFINITION -->
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P325 -->
 
     <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P325">
-        <P97>English language definitions of what a source other than NCI means by the concept. These are limited to 1024 characters. They include information about the definition&apos;s source in a form that can easily be interpreted by software.</P97>
-        <P90>ALT_DEFINITION</P90>
         <NHC0>P325</NHC0>
+        <P90>ALT_DEFINITION</P90>
+        <P97>English language definitions of what a source other than NCI means by the concept. These are limited to 1024 characters. They include information about the definition&apos;s source in a form that can easily be interpreted by software.</P97>
         <rdfs:label>ALT_DEFINITION</rdfs:label>
     </owl:AnnotationProperty>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P325"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97"/>
-        <owl:annotatedTarget>English language definitions of what a source other than NCI means by the concept. These are limited to 1024 characters. They include information about the definition&apos;s source in a form that can easily be interpreted by software.</owl:annotatedTarget>
-        <P378>NCI</P378>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P325"/>
         <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
@@ -294,18 +200,32 @@
         <P383>PT</P383>
         <P384>NCI</P384>
     </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P325"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97"/>
+        <owl:annotatedTarget>English language definitions of what a source other than NCI means by the concept. These are limited to 1024 characters. They include information about the definition&apos;s source in a form that can easily be interpreted by software.</owl:annotatedTarget>
+        <P378>NCI</P378>
+    </owl:Axiom>
     
-        <!-- Publish_Value_Set -->
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P366 -->
+
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P366"/>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P372 -->
 
     <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P372">
-        <rdfs:label>Publish_Value_Set</rdfs:label>
-        <rdfs:range rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Publish_Value_Set-enum"/>
         <NHC0>P372</NHC0>
         <P106>Conceptual Entity</P106>
         <P108>Publish_Value_Set</P108>
         <P90>Publish_Value_Set</P90>
         <P95>This property will be used internally, and scrubbed before publication to the ftp and browser.</P95>
         <P97>Indicates whether or not a value set is ready for publication in the browser.</P97>
+        <rdfs:label>Publish_Value_Set</rdfs:label>
+        <rdfs:range rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Publish_Value_Set-enum"/>
     </owl:AnnotationProperty>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P372"/>
@@ -319,127 +239,355 @@
         <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97"/>
         <owl:annotatedTarget>Indicates whether or not a value set is ready for publication in the browser.</owl:annotatedTarget>
         <P378>NCI</P378>
-        <P379>Elizabeth Hahn-Dantona</P379>
-        <P380>160413</P380>
     </owl:Axiom>
     
-    
-       <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Term_Browser_Value_Set_Description -->
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P376 -->
 
     <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P376">
         <P90>Term_Browser_Value_Set_Description</P90>
+        <P97>Used to house the text on the introductory page on the NCI Term Browser for the Value Set named by a concept when that text differs from the DEFINITION for that concept.</P97>
         <rdfs:label>Term_Browser_Value_Set_Description</rdfs:label>
     </owl:AnnotationProperty>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P376"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97"/>
-        <owl:annotatedTarget>Used to house the text on the introductory page on the NCI Term Browser for the Value Set named by a concept when that text differs from the DEFINITION for that concept.</owl:annotatedTarget>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P376"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
-        <owl:annotatedTarget>Term_Browser_Value_Set_Description</owl:annotatedTarget>
-    </owl:Axiom>
-    
-    
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Concept_In_Subset -->
-
-    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#A8">
-        <P90>Concept_In_Subset</P90>
-        <rdfs:label>Concept_In_Subset</rdfs:label>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#anyURI"/>
-    </owl:AnnotationProperty>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#A8"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97"/>
-        <owl:annotatedTarget>Used to associate the concept defining a particular terminology subset with concepts that belong to this subset.</owl:annotatedTarget>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#A8"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
-        <owl:annotatedTarget>Concept_In_Subset</owl:annotatedTarget>
-    </owl:Axiom>
-    
-    <!-- Semantic_Type -->
-
-    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P106">
-        <rdfs:label>Semantic_Type</rdfs:label>
-        <P108>Semantic_Type</P108>
-        <P90>Semantic_Type</P90>
-    </owl:AnnotationProperty>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P106"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
-        <owl:annotatedTarget>Semantic_Type</owl:annotatedTarget>
-        <P383>PT</P383>
-        <P384>NCI</P384>
-    </owl:Axiom>
     
 
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Preferred_Name -->
-    
-    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P108">
-        <P90>Preferred Name</P90>
-        <P90>Preferred Term</P90>
-        <P90>Preferred_Name</P90>
-        <P108>Preferred_Name</P108>
-        <NHC0>P108</NHC0>
-        <rdfs:label>Preferred_Name</rdfs:label>
-    </owl:AnnotationProperty>
 
-    
-        <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#code -->
-
-    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#NHC0">
-        <P90>code</P90>
-        <P108>code</P108>
-        <NHC0>NHC0</NHC0>
-        <protege:readOnly rdf:datatype="http://www.w3.org/2001/XMLSchema#string">true</protege:readOnly>
-        <rdfs:label>code</rdfs:label>
-    </owl:AnnotationProperty>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#NHC0"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
-        <owl:annotatedTarget>code</owl:annotatedTarget>
-        <P383>PT</P383>
-    </owl:Axiom>
-    
-        <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#def-source -->
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P378 -->
 
     <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P378">
-        <P108>def-source</P108>
         <NHC0>P378</NHC0>
+        <P108>def-source</P108>
         <rdfs:label>def-source</rdfs:label>
     </owl:AnnotationProperty>
     
-        <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term-group -->
-
-    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P383">
-        <P108>term-group</P108>
-        <NHC0>P383</NHC0>
-        <rdfs:label>term-group</rdfs:label>
-    </owl:AnnotationProperty>
-    
 
 
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term-name -->
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P382 -->
 
     <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P382">
-        <P108>term-name</P108>
         <NHC0>P382</NHC0>
+        <P108>term-name</P108>
         <rdfs:label>term-name</rdfs:label>
     </owl:AnnotationProperty>
     
 
 
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term-source -->
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P383 -->
+
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P383">
+        <NHC0>P383</NHC0>
+        <P108>term-group</P108>
+        <rdfs:label>term-group</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P384 -->
 
     <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P384">
-        <P108>term-source</P108>
         <NHC0>P384</NHC0>
+        <P108>term-source</P108>
         <rdfs:label>term-source</rdfs:label>
     </owl:AnnotationProperty>
     
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90 -->
+
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90">
+        <P90>FULL_SYN</P90>
+        <P90>Synonym with Source Data</P90>
+        <P97>Fully qualified synonym, contains the string, term type, source, and an optional source code if appropriate. Each subfield is deliniated to facilitate interpretation by software.</P97>
+        <rdfs:label>FULL_SYN</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P95 -->
+
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P95"/>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97 -->
+
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97">
+        <NHC0>P97</NHC0>
+        <P106>Conceptual Entity</P106>
+        <P108>DEFINITION</P108>
+        <P90>DEFINITION</P90>
+        <P97>English language definitions of what NCI means by the concept. These are limited to 1024 characters. They may also include information about the definition&apos;s source and attribution in a form that can easily be interpreted by software.</P97>
+        <rdfs:label>DEFINITION</rdfs:label>
+    </owl:AnnotationProperty>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97"/>
+        <owl:annotatedTarget>English language definitions of what NCI means by the concept. These are limited to 1024 characters. They may also include information about the definition&apos;s source and attribution in a form that can easily be interpreted by software.</owl:annotatedTarget>
+        <P378>NCI</P378>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
+        <owl:annotatedTarget>DEFINITION</owl:annotatedTarget>
+        <P383>PT</P383>
+        <P384>NCI</P384>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Preferred_Name -->
+
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Preferred_Name"/>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Semantic_Type -->
+
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Semantic_Type"/>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#code -->
+
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#code"/>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#definition -->
+
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#definition"/>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#note -->
+
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#note"/>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#provenance -->
+
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#provenance"/>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#semanticType -->
+
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#semanticType"/>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#source -->
+
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#source"/>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term -->
+
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term"/>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term_type -->
+
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term_type"/>
+    
+
+
+    <!-- http://protege.stanford.edu/plugins/owl/protege#readOnly -->
+
+    <owl:AnnotationProperty rdf:about="http://protege.stanford.edu/plugins/owl/protege#readOnly"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/BFO_0000179 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/BFO_0000179"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/BFO_0000180 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/BFO_0000180"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000111 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000111">
+        <obo:IAO_0000111 xml:lang="en">editor preferred label</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000115 xml:lang="en">The concise, meaningful, and human-friendly name for a class or property preferred by the ontology developers. (US-English)</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Daniel Schober</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">GROUP:OBI:&lt;http://purl.obolibrary.org/obo/obi&gt;</obo:IAO_0000119>
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label>editor preferred label</rdfs:label>
+        <rdfs:label xml:lang="en">editor preferred label</rdfs:label>
+        <rdfs:label>editor preferred term</rdfs:label>
+        <rdfs:label xml:lang="en">editor preferred term</rdfs:label>
+        <rdfs:label>editor preferred term~editor preferred label</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000112 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000112"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000114 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000114">
+        <obo:IAO_0000111 xml:lang="en">has curation status</obo:IAO_0000111>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Bill Bug</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Melanie Courtot</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">OBI_0000281</obo:IAO_0000119>
+        <rdfs:label xml:lang="en">has curation status</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000115 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000115"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000116 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000116"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000117 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000117"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000118 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000118"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000119 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000119"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000232 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000232"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000412 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000412">
+        <obo:IAO_0000111 xml:lang="en">imported from</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+        <obo:IAO_0000115 xml:lang="en">For external terms/classes, the ontology from which the term was imported</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Melanie Courtot</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">GROUP:OBI:&lt;http://purl.obolibrary.org/obo/obi&gt;</obo:IAO_0000119>
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">imported from</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000600 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000600"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000601 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000601"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000602 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000602"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0010000 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0010000">
+        <obo:IAO_0000111 xml:lang="en">has axiom label</obo:IAO_0000111>
+        <obo:IAO_0000117 xml:lang="en">Person:Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">Person:Alan Ruttenberg</obo:IAO_0000119>
+        <obo:IAO_0000600 xml:lang="en">A URI that is intended to be unique label for an axiom used for tracking change to the ontology. For an axiom expressed in different languages, each expression is given the same URI</obo:IAO_0000600>
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">has axiom label</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0100001 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0100001">
+        <obo:IAO_0000111 xml:lang="en">term replaced by</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+        <obo:IAO_0000115 xml:lang="en">Add as annotation triples in the granting ontology</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Use on obsolete terms, relating the term to another term that can be used as a substitute</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Person:Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">Person:Alan Ruttenberg</obo:IAO_0000119>
+        <rdfs:label xml:lang="en">term replaced by</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_9991118 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/OBI_9991118"/>
+    
+
+
+    <!-- http://purl.org/dc/elements/1.1/date -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/date"/>
+    
+
+
+    <!-- http://purl.org/dc/elements/1.1/source -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/source"/>
+    
+
+
+    <!-- http://www.w3.org/2002/07/owl#minCardinality -->
+
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2002/07/owl#minCardinality"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Datatypes
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://www.w3.org/2001/XMLScheme#string -->
+
+    <rdfs:Datatype rdf:about="http://www.w3.org/2001/XMLScheme#string"/>
+    
+
+
     <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //
@@ -453,101 +601,67 @@
 
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationV1 -->
 
-    <owl:ObjectProperty rdf:about="&owl2lexevs;AssociationV1">
-        <term rdf:datatype="&xsd;string">Association</term>
+    <owl:ObjectProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationV1"/>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#R81 -->
+
+    <owl:ObjectProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#R81">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
+        <rdfs:domain rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C12219"/>
+        <rdfs:range rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C12219"/>
+        <code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R81</code>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Anatomic_Structure_Has_Location</rdfs:label>
     </owl:ObjectProperty>
     
 
 
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#gene_expressed_in -->
 
-    <owl:ObjectProperty rdf:about="&owl2lexevs;gene_expressed_in">
-        <term rdf:datatype="&xsd;string">gene expressed in</term>
+    <owl:ObjectProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#gene_expressed_in">
+        <term rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gene expressed in</term>
     </owl:ObjectProperty>
     <owl:Axiom>
-        <term_type rdf:datatype="&xsd;string">PT</term_type>
-        <owl:annotatedTarget rdf:datatype="&xsd;string">gene expressed in</owl:annotatedTarget>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;gene_expressed_in"/>
-        <owl:annotatedProperty rdf:resource="&owl2lexevs;term"/>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#gene_expressed_in"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gene expressed in</owl:annotatedTarget>
+        <term_type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PT</term_type>
     </owl:Axiom>
     
 
 
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#gene_related_to_disease -->
 
-    <owl:ObjectProperty rdf:about="&owl2lexevs;gene_related_to_disease">
-        <rdfs:domain rdf:resource="&owl2lexevs;C123"/>
-        <rdfs:range rdf:resource="&owl2lexevs;DiseasesDisordersFindings"/>
+    <owl:ObjectProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#gene_related_to_disease">
+        <rdfs:domain rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
+        <rdfs:range rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#DiseasesDisordersFindings"/>
     </owl:ObjectProperty>
     
 
 
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_finding -->
 
-    <owl:ObjectProperty rdf:about="&owl2lexevs;patient_has_finding">
-        <rdfs:range rdf:resource="&owl2lexevs;Finding"/>
+    <owl:ObjectProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_finding">
+        <rdfs:range rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Finding"/>
     </owl:ObjectProperty>
     
 
 
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_prognosis -->
 
-    <owl:ObjectProperty rdf:about="&owl2lexevs;patient_has_prognosis">
-        <rdfs:domain rdf:resource="&owl2lexevs;Patient"/>
-        <rdfs:range rdf:resource="&owl2lexevs;Prognosis"/>
+    <owl:ObjectProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_prognosis">
+        <rdfs:domain rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Patient"/>
+        <rdfs:range rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Prognosis"/>
     </owl:ObjectProperty>
     
-    
-     <!-- http://purl.obolibrary.org/obo/OBI_0000643 -->                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
- <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/OBI_0000643"><!-- has grain -->                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
-     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has grain</rdfs:label>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
-     <obo:IAO_0000119 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PAPER: Granularity, scale and collectivity: When size does and does not matter, Alan Rector, Jeremy Rogers, Thomas Bittner, Journal of Biomedical Informatics 39 (2006) 333-349</obo:IAO_0000119>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
-     <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has grain</obo:IAO_0000111>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
-     <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">the relation of the cells in the finger of the skin to the finger, in which an indeterminate number of grains are parts of the whole by virtue of being grains in a collective that is part of the whole, and in which removing one granular part does not nec- essarily damage or diminish the whole. Ontological Whether there is a fixed, or nearly fixed number of parts - e.g. fingers of the hand, chambers of the heart, or wheels of a car - such that there can be a notion of a single one being missing, or whether, by contrast, the number of parts is indeterminate - e.g., cells in the skin of the hand, red cells in blood, or rubber molecules in the tread of the tire of the wheel of the car.</obo:IAO_0000115>                          
-     <obo:IAO_0000116 xml:lang="en">Discussion in Karslruhe with, among others, Alan Rector, Stefan Schulz, Marijke Keet, Melanie Courtot, and Alan Ruttenberg. Definition take from the definition of granular parthood in the cited paper. Needs work to put into standard form</obo:IAO_0000116>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
-     <obo:IAO_0000117 xml:lang="en">PERSON: Alan Ruttenberg</obo:IAO_0000117>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              
-     <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/><!-- has part -->                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      
-     <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/><!-- metadata complete -->                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
- </owl:ObjectProperty>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     
-                                  
-                                                                                                                                                                                                                                                                                                                                            
-  <!-- http://purl.obolibrary.org/obo/OBI_0000312 -->                                                                                                                                                                                                                                                     
-                                                                                                                                                                                                                                                                                                          
-  <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/OBI_0000312"><!-- is_specified_output_of -->                                                                                                                                                                                              
-      <rdfs:label xml:lang="en">is_specified_output_of</rdfs:label>                                                                                                                                                                                                                                       
-      <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PERSON:Bjoern Peters</obo:IAO_0000117>                                                                                                                                                                                      
-      <obo:IAO_0000115 xml:lang="en">A relation between a planned process and a continuant participating in that process. The presence of the continuant at the end of the process is explicitly specified in the objective specification which the process realizes the concretization of.</obo:IAO_0000115>
-      <obo:IAO_0000117 xml:lang="en">Alan Ruttenberg</obo:IAO_0000117>                                                                                                                                                                                                                                    
-      <obo:IAO_0000111 xml:lang="en">is_specified_output_of</obo:IAO_0000111>                                                                                                                                                                                                                             
-      <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/><!-- ready for release -->                                                                                                                                                                                              
-      <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/OBI_0000011"/><!-- planned process -->                                                                                                                                                                                                     
-      <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000056"/><!-- participates in -->                                                                                                                                                                                              
-      <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>                                                                                                                                                                                                                            
-  </owl:ObjectProperty>                                                                                                                                                                                                                                                                                   
-                                                                                                                                                                                                                                                                                                          
-    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0000087"><!-- has role -->
-        <rdfs:label xml:lang="en">has role</rdfs:label>
-        <obo:IAO_0000116 xml:lang="en">A bearer can have many roles, and its roles can exist for different periods of time, but none of its roles can exist when the bearer does not exist. A role need not be realized at all the times that the role exists.</obo:IAO_0000116>
-        <obo:IAO_0000115 xml:lang="en">a relation between an independent continuant (the bearer) and a role, in which the role specifically depends on the bearer for its existence</obo:IAO_0000115>
-        <obo:IAO_0000111 xml:lang="en">has role</obo:IAO_0000111>
-        <obo:IAO_0000118 xml:lang="en">has_role</obo:IAO_0000118>
-        <obo:IAO_0000112 xml:lang="en">this person has role this investigator role (more colloquially: this person has this role of investigator)</obo:IAO_0000112>
-        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000004"/><!-- independent continuant -->
-        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/BFO_0000023"/><!-- role -->
-        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000053"/><!-- bearer of -->
-        <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000081"/><!-- role of -->
-    </owl:ObjectProperty>                                                                                                                                                                                                                                                                                      
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
-       <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Anatomic_Structure_Has_Location -->
 
-    <owl:ObjectProperty rdf:about="#R81">
-        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Anatomic_Structure_Has_Location</rdfs:label>
-        <code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R81</code>
-        <rdfs:range rdf:resource="#C12219"/>
-        <rdfs:domain rdf:resource="#C12219"/>
-    </owl:ObjectProperty>
+
+    <!-- http://purl.obolibrary.org/obo/BFO_0000051 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/BFO_0000051"/>
+    
+
 
     <!-- http://purl.obolibrary.org/obo/BFO_0000062 -->
 
@@ -577,6 +691,8 @@
         <rdfs:label xml:lang="en">precedes</rdfs:label>
     </owl:ObjectProperty>
     
+
+
     <!-- http://purl.obolibrary.org/obo/BSO_0000062 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/BSO_0000062">
@@ -597,7 +713,6 @@
     <!-- http://purl.obolibrary.org/obo/BSO_0000063 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/BSO_0000063">
-        <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/BSO_0000062"/>
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002222"/>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000003"/>
@@ -606,6 +721,116 @@
         <rdfs:label xml:lang="en">unwilling</rdfs:label>
     </owl:ObjectProperty>
     
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000136 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000136"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0000293 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/OBI_0000293"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0000299 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/OBI_0000299"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0000312 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/OBI_0000312">
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000056"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/OBI_0000011"/>
+        <obo:IAO_0000111 xml:lang="en">is_specified_output_of</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000115 xml:lang="en">A relation between a planned process and a continuant participating in that process. The presence of the continuant at the end of the process is explicitly specified in the objective specification which the process realizes the concretization of.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PERSON:Bjoern Peters</obo:IAO_0000117>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+        <rdfs:label xml:lang="en">is_specified_output_of</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0000417 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/OBI_0000417"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0000643 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/OBI_0000643">
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has grain</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">the relation of the cells in the finger of the skin to the finger, in which an indeterminate number of grains are parts of the whole by virtue of being grains in a collective that is part of the whole, and in which removing one granular part does not nec- essarily damage or diminish the whole. Ontological Whether there is a fixed, or nearly fixed number of parts - e.g. fingers of the hand, chambers of the heart, or wheels of a car - such that there can be a notion of a single one being missing, or whether, by contrast, the number of parts is indeterminate - e.g., cells in the skin of the hand, red cells in blood, or rubber molecules in the tread of the tire of the wheel of the car.</obo:IAO_0000115>
+        <obo:IAO_0000116 xml:lang="en">Discussion in Karslruhe with, among others, Alan Rector, Stefan Schulz, Marijke Keet, Melanie Courtot, and Alan Ruttenberg. Definition take from the definition of granular parthood in the cited paper. Needs work to put into standard form</obo:IAO_0000116>
+        <obo:IAO_0000117 xml:lang="en">PERSON: Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000119 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PAPER: Granularity, scale and collectivity: When size does and does not matter, Alan Rector, Jeremy Rogers, Thomas Bittner, Journal of Biomedical Informatics 39 (2006) 333-349</obo:IAO_0000119>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has grain</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0001938 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/OBI_0001938"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/RO_0000053 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0000053"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/RO_0000056 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0000056"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/RO_0000081 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0000081">
+        <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/RO_0000087 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0000087">
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000053"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000004"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/BFO_0000023"/>
+        <obo:IAO_0000111 xml:lang="en">has role</obo:IAO_0000111>
+        <obo:IAO_0000112 xml:lang="en">this person has role this investigator role (more colloquially: this person has this role of investigator)</obo:IAO_0000112>
+        <obo:IAO_0000115 xml:lang="en">a relation between an independent continuant (the bearer) and a role, in which the role specifically depends on the bearer for its existence</obo:IAO_0000115>
+        <obo:IAO_0000116 xml:lang="en">A bearer can have many roles, and its roles can exist for different periods of time, but none of its roles can exist when the bearer does not exist. A role need not be realized at all the times that the role exists.</obo:IAO_0000116>
+        <obo:IAO_0000118 xml:lang="en">has_role</obo:IAO_0000118>
+        <rdfs:label xml:lang="en">has role</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/RO_0001000 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0001000"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/RO_0002222 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002222"/>
+    
+
 
     <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
@@ -620,52 +845,51 @@
 
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#has_physical_location -->
 
-    <owl:DatatypeProperty rdf:about="&owl2lexevs;has_physical_location"/>
+    <owl:DatatypeProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#has_physical_location"/>
     
 
 
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#in_organism -->
 
-    <owl:DatatypeProperty rdf:about="&owl2lexevs;in_organism">
-        <definition rdf:datatype="&xsd;string">hello there</definition>
-        <rdfs:range rdf:resource="&xsd;string"/>
+    <owl:DatatypeProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#in_organism">
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hello there</definition>
     </owl:DatatypeProperty>
     <owl:Axiom>
-        <owl:annotatedTarget rdf:datatype="&xsd;string">hello there</owl:annotatedTarget>
-        <provenance rdf:datatype="&xsd;string">somebody said so</provenance>
-        <owl:annotatedProperty rdf:resource="&owl2lexevs;definition"/>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;in_organism"/>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#in_organism"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#definition"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hello there</owl:annotatedTarget>
+        <provenance rdf:datatype="http://www.w3.org/2001/XMLSchema#string">somebody said so</provenance>
     </owl:Axiom>
     
 
 
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#semanticType -->
 
-    <owl:DatatypeProperty rdf:about="&owl2lexevs;semanticType">
-        <semanticType rdf:datatype="&xsd;string">Conceptual</semanticType>
+    <owl:DatatypeProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#semanticType">
         <rdfs:range>
             <rdfs:Datatype>
                 <owl:oneOf>
                     <rdf:Description>
-                        <rdf:type rdf:resource="&rdf;List"/>
+                        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
                         <rdf:first>Anatomic</rdf:first>
                         <rdf:rest>
                             <rdf:Description>
-                                <rdf:type rdf:resource="&rdf;List"/>
+                                <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
                                 <rdf:first>Conceptual</rdf:first>
                                 <rdf:rest>
                                     <rdf:Description>
-                                        <rdf:type rdf:resource="&rdf;List"/>
+                                        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
                                         <rdf:first>Disease</rdf:first>
                                         <rdf:rest>
                                             <rdf:Description>
-                                                <rdf:type rdf:resource="&rdf;List"/>
+                                                <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
                                                 <rdf:first>Gene</rdf:first>
                                                 <rdf:rest>
                                                     <rdf:Description>
-                                                        <rdf:type rdf:resource="&rdf;List"/>
+                                                        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#List"/>
                                                         <rdf:first>Organism</rdf:first>
-                                                        <rdf:rest rdf:resource="&rdf;nil"/>
+                                                        <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
                                                     </rdf:Description>
                                                 </rdf:rest>
                                             </rdf:Description>
@@ -680,7 +904,21 @@
         </rdfs:range>
     </owl:DatatypeProperty>
     
-        <!-- http://purl.obolibrary.org/obo/OBI_0001937 -->
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000004 -->
+
+    <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000004">
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topDataProperty"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/IAO_0000032"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#double"/>
+        <rdfs:label xml:lang="en">has measurement value</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0001937 -->
 
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/OBI_0001937">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0002135"/>
@@ -695,16 +933,11 @@
         <rdfs:label>has specified numeric value</rdfs:label>
     </owl:DatatypeProperty>
     
-        <!-- http://purl.obolibrary.org/obo/IAO_0000004 -->
 
-    <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000004">
-        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topDataProperty"/>
-        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
-        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/IAO_0000032"/>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#double"/>
-        <rdfs:label xml:lang="en">has measurement value</rdfs:label>
-    </owl:DatatypeProperty>
-    
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0002135 -->
+
+    <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/OBI_0002135"/>
     
 
 
@@ -721,13 +954,13 @@
 
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#BRaf -->
 
-    <owl:Class rdf:about="&owl2lexevs;BRaf">
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#BRaf">
         <owl:equivalentClass>
             <owl:Class>
                 <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&owl2lexevs;C123"/>
+                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
                     <owl:Restriction>
-                        <owl:onProperty rdf:resource="&owl2lexevs;gene_expressed_in"/>
+                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#gene_expressed_in"/>
                         <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CL_0000148"/>
                     </owl:Restriction>
                 </owl:intersectionOf>
@@ -735,39 +968,39 @@
         </owl:equivalentClass>
     </owl:Class>
     <owl:Axiom>
-        <note rdf:datatype="&xsd;string">test of annotation on object restriction subclass to external class</note>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;BRaf"/>
-        <owl:annotatedProperty rdf:resource="&owl;equivalentClass"/>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#BRaf"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
         <owl:annotatedTarget>
             <owl:Class>
                 <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&owl2lexevs;C123"/>
+                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
                     <owl:Restriction>
-                        <owl:onProperty rdf:resource="&owl2lexevs;gene_expressed_in"/>
+                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#gene_expressed_in"/>
                         <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CL_0000148"/>
                     </owl:Restriction>
                 </owl:intersectionOf>
             </owl:Class>
         </owl:annotatedTarget>
+        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">test of annotation on object restriction subclass to external class</note>
     </owl:Axiom>
     
 
 
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Brca1 -->
 
-    <owl:Class rdf:about="&owl2lexevs;Brca1">
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Brca1">
         <owl:equivalentClass>
             <owl:Class>
                 <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&owl2lexevs;C123"/>
+                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="&owl2lexevs;gene_expressed_in"/>
-                                <owl:someValuesFrom rdf:resource="&owl2lexevs;EpithelialCell"/>
+                                <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#gene_expressed_in"/>
+                                <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#EpithelialCell"/>
                             </owl:Restriction>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="&owl2lexevs;in_organism"/>
+                                <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#in_organism"/>
                                 <owl:hasValue>homo sapiens</owl:hasValue>
                             </owl:Restriction>
                         </owl:intersectionOf>
@@ -777,21 +1010,20 @@
         </owl:equivalentClass>
     </owl:Class>
     <owl:Axiom>
-        <note rdf:datatype="&xsd;string">test of annotation on intersection of datatype and object restriction subclass</note>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;Brca1"/>
-        <owl:annotatedProperty rdf:resource="&owl;equivalentClass"/>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Brca1"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
         <owl:annotatedTarget>
             <owl:Class>
                 <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&owl2lexevs;C123"/>
+                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="&owl2lexevs;gene_expressed_in"/>
-                                <owl:someValuesFrom rdf:resource="&owl2lexevs;EpithelialCell"/>
+                                <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#gene_expressed_in"/>
+                                <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#EpithelialCell"/>
                             </owl:Restriction>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="&owl2lexevs;in_organism"/>
+                                <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#in_organism"/>
                                 <owl:hasValue>homo sapiens</owl:hasValue>
                             </owl:Restriction>
                         </owl:intersectionOf>
@@ -799,1562 +1031,21 @@
                 </owl:intersectionOf>
             </owl:Class>
         </owl:annotatedTarget>
+        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">test of annotation on intersection of datatype and object restriction subclass</note>
     </owl:Axiom>
     
 
 
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123 -->
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C117743 -->
 
-    <owl:Class rdf:about="&owl2lexevs;C123">
-        <rdfs:label>Gene</rdfs:label>
-        <definition rdf:datatype="&xsd;string">The fundamental unit of heredity.</definition>
-        <term>gene</term>
-        <owl:disjointUnionOf rdf:parseType="Collection">
-            <rdf:Description rdf:about="&owl2lexevs;BRaf"/>
-            <rdf:Description rdf:about="&owl2lexevs;Erbb2"/>
-            <rdf:Description rdf:about="&owl2lexevs;Mefv"/>
-            <rdf:Description rdf:about="&owl2lexevs;Ras"/>
-            <rdf:Description rdf:about="&owl2lexevs;SHH"/>
-            <rdf:Description rdf:about="&owl2lexevs;SOS"/>
-            <rdf:Description rdf:about="&owl2lexevs;actin"/>
-            <rdf:Description rdf:about="&owl2lexevs;k-Ras"/>
-        </owl:disjointUnionOf>
-    </owl:Class>
-    <owl:Axiom>
-        <term_type rdf:datatype="&xsd;string">PT</term_type>
-        <source rdf:datatype="&xsd;string">Wikipedia</source>
-        <owl:annotatedTarget>gene</owl:annotatedTarget>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;C123"/>
-        <owl:annotatedProperty rdf:resource="&owl2lexevs;term"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <source rdf:datatype="&xsd;string">Encyclopedia</source>
-        <provenance rdf:datatype="&xsd;string">Gregor Mendel</provenance>
-        <owl:annotatedTarget rdf:datatype="&xsd;string">The fundamental unit of heredity.</owl:annotatedTarget>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;C123"/>
-        <owl:annotatedProperty rdf:resource="&owl2lexevs;definition"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <note rdf:datatype="&xsd;string">all genes are disjoint.  splicing variants are not considered individual genes.</note>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;C123"/>
-        <owl:annotatedProperty rdf:resource="&owl;disjointUnionOf"/>
-        <owl:annotatedTarget rdf:parseType="Collection">
-            <rdf:Description rdf:about="&owl2lexevs;BRaf"/>
-            <rdf:Description rdf:about="&owl2lexevs;Erbb2"/>
-            <rdf:Description rdf:about="&owl2lexevs;Mefv"/>
-            <rdf:Description rdf:about="&owl2lexevs;Ras"/>
-            <rdf:Description rdf:about="&owl2lexevs;SHH"/>
-            <rdf:Description rdf:about="&owl2lexevs;SOS"/>
-            <rdf:Description rdf:about="&owl2lexevs;actin"/>
-            <rdf:Description rdf:about="&owl2lexevs;k-Ras"/>
-        </owl:annotatedTarget>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#CancerPatient -->
-
-    <owl:Class rdf:about="&owl2lexevs;CancerPatient">
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&owl2lexevs;SickPatient"/>
-                    <owl:Class>
-                        <owl:unionOf rdf:parseType="Collection">
-                            <owl:Class>
-                                <owl:intersectionOf rdf:parseType="Collection">
-                                    <owl:Restriction>
-                                        <owl:onProperty rdf:resource="&owl2lexevs;patient_has_finding"/>
-                                        <owl:someValuesFrom rdf:resource="&owl2lexevs;TumorBenign"/>
-                                    </owl:Restriction>
-                                    <owl:Restriction>
-                                        <owl:onProperty rdf:resource="&owl2lexevs;patient_has_prognosis"/>
-                                        <owl:someValuesFrom rdf:resource="&owl2lexevs;PrognosisGood"/>
-                                    </owl:Restriction>
-                                </owl:intersectionOf>
-                            </owl:Class>
-                            <owl:Class>
-                                <owl:intersectionOf rdf:parseType="Collection">
-                                    <owl:Restriction>
-                                        <owl:onProperty rdf:resource="&owl2lexevs;patient_has_finding"/>
-                                        <owl:someValuesFrom rdf:resource="&owl2lexevs;TumorMalignant"/>
-                                    </owl:Restriction>
-                                    <owl:Restriction>
-                                        <owl:onProperty rdf:resource="&owl2lexevs;patient_has_prognosis"/>
-                                        <owl:someValuesFrom rdf:resource="&owl2lexevs;PrognosisBad"/>
-                                    </owl:Restriction>
-                                </owl:intersectionOf>
-                            </owl:Class>
-                        </owl:unionOf>
-                    </owl:Class>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
-    </owl:Class>
-    <owl:Axiom>
-        <note rdf:datatype="&xsd;string">test of annotation on role group subclass</note>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;CancerPatient"/>
-        <owl:annotatedProperty rdf:resource="&owl;equivalentClass"/>
-        <owl:annotatedTarget>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&owl2lexevs;SickPatient"/>
-                    <owl:Class>
-                        <owl:unionOf rdf:parseType="Collection">
-                            <owl:Class>
-                                <owl:intersectionOf rdf:parseType="Collection">
-                                    <owl:Restriction>
-                                        <owl:onProperty rdf:resource="&owl2lexevs;patient_has_finding"/>
-                                        <owl:someValuesFrom rdf:resource="&owl2lexevs;TumorBenign"/>
-                                    </owl:Restriction>
-                                    <owl:Restriction>
-                                        <owl:onProperty rdf:resource="&owl2lexevs;patient_has_prognosis"/>
-                                        <owl:someValuesFrom rdf:resource="&owl2lexevs;PrognosisGood"/>
-                                    </owl:Restriction>
-                                </owl:intersectionOf>
-                            </owl:Class>
-                            <owl:Class>
-                                <owl:intersectionOf rdf:parseType="Collection">
-                                    <owl:Restriction>
-                                        <owl:onProperty rdf:resource="&owl2lexevs;patient_has_finding"/>
-                                        <owl:someValuesFrom rdf:resource="&owl2lexevs;TumorMalignant"/>
-                                    </owl:Restriction>
-                                    <owl:Restriction>
-                                        <owl:onProperty rdf:resource="&owl2lexevs;patient_has_prognosis"/>
-                                        <owl:someValuesFrom rdf:resource="&owl2lexevs;PrognosisBad"/>
-                                    </owl:Restriction>
-                                </owl:intersectionOf>
-                            </owl:Class>
-                        </owl:unionOf>
-                    </owl:Class>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:annotatedTarget>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Cold -->
-
-    <owl:Class rdf:about="&owl2lexevs;Cold">
-        <rdfs:subClassOf rdf:resource="&owl2lexevs;Disease"/>
-    </owl:Class>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Disease -->
-
-    <owl:Class rdf:about="&owl2lexevs;Disease">
-        <rdfs:subClassOf rdf:resource="&owl2lexevs;DiseasesDisordersFindings"/>
-        <term>disease</term>
-        <definition>any entity that impacts the health of a patient.</definition>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedTarget>disease</owl:annotatedTarget>
-        <term_type>pt</term_type>
-        <source>nci</source>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;Disease"/>
-        <owl:annotatedProperty rdf:resource="&owl2lexevs;term"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <definition rdf:datatype="&xsd;string">One of the three entities in the parent covering partition.</definition>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;Disease"/>
-        <owl:annotatedTarget rdf:resource="&owl2lexevs;DiseasesDisordersFindings"/>
-        <owl:annotatedProperty rdf:resource="&rdfs;subClassOf"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedTarget>any entity that impacts the health of a patient.</owl:annotatedTarget>
-        <source>nih</source>
-        <provenance>joe blow via lily librarian</provenance>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;Disease"/>
-        <owl:annotatedProperty rdf:resource="&owl2lexevs;definition"/>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#DiseasesDisordersFindings -->
-
-    <owl:Class rdf:about="&owl2lexevs;DiseasesDisordersFindings">
-        <owl:disjointWith rdf:resource="&owl2lexevs;Person"/>
-        <definition>any entitie categorized as a disease, a disorder, or a finding.</definition>
-        <term>diseases, disorders, and findings</term>
-    </owl:Class>
-    <owl:Axiom>
-        <source>ctep</source>
-        <owl:annotatedTarget>any entitie categorized as a disease, a disorder, or a finding.</owl:annotatedTarget>
-        <provenance>pers. comm.</provenance>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;DiseasesDisordersFindings"/>
-        <owl:annotatedProperty rdf:resource="&owl2lexevs;definition"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <source>nci</source>
-        <owl:annotatedTarget>diseases, disorders, and findings</owl:annotatedTarget>
-        <term_type>sy</term_type>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;DiseasesDisordersFindings"/>
-        <owl:annotatedProperty rdf:resource="&owl2lexevs;term"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <note>treat disorders as always disjoint with people.</note>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;DiseasesDisordersFindings"/>
-        <owl:annotatedTarget rdf:resource="&owl2lexevs;Person"/>
-        <owl:annotatedProperty rdf:resource="&owl;disjointWith"/>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#EpithelialCell -->
-
-    <owl:Class rdf:about="&owl2lexevs;EpithelialCell">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL_0000000"/>
-        <term>epithelial cell</term>
-        <definition>a cell located in an epithelial surface.</definition>
-    </owl:Class>
-    <owl:Axiom>
-        <source rdf:datatype="&xsd;string">caDSR</source>
-        <term_type>pt</term_type>
-        <owl:annotatedTarget>epithelial cell</owl:annotatedTarget>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;EpithelialCell"/>
-        <owl:annotatedProperty rdf:resource="&owl2lexevs;term"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <definition rdf:datatype="&xsd;string">an isa relation to an external entity.</definition>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;EpithelialCell"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/CL_0000000"/>
-        <owl:annotatedProperty rdf:resource="&rdfs;subClassOf"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <provenance rdf:datatype="&xsd;string">NLM</provenance>
-        <source>nci</source>
-        <owl:annotatedTarget>a cell located in an epithelial surface.</owl:annotatedTarget>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;EpithelialCell"/>
-        <owl:annotatedProperty rdf:resource="&owl2lexevs;definition"/>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Erbb2 -->
-
-    <owl:Class rdf:about="&owl2lexevs;Erbb2">
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&owl2lexevs;C123"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="&owl2lexevs;gene_expressed_in"/>
-                        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CL_0000148"/>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
-    </owl:Class>
-    <owl:Axiom>
-        <note rdf:datatype="&xsd;string">test of annotation on object restriction subclass to external class</note>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;Erbb2"/>
-        <owl:annotatedProperty rdf:resource="&owl;equivalentClass"/>
-        <owl:annotatedTarget>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&owl2lexevs;C123"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="&owl2lexevs;gene_expressed_in"/>
-                        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CL_0000148"/>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:annotatedTarget>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Finding -->
-
-    <owl:Class rdf:about="&owl2lexevs;Finding">
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&owl2lexevs;DiseasesDisordersFindings"/>
-                    <owl:Class>
-                        <owl:oneOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&owl2lexevs;Fever"/>
-                            <rdf:Description rdf:about="&owl2lexevs;ShallowBreathing"/>
-                            <rdf:Description rdf:about="&owl2lexevs;PaleSkin"/>
-                        </owl:oneOf>
-                    </owl:Class>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
-        <semanticType rdf:datatype="&xsd;string">Disease</semanticType>
-    </owl:Class>
-    <owl:Axiom>
-        <definition rdf:datatype="&xsd;string">One of the three entities in the parent covering partition.</definition>
-        <note rdf:datatype="&xsd;string">the extension of the class</note>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;Finding"/>
-        <owl:annotatedProperty rdf:resource="&owl;equivalentClass"/>
-        <owl:annotatedTarget>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&owl2lexevs;DiseasesDisordersFindings"/>
-                    <owl:Class>
-                        <owl:oneOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&owl2lexevs;Fever"/>
-                            <rdf:Description rdf:about="&owl2lexevs;ShallowBreathing"/>
-                            <rdf:Description rdf:about="&owl2lexevs;PaleSkin"/>
-                        </owl:oneOf>
-                    </owl:Class>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:annotatedTarget>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientDrivingAround -->
-
-    <owl:Class rdf:about="&owl2lexevs;HappyPatientDrivingAround">
-        <rdfs:subClassOf rdf:resource="&owl2lexevs;Patient"/>
-        <AssociationURIAsResource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood"/>
-        <InvalidAssociationURIAsResource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood"/>
-        <AssociationURI rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood"/>
-        <AssociationSTR rdf:datatype="&xsd;string">http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood</AssociationSTR>
-        <AssociationLIT>http://ncicb.nci.nih.gov/xml/owl/evs/owl2lexevs.owl#PrognosisGood</AssociationLIT>
-        <AssociationV1 rdf:resource="&owl2lexevs;PrognosisGood"/>
-        <AssociationURI rdf:resource="&owl2lexevs;PrognosisGood"/>
-    </owl:Class>
-    <owl:Axiom>
-        <note rdf:datatype="&xsd;string">annotation on an AssociationLIT.</note>
-        <owl:annotatedTarget>http://ncicb.nci.nih.gov/xml/owl/evs/owl2lexevs.owl#PrognosisGood</owl:annotatedTarget>
-        <owl:annotatedProperty rdf:resource="&owl2lexevs;AssociationLIT"/>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;HappyPatientDrivingAround"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <note rdf:datatype="&xsd;string">annotation on an AssociationURI of a class (rdf:resource).</note>
-        <owl:annotatedProperty rdf:resource="&owl2lexevs;AssociationURI"/>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;HappyPatientDrivingAround"/>
-        <owl:annotatedTarget rdf:resource="&owl2lexevs;PrognosisGood"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <note rdf:datatype="&xsd;string">annotation on an AssociationSTR.</note>
-        <owl:annotatedTarget rdf:datatype="&xsd;string">http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood</owl:annotatedTarget>
-        <owl:annotatedProperty rdf:resource="&owl2lexevs;AssociationSTR"/>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;HappyPatientDrivingAround"/>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientWalkingAround -->
-
-    <owl:Class rdf:about="&owl2lexevs;HappyPatientWalkingAround">
-        <rdfs:subClassOf rdf:resource="&owl2lexevs;Patient"/>
-        <AssociationURI rdf:datatype="&xsd;anyURI">http://purl.obolibrary.org/obo/CL_0000148</AssociationURI>
-        <AssociationSTR rdf:datatype="&xsd;string">http://purl.obolibrary.org/obo/CL_0000148</AssociationSTR>
-        <AssociationLIT>http://purl.obolibrary.org/obo/cl_0000148</AssociationLIT>
-        <AssociationURI rdf:resource="http://purl.obolibrary.org/obo/CL_0000148"/>
-        <AssociationV1 rdf:resource="http://purl.obolibrary.org/obo/CL_0000148"/>
-    </owl:Class>
-    <owl:Axiom>
-        <note rdf:datatype="&xsd;string">annotation on an AssociationURI of external class (rdf:resource)</note>
-        <owl:annotatedProperty rdf:resource="&owl2lexevs;AssociationURI"/>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;HappyPatientWalkingAround"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/CL_0000148"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <note rdf:datatype="&xsd;string">annotation on an AssociationURI of external.</note>
-        <owl:annotatedTarget rdf:datatype="&xsd;anyURI">http://purl.obolibrary.org/obo/CL_0000148</owl:annotatedTarget>
-        <owl:annotatedProperty rdf:resource="&owl2lexevs;AssociationURI"/>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;HappyPatientWalkingAround"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <note rdf:datatype="&xsd;string">annotation on an AssociationSTR of external.</note>
-        <owl:annotatedTarget rdf:datatype="&xsd;string">http://purl.obolibrary.org/obo/CL_0000148</owl:annotatedTarget>
-        <owl:annotatedProperty rdf:resource="&owl2lexevs;AssociationSTR"/>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;HappyPatientWalkingAround"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <note rdf:datatype="&xsd;string">annotation on an AssociationLIT of external.</note>
-        <owl:annotatedTarget>http://purl.obolibrary.org/obo/cl_0000148</owl:annotatedTarget>
-        <owl:annotatedProperty rdf:resource="&owl2lexevs;AssociationLIT"/>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;HappyPatientWalkingAround"/>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HealthyPatient -->
-
-    <owl:Class rdf:about="&owl2lexevs;HealthyPatient">
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&owl2lexevs;Patient"/>
-                    <owl:Class>
-                        <owl:complementOf rdf:resource="&owl2lexevs;SickPatient"/>
-                    </owl:Class>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
-    </owl:Class>
-    <owl:Axiom>
-        <note rdf:datatype="&xsd;string">definitely you are healthy if you are not sick.</note>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;HealthyPatient"/>
-        <owl:annotatedProperty rdf:resource="&owl;equivalentClass"/>
-        <owl:annotatedTarget>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&owl2lexevs;Patient"/>
-                    <owl:Class>
-                        <owl:complementOf rdf:resource="&owl2lexevs;SickPatient"/>
-                    </owl:Class>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:annotatedTarget>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Mefv -->
-
-    <owl:Class rdf:about="&owl2lexevs;Mefv">
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&owl2lexevs;C123"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="&owl2lexevs;gene_related_to_disease"/>
-                        <owl:hasValue rdf:resource="&owl2lexevs;Fever"/>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
-    </owl:Class>
-    <owl:Axiom>
-        <note rdf:datatype="&xsd;string">test of annotation on object restriction value subclass</note>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;Mefv"/>
-        <owl:annotatedProperty rdf:resource="&owl;equivalentClass"/>
-        <owl:annotatedTarget>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&owl2lexevs;C123"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="&owl2lexevs;gene_related_to_disease"/>
-                        <owl:hasValue rdf:resource="&owl2lexevs;Fever"/>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:annotatedTarget>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#MildlySickCancerPatient -->
-
-    <owl:Class rdf:about="&owl2lexevs;MildlySickCancerPatient">
-        <P108>slightly sick cancer patient</P108>
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&owl2lexevs;MildlySickPatient"/>
-                    <owl:Class>
-                        <owl:intersectionOf rdf:parseType="Collection">
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="&owl2lexevs;patient_has_finding"/>
-                                <owl:someValuesFrom rdf:resource="&owl2lexevs;TumorBenign"/>
-                            </owl:Restriction>
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="&owl2lexevs;patient_has_prognosis"/>
-                                <owl:someValuesFrom rdf:resource="&owl2lexevs;PrognosisGood"/>
-                            </owl:Restriction>
-                        </owl:intersectionOf>
-                    </owl:Class>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
-    </owl:Class>
-    <owl:Axiom>
-        <note rdf:datatype="&xsd;string">test of annotation on intersection of object restriction subclass</note>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;MildlySickCancerPatient"/>
-        <owl:annotatedProperty rdf:resource="&owl;equivalentClass"/>
-        <owl:annotatedTarget>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&owl2lexevs;MildlySickPatient"/>
-                    <owl:Class>
-                        <owl:intersectionOf rdf:parseType="Collection">
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="&owl2lexevs;patient_has_finding"/>
-                                <owl:someValuesFrom rdf:resource="&owl2lexevs;TumorBenign"/>
-                            </owl:Restriction>
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="&owl2lexevs;patient_has_prognosis"/>
-                                <owl:someValuesFrom rdf:resource="&owl2lexevs;PrognosisGood"/>
-                            </owl:Restriction>
-                        </owl:intersectionOf>
-                    </owl:Class>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:annotatedTarget>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#MildlySickPatient -->
-
-    <owl:Class rdf:about="&owl2lexevs;MildlySickPatient">
-        <rdfs:subClassOf rdf:resource="&owl2lexevs;SickPatient"/>
-    </owl:Class>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#NeoplasticDisease -->
-
-    <owl:Class rdf:about="&owl2lexevs;NeoplasticDisease">
-        <rdfs:subClassOf rdf:resource="&owl2lexevs;Disease"/>
-        <semanticType rdf:datatype="&xsd;string">Disease</semanticType>
-    </owl:Class>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#OncogeneTim -->
-
-    <owl:Class rdf:about="&owl2lexevs;OncogeneTim">
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&owl2lexevs;C123"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="&owl2lexevs;has_physical_location"/>
-                        <owl:hasValue rdf:datatype="&xsd;integer">12345</owl:hasValue>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
-    </owl:Class>
-    <owl:Axiom>
-        <note rdf:datatype="&xsd;string">test of annotation on datatype restriction value subclass</note>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;OncogeneTim"/>
-        <owl:annotatedProperty rdf:resource="&owl;equivalentClass"/>
-        <owl:annotatedTarget>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&owl2lexevs;C123"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="&owl2lexevs;has_physical_location"/>
-                        <owl:hasValue rdf:datatype="&xsd;integer">12345</owl:hasValue>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:annotatedTarget>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Patient -->
-
-    <owl:Class rdf:about="&owl2lexevs;Patient">
-        <rdfs:subClassOf rdf:resource="&owl2lexevs;Person"/>
-        <semanticType rdf:datatype="&xsd;string">Organism</semanticType>
-    </owl:Class>
-    <owl:Axiom>
-        <definition rdf:datatype="&xsd;string">a role taken by a person on a health care provider visit.</definition>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;Patient"/>
-        <owl:annotatedTarget rdf:resource="&owl2lexevs;Person"/>
-        <owl:annotatedProperty rdf:resource="&rdfs;subClassOf"/>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PatientWithCold -->
-
-    <owl:Class rdf:about="&owl2lexevs;PatientWithCold">
-        <rdfs:subClassOf rdf:resource="&owl2lexevs;MildlySickPatient"/>
-        <P108>Patient With Cold</P108>
-        <P90>slightly sick patient</P90>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="&owl2lexevs;patient_has_finding"/>
-                <owl:someValuesFrom rdf:resource="&owl2lexevs;Cold"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-    </owl:Class>   
-    <owl:Axiom>
-        <source rdf:datatype="&xsd;string">CDISC</source>
-        <term_type rdf:datatype="&xsd;string">PT</term_type>
-        <owl:annotatedTarget rdf:datatype="&xsd;string">slightly sick patient</owl:annotatedTarget>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;PatientWithCold"/>
-        <owl:annotatedProperty rdf:resource="&owl2lexevs;term"/>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Person -->
-
-    <owl:Class rdf:about="&owl2lexevs;Person">
-        <definition rdf:datatype="&xsd;string">Any human being.</definition>
-        <term rdf:datatype="&xsd;string">Human</term>
-        <term rdf:datatype="&xsd;string">Person</term>
-    </owl:Class>
-    <owl:Axiom>
-        <source rdf:datatype="&xsd;string">NCI</source>
-        <term_type rdf:datatype="&xsd;string">PT</term_type>
-        <owl:annotatedTarget rdf:datatype="&xsd;string">Person</owl:annotatedTarget>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;Person"/>
-        <owl:annotatedProperty rdf:resource="&owl2lexevs;term"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedTarget rdf:datatype="&xsd;string">Any human being.</owl:annotatedTarget>
-        <source rdf:datatype="&xsd;string">common knowledge</source>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;Person"/>
-        <owl:annotatedProperty rdf:resource="&owl2lexevs;definition"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedTarget rdf:datatype="&xsd;string">Human</owl:annotatedTarget>
-        <source rdf:datatype="&xsd;string">LOC</source>
-        <term_type rdf:datatype="&xsd;string">SY</term_type>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;Person"/>
-        <owl:annotatedProperty rdf:resource="&owl2lexevs;term"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <note>treat disorders as always disjoint with people.</note>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;DiseasesDisordersFindings"/>
-        <owl:annotatedTarget rdf:resource="&owl2lexevs;Person"/>
-        <owl:annotatedProperty rdf:resource="&owl;disjointWith"/>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PersonRole -->
-
-    <owl:Class rdf:about="&owl2lexevs;PersonRole">
-        <definition rdf:datatype="&xsd;string">Any role adopted by a person.</definition>
-        <term rdf:datatype="&xsd;string">Personal Role</term>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedTarget rdf:datatype="&xsd;string">Any role adopted by a person.</owl:annotatedTarget>
-        <provenance rdf:datatype="&xsd;string">JQ Public</provenance>
-        <source rdf:datatype="&xsd;string">ONC</source>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;PersonRole"/>
-        <owl:annotatedProperty rdf:resource="&owl2lexevs;definition"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <source rdf:datatype="&xsd;string">NCI</source>
-        <owl:annotatedTarget rdf:datatype="&xsd;string">Personal Role</owl:annotatedTarget>
-        <term_type rdf:datatype="&xsd;string">SY</term_type>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;PersonRole"/>
-        <owl:annotatedProperty rdf:resource="&owl2lexevs;term"/>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Prognosis -->
-
-    <owl:Class rdf:about="&owl2lexevs;Prognosis">
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&owl2lexevs;DiseasesDisordersFindings"/>
-                    <owl:Class>
-                        <owl:unionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&owl2lexevs;PrognosisBad"/>
-                            <rdf:Description rdf:about="&owl2lexevs;PrognosisGood"/>
-                        </owl:unionOf>
-                    </owl:Class>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
-        <semanticType rdf:datatype="&xsd;string">Disease</semanticType>
-    </owl:Class>
-    <owl:Axiom>
-        <definition rdf:datatype="&xsd;string">One of the three entities in the parent covering partition.</definition>
-        <note rdf:datatype="&xsd;string">essentially the sum of subclasses</note>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;Prognosis"/>
-        <owl:annotatedProperty rdf:resource="&owl;equivalentClass"/>
-        <owl:annotatedTarget>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&owl2lexevs;DiseasesDisordersFindings"/>
-                    <owl:Class>
-                        <owl:unionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&owl2lexevs;PrognosisBad"/>
-                            <rdf:Description rdf:about="&owl2lexevs;PrognosisGood"/>
-                        </owl:unionOf>
-                    </owl:Class>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:annotatedTarget>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisBad -->
-
-    <owl:Class rdf:about="&owl2lexevs;PrognosisBad">
-        <rdfs:subClassOf rdf:resource="&owl2lexevs;Prognosis"/>
-    </owl:Class>
-    <owl:Axiom>
-        <definition rdf:datatype="&xsd;string">One of the two entities in the parent undeclared covering partition.</definition>
-        <owl:annotatedTarget rdf:resource="&owl2lexevs;Prognosis"/>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;PrognosisBad"/>
-        <owl:annotatedProperty rdf:resource="&rdfs;subClassOf"/>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood -->
-
-    <owl:Class rdf:about="&owl2lexevs;PrognosisGood">
-        <rdfs:subClassOf rdf:resource="&owl2lexevs;Prognosis"/>
-    </owl:Class>
-    <owl:Axiom>
-        <definition rdf:datatype="&xsd;string">One of the two entities in the parent undeclared covering partition.</definition>
-        <owl:annotatedTarget rdf:resource="&owl2lexevs;Prognosis"/>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;PrognosisGood"/>
-        <owl:annotatedProperty rdf:resource="&rdfs;subClassOf"/>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Ras -->
-
-    <owl:Class rdf:about="&owl2lexevs;Ras">
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&owl2lexevs;C123"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="&owl2lexevs;has_physical_location"/>
-                        <owl:someValuesFrom rdf:resource="&xsd;positiveInteger"/>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
-    </owl:Class>
-    <owl:Axiom>
-        <note rdf:datatype="&xsd;string">test of annotation on datatype restriction subclass</note>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;Ras"/>
-        <owl:annotatedProperty rdf:resource="&owl;equivalentClass"/>
-        <owl:annotatedTarget>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&owl2lexevs;C123"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="&owl2lexevs;has_physical_location"/>
-                        <owl:someValuesFrom rdf:resource="&xsd;positiveInteger"/>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:annotatedTarget>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SHH -->
-
-    <owl:Class rdf:about="&owl2lexevs;SHH">
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&owl2lexevs;C123"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="&owl2lexevs;gene_related_to_disease"/>
-                        <owl:allValuesFrom rdf:resource="&owl2lexevs;NeoplasticDisease"/>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
-    </owl:Class>
-    <owl:Axiom>
-        <note rdf:datatype="&xsd;string">test of annotation on object restriction subclass</note>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;SHH"/>
-        <owl:annotatedProperty rdf:resource="&owl;equivalentClass"/>
-        <owl:annotatedTarget>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&owl2lexevs;C123"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="&owl2lexevs;gene_related_to_disease"/>
-                        <owl:allValuesFrom rdf:resource="&owl2lexevs;NeoplasticDisease"/>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:annotatedTarget>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SOS -->
-
-    <owl:Class rdf:about="&owl2lexevs;SOS">
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&owl2lexevs;C123"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="&owl2lexevs;gene_related_to_disease"/>
-                        <owl:someValuesFrom rdf:resource="&owl2lexevs;NeoplasticDisease"/>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
-    </owl:Class>
-    <owl:Axiom>
-        <note rdf:datatype="&xsd;string">test of annotation on object restriction subclass</note>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;SOS"/>
-        <owl:annotatedProperty rdf:resource="&owl;equivalentClass"/>
-        <owl:annotatedTarget>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&owl2lexevs;C123"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="&owl2lexevs;gene_related_to_disease"/>
-                        <owl:someValuesFrom rdf:resource="&owl2lexevs;NeoplasticDisease"/>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:annotatedTarget>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SickPatient -->
-
-    <owl:Class rdf:about="&owl2lexevs;SickPatient">
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&owl2lexevs;Patient"/>
-                    <owl:Class>
-                        <owl:unionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&owl2lexevs;CancerPatient"/>
-                            <rdf:Description rdf:about="&owl2lexevs;MildlySickPatient"/>
-                            <rdf:Description rdf:about="&owl2lexevs;VerySickPatient"/>
-                        </owl:unionOf>
-                    </owl:Class>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
-    </owl:Class>
-    <owl:Axiom>
-        <note rdf:datatype="&xsd;string">essentially the sum of subclasses</note>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;SickPatient"/>
-        <owl:annotatedProperty rdf:resource="&owl;equivalentClass"/>
-        <owl:annotatedTarget>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&owl2lexevs;Patient"/>
-                    <owl:Class>
-                        <owl:unionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&owl2lexevs;CancerPatient"/>
-                            <rdf:Description rdf:about="&owl2lexevs;MildlySickPatient"/>
-                            <rdf:Description rdf:about="&owl2lexevs;VerySickPatient"/>
-                        </owl:unionOf>
-                    </owl:Class>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:annotatedTarget>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#TotalPerson -->
-
-    <owl:Class rdf:about="&owl2lexevs;TotalPerson">
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&owl2lexevs;Person"/>
-                    <rdf:Description rdf:about="&owl2lexevs;PersonRole"/>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
-    </owl:Class>
-    <owl:Axiom>
-        <note rdf:datatype="&xsd;string">in real life, probably a union.</note>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;TotalPerson"/>
-        <owl:annotatedProperty rdf:resource="&owl;equivalentClass"/>
-        <owl:annotatedTarget>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&owl2lexevs;Person"/>
-                    <rdf:Description rdf:about="&owl2lexevs;PersonRole"/>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:annotatedTarget>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#TumorBenign -->
-
-    <owl:Class rdf:about="&owl2lexevs;TumorBenign">
-        <rdfs:subClassOf rdf:resource="&owl2lexevs;NeoplasticDisease"/>
-    </owl:Class>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#TumorMalignant -->
-
-    <owl:Class rdf:about="&owl2lexevs;TumorMalignant">
-        <rdfs:subClassOf rdf:resource="&owl2lexevs;NeoplasticDisease"/>
-    </owl:Class>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#VerySickCancerPatient -->
-
-    <owl:Class rdf:about="&owl2lexevs;VerySickCancerPatient">
-    		<P108>very sick cancer patient</P108>
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&owl2lexevs;VerySickPatient"/>
-                    <owl:Class>
-                        <owl:unionOf rdf:parseType="Collection">
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="&owl2lexevs;patient_has_finding"/>
-                                <owl:someValuesFrom rdf:resource="&owl2lexevs;TumorMalignant"/>
-                            </owl:Restriction>
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="&owl2lexevs;patient_has_prognosis"/>
-                                <owl:someValuesFrom rdf:resource="&owl2lexevs;PrognosisBad"/>
-                            </owl:Restriction>
-                        </owl:unionOf>
-                    </owl:Class>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
-    </owl:Class>
-    <owl:Axiom>
-        <source rdf:datatype="&xsd;string">NCI</source>
-        <term_type rdf:datatype="&xsd;string">PT</term_type>
-        <owl:annotatedTarget rdf:datatype="&xsd;string">very sick cancer patient</owl:annotatedTarget>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;VerySickCancerPatient"/>
-        <owl:annotatedProperty rdf:resource="&owl2lexevs;term"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <note rdf:datatype="&xsd;string">test of annotation on union of object restriction subclass</note>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;VerySickCancerPatient"/>
-        <owl:annotatedProperty rdf:resource="&owl;equivalentClass"/>
-        <owl:annotatedTarget>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&owl2lexevs;VerySickPatient"/>
-                    <owl:Class>
-                        <owl:unionOf rdf:parseType="Collection">
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="&owl2lexevs;patient_has_finding"/>
-                                <owl:someValuesFrom rdf:resource="&owl2lexevs;TumorMalignant"/>
-                            </owl:Restriction>
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="&owl2lexevs;patient_has_prognosis"/>
-                                <owl:someValuesFrom rdf:resource="&owl2lexevs;PrognosisBad"/>
-                            </owl:Restriction>
-                        </owl:unionOf>
-                    </owl:Class>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:annotatedTarget>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#VerySickPatient -->
-
-    <owl:Class rdf:about="&owl2lexevs;VerySickPatient">
-        <rdfs:subClassOf rdf:resource="&owl2lexevs;SickPatient"/>
-    </owl:Class>
-    <owl:Axiom>
-        <source rdf:datatype="&xsd;string">NCI</source>
-        <term_type rdf:datatype="&xsd;string">PT</term_type>
-        <owl:annotatedTarget rdf:datatype="&xsd;string">very sick patient</owl:annotatedTarget>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;VerySickPatient"/>
-        <owl:annotatedProperty rdf:resource="&owl2lexevs;term"/>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#actin -->
-
-    <owl:Class rdf:about="&owl2lexevs;actin">
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&owl2lexevs;C123"/>
-                    <owl:Class>
-                        <owl:unionOf rdf:parseType="Collection">
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="&owl2lexevs;gene_expressed_in"/>
-                                <owl:someValuesFrom rdf:resource="&owl2lexevs;EpithelialCell"/>
-                            </owl:Restriction>
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="&owl2lexevs;in_organism"/>
-                                <owl:hasValue>all organisms</owl:hasValue>
-                            </owl:Restriction>
-                        </owl:unionOf>
-                    </owl:Class>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
-    </owl:Class>
-    <owl:Axiom>
-        <note rdf:datatype="&xsd;string">test of annotation on union of datatype and object restriction subclass</note>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;actin"/>
-        <owl:annotatedProperty rdf:resource="&owl;equivalentClass"/>
-        <owl:annotatedTarget>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&owl2lexevs;C123"/>
-                    <owl:Class>
-                        <owl:unionOf rdf:parseType="Collection">
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="&owl2lexevs;gene_expressed_in"/>
-                                <owl:someValuesFrom rdf:resource="&owl2lexevs;EpithelialCell"/>
-                            </owl:Restriction>
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="&owl2lexevs;in_organism"/>
-                                <owl:hasValue>all organisms</owl:hasValue>
-                            </owl:Restriction>
-                        </owl:unionOf>
-                    </owl:Class>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:annotatedTarget>
-    </owl:Axiom>
-    
-
-
-    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#k-Ras -->
-
-    <owl:Class rdf:about="&owl2lexevs;k-Ras">
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&owl2lexevs;C123"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="&owl2lexevs;has_physical_location"/>
-                        <owl:allValuesFrom rdf:resource="&xsd;positiveInteger"/>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
-    </owl:Class>
-    <owl:Axiom>
-        <note rdf:datatype="&xsd;string">test of annotation on datatype restriction subclass</note>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;k-Ras"/>
-        <owl:annotatedProperty rdf:resource="&owl;equivalentClass"/>
-        <owl:annotatedTarget>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&owl2lexevs;C123"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="&owl2lexevs;has_physical_location"/>
-                        <owl:allValuesFrom rdf:resource="&xsd;positiveInteger"/>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:annotatedTarget>
-    </owl:Axiom>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/CL_0000000 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_0000000">
-        <rdfs:label>Cell</rdfs:label>
-        <definition>external class from the cl.</definition>
-    </owl:Class>
-    <owl:Axiom>
-        <source>cl</source>
-        <provenance>lily librarian</provenance>
-        <owl:annotatedTarget>external class from the cl.</owl:annotatedTarget>
-        <owl:annotatedProperty rdf:resource="&owl2lexevs;definition"/>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_0000000"/>
-    </owl:Axiom>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/CL_0000148 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_0000148">
-        <rdfs:label>melanocyte</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL_0000000"/>
-    </owl:Class>
-    
-        <!-- http://www.w3.org/2002/07/owl#Nothing -->
-
-    <owl:Class rdf:about="http://www.w3.org/2002/07/owl#Nothing">
-        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Nothing"/>
-    </owl:Class>
-    
-
-
-    <!-- http://www.w3.org/2002/07/owl#Thing -->
-
-    <owl:Class rdf:about="http://www.w3.org/2002/07/owl#Thing"/>
-    
-
-    <!-- http://purl.obolibrary.org/obo/BFO_0000182 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000182"><!-- history -->
-        <rdfs:label xml:lang="en">history</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000015"/><!-- process -->
-        <obo:BFO_0000179>history</obo:BFO_0000179>
-        <obo:BFO_0000180>History</obo:BFO_0000180>
-        <obo:IAO_0000600 xml:lang="en">A history is a process that is the sum of the totality of processes taking place in the spatiotemporal region occupied by a material entity or site, including processes on the surface of the entity or within the cavities to which it serves as host. (axiom label in BFO2 Reference: [138-001])</obo:IAO_0000600>
-        <obo:IAO_0000111 xml:lang="en">history</obo:IAO_0000111>
-        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/bfo.owl"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedTarget xml:lang="en">A history is a process. (axiom label in BFO2 Reference: [138-001])</owl:annotatedTarget>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000182"/><!-- history -->
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000600"/><!-- elucidation -->
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/138-001"/>
-    </owl:Axiom>
-    
-    <!-- http://purl.obolibrary.org/obo/OBI_0100061 -->                                                                                                                                                                                                                                                                                                                                                          
-                                                                                                                                                                                                                                                                                                                                                                                                             
-    <!-- http://purl.obolibrary.org/obo/OBI_0100061 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0100061"><!-- primary cultured cell population -->
-        <rdfs:label xml:lang="en">primary cultured cell population</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0100060"/><!-- cultured cell population -->
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000643"/><!-- has grain -->
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CL_0000001"/><!-- primary cultured cell -->
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000643"/><!-- has grain -->
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CL_0000001"/><!-- primary cultured cell -->
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000312"/><!-- is_specified_output_of -->
-                <owl:onClass rdf:resource="http://purl.obolibrary.org/obo/OBI_0600037"/><!-- cell culture splitting -->
-                <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">0</owl:qualifiedCardinality>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A cultured cell population comprised of cells expanded directly from living tissue prior to being passaged.
-
-</obo:IAO_0000115>
-        <obo:IAO_0000119 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PERSON:Matthew Brush</obo:IAO_0000119>
-        <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PERSON:Matthew Brush</obo:IAO_0000117>
-        <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Spleen cells put directly into culture;  Cold storage of biopsies from wild endangered native Chilean species in field conditions and subsequent isolation of primary culture cell lines. In Vitro Cell Dev Biol Anim. 2008 Jul 2. PMID: 18594934</obo:IAO_0000112>
-        <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cells that have been isolated from some organismal source, expanded in culture, but not undergone a complete passaging (ie are still in culture, or have been lifted from culture and frozen in aliquots for future use)</obo:IAO_0000112>
-        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">primary cell culture</obo:IAO_0000118>
-        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">primary cell culture sample</obo:IAO_0000118>
-        <obo:IAO_0000116>2013-6-5 MHB: This OBI class was formerly called 'primary cell culture', but label changed and definition updated following CLO alignment work.  Previous definition: 'a primary cell culture is a cell culture where the cells derive from a fresh tissue source.'</obo:IAO_0000116>
-        <obo:IAO_0000111 xml:lang="en">primary cultured cell population</obo:IAO_0000111>
-        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/><!-- metadata complete -->
-    </owl:Class>
-    <owl:Axiom>
-        <obo:IAO_0000116>consider if we really want to be so strict here . . . ie maybe we we say that they have not been output from an 'establishing cell line' process, but in some cases a passage or two may be allowed for a primary culture.  the establishing of a line requires some  procedss that attains a degree of homogeneity in the culture.</obo:IAO_0000116>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/OBI_0100061"/><!-- primary cultured cell population -->
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000312"/><!-- is_specified_output_of -->
-                <owl:onClass rdf:resource="http://purl.obolibrary.org/obo/OBI_0600037"/><!-- cell culture splitting -->
-                <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">0</owl:qualifiedCardinality>
-            </owl:Restriction>
-        </owl:annotatedTarget>
-    </owl:Axiom>                                                                                                                                                                                                                                                                                    
-                                                                                                                                                                                                                                                                                                              
-      <!-- http://purl.obolibrary.org/obo/CL_0000001 -->                                                                                                                                                                                                                                                                                                                    
-                                                                                                                                                                                                                                                                                                                                                                       
- <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_0000001"><!-- primary cultured cell -->                                                                                                                                                                                                                                                                       
-     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">primary cultured cell</rdfs:label>                                                                                                                                                                                                                                                             
-     <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL_0000010"/><!-- cultured cell -->                                                                                                                                                                                                                                                                 
-     <rdfs:subClassOf>                                                                                                                                                                                                                                                                                                                                                 
-         <owl:Class>                                                                                                                                                                                                                                                                                                                                                   
-             <owl:complementOf>                                                                                                                                                                                                                                                                                                                                        
-                 <owl:Restriction>                                                                                                                                                                                                                                                                                                                                     
-                     <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000312"/><!-- is_specified_output_of -->                                                                                                                                                                                                                                        
-                     <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0600037"/><!-- cell culture splitting -->                                                                                                                                                                                                                                    
-                 </owl:Restriction>                                                                                                                                                                                                                                                                                                                                    
-             </owl:complementOf>                                                                                                                                                                                                                                                                                                                                       
-         </owl:Class>                                                                                                                                                                                                                                                                                                                                                  
-     </rdfs:subClassOf>                                                                                                                                                                                                                                                                                                                                                
-     <rdfs:subClassOf>                                                                                                                                                                                                                                                                                                                                                 
-         <owl:Class>                                                                                                                                                                                                                                                                                                                                                   
-             <owl:complementOf>                                                                                                                                                                                                                                                                                                                                        
-                 <owl:Restriction>                                                                                                                                                                                                                                                                                                                                     
-                     <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001000"/><!-- derives from -->                                                                                                                                                                                                                                                   
-                     <owl:someValuesFrom>                                                                                                                                                                                                                                                                                                                              
-                         <owl:Class>                                                                                                                                                                                                                                                                                                                                   
-                             <owl:intersectionOf rdf:parseType="Collection">                                                                                                                                                                                                                                                                                           
-                                 <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CL_0000010"/><!-- cultured cell -->                                                                                                                                                                                                                                        
-                                 <owl:Restriction>                                                                                                                                                                                                                                                                                                                     
-                                     <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000312"/><!-- is_specified_output_of -->                                                                                                                                                                                                                        
-                                     <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0600037"/><!-- cell culture splitting -->                                                                                                                                                                                                                    
-                                 </owl:Restriction>                                                                                                                                                                                                                                                                                                                    
-                             </owl:intersectionOf>                                                                                                                                                                                                                                                                                                                     
-                         </owl:Class>                                                                                                                                                                                                                                                                                                                                  
-                     </owl:someValuesFrom>                                                                                                                                                                                                                                                                                                                             
-                 </owl:Restriction>                                                                                                                                                                                                                                                                                                                                    
-             </owl:complementOf>                                                                                                                                                                                                                                                                                                                                       
-         </owl:Class>                                                                                                                                                                                                                                                                                                                                                  
-     </rdfs:subClassOf>                                                                                                                                                                                                                                                                                                                                                
-     <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A cultured cell that is freshly isolated from a organismal source, or derives in culture from such a cell prior to the culture being passaged.</obo:IAO_0000115>                                                                                                                          
-     <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">primary cultured cell</obo:IAO_0000111>                                                                                                                                                                                                                                                   
-     <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/cl.owl"/>                                                                                                                                                                                                                                                                                           
- </owl:Class>                                                                                                                                                                                                                                                                                                                                                          
-         
-
-      
-      
-          <!-- http://purl.obolibrary.org/obo/OBI_0100063 -->                                                                                                                                                                              
-                                                                                                                                                                                                                                     
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0100063"><!-- cultured clonal cell population -->                                                                                                                       
-        <rdfs:label xml:lang="en">cultured clonal cell population</rdfs:label>                                                                                                                                                       
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0100060"/><!-- cultured cell population -->                                                                                                                
-        <obo:IAO_0000119 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GROUP: OBI Biomaterial Branch</obo:IAO_0000119>                                                                                                      
-        <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PERSON: Susanna Sansone</obo:IAO_0000117>                                                                                                            
-        <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PERSON:Matthew Brush</obo:IAO_0000117>                                                                                                               
-        <obo:IAO_0000115 xml:lang="en">A cultured cell population comprised of cells which can all be traced back to a single ancestor cell, and which therefore can be treated as identical.</obo:IAO_0000115>                      
-        <obo:IAO_0000118>clonal cell culture sample</obo:IAO_0000118>                                                                                                                                                                
-        <obo:IAO_0000112 xml:lang="en">cell cut                                                                                                                                                                                      
-Stem cell functions assessed in clonal culture. Soc Gen Physiol Ser. 1988;43:39-45. Review. PMID: 3077557</obo:IAO_0000112>                                                                                                          
-        <obo:IAO_0000111 xml:lang="en">cultured clonal cell population</obo:IAO_0000111>                                                                                                                                             
-        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/><!-- metadata complete -->                                                                                                                       
-    </owl:Class>                                                                                                                                                                                                                     
-                                                                                                                                                                                                                                     
-    <!-- http://purl.obolibrary.org/obo/OBI_0100060 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0100060"><!-- cultured cell population -->
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cultured cell population</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0000047"/><!-- processed material -->
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000643"/><!-- has grain -->
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CL_0000010"/><!-- cultured cell -->
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000643"/><!-- has grain -->
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CL_0000010"/><!-- cultured cell -->
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000312"/><!-- is_specified_output_of -->
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0600024"/><!-- maintaining cell culture -->
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A processed material comprised of a collection of cultured cells that has been continuously maintained together in culture and shares a common propagation history.</obo:IAO_0000115>
-        <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PERSON:Matthew Brush</obo:IAO_0000117>
-        <obo:IAO_0000119 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PERSON:Matthew Brush</obo:IAO_0000119>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The extent of a 'cultured cell population' is restricted only in that all cell members must share a propagation history (ie be derived through a common lineage of passages from an initial culture). In being defined in this way, this class can be used to refer to the populations that researchers actually use in the practice of science - ie are the inputs to culturing, experimentation, and sharing. The cells in such populations will be a relatively uniform population as they have experienced similar selective pressures due to their continuous co-propagation. And this population will also have a single passage number, again owing to their common passaging history. Cultured cell populations represent only a collection of cells (ie do not include media, culture dishes, etc), and include populations of cultured unicellular organisms or cultured multicellular organism cells. They can exist under active culture, stored in a quiescent state for future use, or applied experimentally.</rdfs:comment>
-        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cultured cell population</obo:IAO_0000111>
-        <obo:IAO_0000112>A cultured cell population applied in an experiment: "293 cells expressing TrkA were serum-starved for 18 hours and then neurotrophins were added for 10 min before cell harvest."  (Lee, Ramee, et al. "Regulation of cell survival by secreted proneurotrophins." Science 294.5548 (2001): 1945-1948).
-
-A cultured cell population maintained in vitro: "Rat cortical neurons from 15 day embryos are grown in dissociated cell culture and maintained in vitro for 8–12 weeks" (Dichter, Marc A. "Rat cortical neurons in cell culture: culture methods, cell morphology, electrophysiology, and synapse formation." Brain Research 149.2 (1978): 279-293).</obo:IAO_0000112>
-        <obo:IAO_0000118>cell culture sample</obo:IAO_0000118>
-        <obo:IAO_0000116 xml:lang="en">2013-6-5 MHB: This OBI class was formerly called 'cell culture', but label changed and definition updated following CLO alignment efforts in spring 2013, during which the intent of this class was clarified to refer to portions of a culture or line rather than a complete cell culture or line.</obo:IAO_0000116>
-        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/><!-- metadata complete -->
-    </owl:Class>
-
-
-    <!-- http://purl.obolibrary.org/obo/CHEBI_15956 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_15956"><!-- biotin -->
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">biotin</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/REO_0000280"/><!-- molecular label -->
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/><!-- has role -->
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/REO_0000171"/><!-- molecular label role -->
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An organic heterobicyclic compound that consists of 2-oxohexahydro-1H-thieno[3,4-d]imidazole having a valeric acid substituent attached to the tetrahydrothiophene ring. The parent of the class of biotins.</obo:IAO_0000115>
-        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">biotin</obo:IAO_0000111>
-        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
-    </owl:Class>
-
-        <!-- http://purl.obolibrary.org/obo/REO_0000171 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/REO_0000171"><!-- molecular label role -->
-        <rdfs:label xml:lang="en">molecular label role</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000023"/><!-- role -->
-        <obo:IAO_0000118>molecular tracer role</obo:IAO_0000118>
-        <obo:IAO_0000119>OBI developer call, 3-12-12</obo:IAO_0000119>
-        <obo:IAO_0000115>a reagent role inhering in a molecular entity intended to associate with some molecular target to serve as a proxy for the presence, abundance, or location of this target in a detection of molecular label assay.</obo:IAO_0000115>
-        <obo:IAO_0000116>MHB (9-29-13): 'molecular label role' imported from the Reagent Ontology and replaced OBI:OBI_0000140 (label role)</obo:IAO_0000116>
-        <obo:IAO_0000111 xml:lang="en">molecular label role</obo:IAO_0000111>
-        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/reo.owl"/>
-    </owl:Class>
-
-    <!-- http://purl.obolibrary.org/obo/BFO_0000001 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000001"><!-- entity -->
-        <rdfs:label xml:lang="en">entity</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
-        <owl:disjointWith rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/><!-- Obsolete Class -->
-        <obo:IAO_0000600 xml:lang="en">An entity is anything that exists or has existed or will exist. (axiom label in BFO2 Reference: [001-001])</obo:IAO_0000600>
-        <obo:IAO_0000116 xml:lang="en">BFO 2 Reference: In all areas of empirical inquiry we encounter general terms of two sorts. First are general terms which refer to universals or types:animaltuberculosissurgical procedurediseaseSecond, are general terms used to refer to groups of entities which instantiate a given universal but do not correspond to the extension of any subuniversal of that universal because there is nothing intrinsic to the entities in question by virtue of which they – and only they – are counted as belonging to the given group. Examples are: animal purchased by the Emperortuberculosis diagnosed on a Wednesdaysurgical procedure performed on a patient from Stockholmperson identified as candidate for clinical trial #2056-555person who is signatory of Form 656-PPVpainting by Leonardo da VinciSuch terms, which represent what are called ‘specializations’ in [81</obo:IAO_0000116>
-        <obo:BFO_0000180>Entity</obo:BFO_0000180>
-        <obo:IAO_0000112 xml:lang="en">Verdi’s Requiem</obo:IAO_0000112>
-        <obo:BFO_0000179>entity</obo:BFO_0000179>
-        <obo:IAO_0000116 xml:lang="en">Entity doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. For example Werner Ceusters 'portions of reality' include 4 sorts, entities (as BFO construes them), universals, configurations, and relations. It is an open question as to whether entities as construed in BFO will at some point also include these other portions of reality. See, for example, 'How to track absolutely everything' at http://www.referent-tracking.com/_RTU/papers/CeustersICbookRevised.pdf</obo:IAO_0000116>
-        <obo:IAO_0000112 xml:lang="en">Julius Caesar</obo:IAO_0000112>
-        <obo:IAO_0000111 xml:lang="en">entity</obo:IAO_0000111>
-        <obo:IAO_0000112 xml:lang="en">the Second World War</obo:IAO_0000112>
-        <obo:IAO_0000112 xml:lang="en">your body mass index</obo:IAO_0000112>
-        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/bfo.owl"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedTarget xml:lang="en">An entity is anything that exists or has existed or will exist. (axiom label in BFO2 Reference: [001-001])</owl:annotatedTarget>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000001"/><!-- entity -->
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000600"/><!-- elucidation -->
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/001-001"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <rdfs:comment>per discussion with Barry Smith</rdfs:comment>
-        <owl:annotatedTarget xml:lang="en">Entity doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. For example Werner Ceusters 'portions of reality' include 4 sorts, entities (as BFO construes them), universals, configurations, and relations. It is an open question as to whether entities as construed in BFO will at some point also include these other portions of reality. See, for example, 'How to track absolutely everything' at http://www.referent-tracking.com/_RTU/papers/CeustersICbookRevised.pdf</owl:annotatedTarget>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000001"/><!-- entity -->
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000116"/><!-- editor note -->
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/0000004"/>
-        <rdfs:seeAlso rdf:resource="http://www.referent-tracking.com/_RTU/papers/CeustersICbookRevised.pdf"/>
-    </owl:Axiom>
-    
-
-
-
-        <!-- http://purl.obolibrary.org/obo/BFO_0000002 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000002"><!-- continuant -->
-        <rdfs:label xml:lang="en">continuant</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000001"/><!-- entity -->
-        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000003"/><!-- occurrent -->
-        <obo:IAO_0000602>(forall (x y) (if (and (Continuant x) (exists (t) (hasContinuantPartOfAt y x t))) (Continuant y))) // axiom label in BFO2 CLIF: [126-001] </obo:IAO_0000602>
-        <obo:IAO_0000115 xml:lang="en">An entity that exists in full at any time in which it exists at all, persists through time while maintaining its identity and has no temporal parts.</obo:IAO_0000115>
-        <obo:IAO_0000116 xml:lang="en">BFO 2 Reference: Continuant entities are entities which can be sliced to yield parts only along the spatial dimension, yielding for example the parts of your table which we call its legs, its top, its nails. ‘My desk stretches from the window to the door. It has spatial parts, and can be sliced (in space) in two. With respect to time, however, a thing is a continuant.’ [60, p. 240</obo:IAO_0000116>
-        <obo:IAO_0000116 xml:lang="en">Continuant doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. For example, in an expansion involving bringing in some of Ceuster's other portions of reality, questions are raised as to whether universals are continuants</obo:IAO_0000116>
-        <obo:BFO_0000179>continuant</obo:BFO_0000179>
-        <obo:BFO_0000180>Continuant</obo:BFO_0000180>
-        <obo:IAO_0000602>(forall (x y) (if (and (Continuant x) (exists (t) (continuantPartOfAt y x t))) (Continuant y))) // axiom label in BFO2 CLIF: [009-002] </obo:IAO_0000602>
-        <obo:IAO_0000602>(forall (x) (if (Continuant x) (Entity x))) // axiom label in BFO2 CLIF: [008-002] </obo:IAO_0000602>
-        <obo:IAO_0000602>(forall (x) (if (Material Entity x) (exists (t) (and (TemporalRegion t) (existsAt x t))))) // axiom label in BFO2 CLIF: [011-002] </obo:IAO_0000602>
-        <obo:IAO_0000600 xml:lang="en">A continuant is an entity that persists, endures, or continues to exist through time while maintaining its identity. (axiom label in BFO2 Reference: [008-002])</obo:IAO_0000600>
-        <obo:IAO_0000111 xml:lang="en">continuant</obo:IAO_0000111>
-        <obo:IAO_0000601 xml:lang="en">if b is a continuant and if, for some t, c has_continuant_part b at t, then c is a continuant. (axiom label in BFO2 Reference: [126-001])</obo:IAO_0000601>
-        <obo:IAO_0000601 xml:lang="en">if b is a continuant and if, for some t, cis continuant_part of b at t, then c is a continuant. (axiom label in BFO2 Reference: [009-002])</obo:IAO_0000601>
-        <obo:IAO_0000601 xml:lang="en">if b is a material entity, then there is some temporal interval (referred to below as a one-dimensional temporal region) during which b exists. (axiom label in BFO2 Reference: [011-002])</obo:IAO_0000601>
-        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/bfo.owl"/>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedTarget>(forall (x) (if (Material Entity x) (exists (t) (and (TemporalRegion t) (existsAt x t))))) // axiom label in BFO2 CLIF: [011-002] </owl:annotatedTarget>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/><!-- continuant -->
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/><!-- has associated axiom(fol) -->
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/011-002"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedTarget>(forall (x y) (if (and (Continuant x) (exists (t) (continuantPartOfAt y x t))) (Continuant y))) // axiom label in BFO2 CLIF: [009-002] </owl:annotatedTarget>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/><!-- continuant -->
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/><!-- has associated axiom(fol) -->
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/009-002"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedTarget xml:lang="en">A continuant is an entity that persists, endures, or continues to exist through time while maintaining its identity. (axiom label in BFO2 Reference: [008-002])</owl:annotatedTarget>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/><!-- continuant -->
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000600"/><!-- elucidation -->
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/008-002"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedTarget xml:lang="en">Continuant doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. For example, in an expansion involving bringing in some of Ceuster's other portions of reality, questions are raised as to whether universals are continuants</owl:annotatedTarget>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/><!-- continuant -->
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000116"/><!-- editor note -->
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/0000007"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedTarget xml:lang="en">if b is a material entity, then there is some temporal interval (referred to below as a one-dimensional temporal region) during which b exists. (axiom label in BFO2 Reference: [011-002])</owl:annotatedTarget>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/><!-- continuant -->
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000601"/><!-- has associated axiom(nl) -->
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/011-002"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedTarget>(forall (x) (if (Continuant x) (Entity x))) // axiom label in BFO2 CLIF: [008-002] </owl:annotatedTarget>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/><!-- continuant -->
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/><!-- has associated axiom(fol) -->
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/008-002"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedTarget>(forall (x y) (if (and (Continuant x) (exists (t) (hasContinuantPartOfAt y x t))) (Continuant y))) // axiom label in BFO2 CLIF: [126-001] </owl:annotatedTarget>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/><!-- continuant -->
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/><!-- has associated axiom(fol) -->
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/126-001"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedTarget xml:lang="en">if b is a continuant and if, for some t, c has_continuant_part b at t, then c is a continuant. (axiom label in BFO2 Reference: [126-001])</owl:annotatedTarget>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/><!-- continuant -->
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000601"/><!-- has associated axiom(nl) -->
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/126-001"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedTarget xml:lang="en">if b is a continuant and if, for some t, cis continuant_part of b at t, then c is a continuant. (axiom label in BFO2 Reference: [009-002])</owl:annotatedTarget>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/><!-- continuant -->
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000601"/><!-- has associated axiom(nl) -->
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/009-002"/>
-    </owl:Axiom>
-
-
-    
-    <!-- http://purl.obolibrary.org/obo/IAO_0000033 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000033"><!-- directive information entity -->
-        <rdfs:label xml:lang="en">directive information entity</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000030"/><!-- information content entity -->
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/><!-- is about -->
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/BFO_0000017"/><!-- realizable entity -->
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <obo:IAO_0000116 xml:lang="en">2009-03-16: provenance: a term realizable information entity was proposed for OBI (OBI_0000337) , edited by the PlanAndPlannedProcess branch. Original definition was  "is the specification of a process that can be concretized and realized by an actor" with alternative term  "instruction".It has been subsequently moved to IAO where the objective for which the original term was defined was satisfied with the definitionof this, different, term.</obo:IAO_0000116>
-        <obo:IAO_0000116 xml:lang="en">2013-05-30 Alan Ruttenberg: What differentiates a directive information entity from an information concretization is that it can have concretizations that are either qualities or realizable entities. The concretizations that are realizable entities are created when an individual chooses to take up the direction, i.e. has the intention to (try to) realize it.</obo:IAO_0000116>
-        <obo:IAO_0000116 xml:lang="en">8/6/2009 Alan Ruttenberg: Changed label from "information entity about a realizable" after discussions at ICBO</obo:IAO_0000116>
-        <obo:IAO_0000115 xml:lang="en">An information content entity whose concretizations indicate to their bearer how to realize them in a process.</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">PERSON: Alan Ruttenberg</obo:IAO_0000117>
-        <obo:IAO_0000117 xml:lang="en">PERSON: Bjoern Peters</obo:IAO_0000117>
-        <obo:IAO_0000116 xml:lang="en">Werner pushed back on calling it realizable information entity as it isn't realizable. However this name isn't right either. An example would be a recipe. The realizable entity would be a plan, but the information entity isn't about the plan, it, once concretized, *is* the plan. -Alan</obo:IAO_0000116>
-        <obo:IAO_0000111 xml:lang="en">directive information entity</obo:IAO_0000111>
-        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/><!-- ready for release -->
-    </owl:Class>
-
-       <!-- http://purl.obolibrary.org/obo/OBI_0500000 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0500000"><!-- study design -->
-        <rdfs:label xml:lang="en">study design</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000104"/><!-- plan specification -->
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/><!-- has part -->
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000272"/><!-- protocol -->
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A plan specification comprised of protocols (which may specify how and what kinds of data will be gathered) that are executed as part of an investigation and is realized during a study design execution.</obo:IAO_0000115>
-        <obo:IAO_0000116 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Editor note: there is at least an implicit restriction on the kind of data transformations that can be done based on the measured data available.</obo:IAO_0000116>
-        <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PERSON: Chris Stoeckert</obo:IAO_0000117>
-        <obo:IAO_0000112 xml:lang="en">a matched pairs study design describes criteria by which subjects are identified as pairs which then undergo the same protocols, and the data generated is analyzed by comparing the differences between the paired subjects, which constitute the results of the executed study design.</obo:IAO_0000112>
-        <obo:IAO_0000118 xml:lang="en">experimental design</obo:IAO_0000118>
-        <obo:IAO_0000232 xml:lang="en">rediscussed at length (MC/JF/BP). 12/9/08). The definition was clarified to differentiate it from protocol.</obo:IAO_0000232>
-        <obo:IAO_0000111 xml:lang="en">study design</obo:IAO_0000111>
-        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/><!-- ready for release -->
-        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
-    </owl:Class>
-
-        <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Clinical_Infection -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Clinical_Infection">
-        <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Infectious_Disorder"/>
-        <FULL_SYN rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Clinical Infection</FULL_SYN>
-        <Preferred_Name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Clinical Infection</Preferred_Name>
-        <Semantic_Type rdf:datatype="http://www.w3.org/2001/XMLScheme#string">Disease of Syndrome</Semantic_Type>
-        <code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C128366</code>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Clinical Infection</rdfs:label>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Clinical_Infection"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#FULL_SYN"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Clinical Infection</owl:annotatedTarget>
-        <term-group rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PT</term-group>
-        <term-source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NCI</term-source>
-    </owl:Axiom>
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0000699 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000699"><!-- survival assessment -->
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">survival assessment</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0000070"/><!-- assay -->
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000417"/><!-- achieves_planned_objective -->
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000441"/><!-- assay objective -->
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000293"/><!-- has_specified_input -->
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0100026"/><!-- organism -->
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000299"/><!-- has_specified_output -->
-                <owl:someValuesFrom>
-                    <owl:Class>
-                        <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000789"/><!-- survival rate -->
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/><!-- is about -->
-                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0100026"/><!-- organism -->
-                            </owl:Restriction>
-                        </owl:intersectionOf>
-                    </owl:Class>
-                </owl:someValuesFrom>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <obo:OBI_9991118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000116 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Need to point out more specifically that survival / death is measured.</obo:IAO_0000116>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Survival assessment is an assay that measures the occurrence of death events in one or more organisms that are monitored over time</obo:IAO_0000115>
-        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">survival assessment</obo:IAO_0000111>
-        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/><!-- metadata incomplete -->
-    </owl:Class>
-    
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C61410">
-        <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C54443"/>
-        <P90>CDISC</P90>
-        <P90>CDISC Terminology</P90>
-        <P90>Clinical Data Interchange Standards Consortium Terminology</P90>
-        <P376>&lt;p&gt;&lt;a href=&quot;http://www.cdisc.org/&quot;&gt;Clinical Data Interchange Standards Consortium (CDISC)&lt;/a&gt; is an international, non-profit organization that develops and supports global data standards for medical research. &lt;a href=&quot;http://www.cancer.gov/cancertopics/cancerlibrary/terminologyresources/cdisc&quot;&gt;CDISC collaborates with EVS&lt;/a&gt; to develop and support controlled terminology for a wide spectrum of clinical and nonclinical studies.  CDISC terminology goes through an extensive process of content development and public review before it is declared ready for release.&lt;/p&gt;&lt;p&gt;The value sets presented here represent the various CDISC codesets stored within the NCI Thesaurus.  These are also available for download from the &lt;a href=&quot;http://evs.nci.nih.gov/ftp1/CDISC&quot;&gt;EVS FTP site&lt;/a&gt;&lt;/p&gt;</P376>
-        <rdfs:label>Clinical Data Interchange Standards Consortium Terminology</rdfs:label>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C61410"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97"/>
-        <owl:annotatedTarget>The terminology that includes terms relevant to the Clinical Data Interchange Standards Consortium.</owl:annotatedTarget>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C61410"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
-        <owl:annotatedTarget>CDISC</owl:annotatedTarget>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C61410"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
-        <owl:annotatedTarget>CDISC Terminology</owl:annotatedTarget>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C61410"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
-        <owl:annotatedTarget>Clinical Data Interchange Standards Consortium Terminology</owl:annotatedTarget>
-    </owl:Axiom>
-    
-       <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Color -->
-
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C37927">
-        <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C25377"/>
-        <A8 rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C117743</A8>
-        <P90>COLOR</P90>
-        <P90>Color</P90>
-        <rdfs:label>Color</rdfs:label>
-    </owl:Class>
-       <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C37927"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P325"/>
-        <owl:annotatedTarget>The appearance of objects (or light sources) described in terms of a person&apos;s perception of their hue and lightness (or brightness) and saturation. (NCI)</owl:annotatedTarget>
-    </owl:Axiom>
-    
-     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#CDISC_SDTM_Ophthalmic_Exam_Test_Code_Terminology -->
-     
     <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C117743">
-        <P90>CDISC SDTM Ophthalmic Exam Test Code Terminology</P90>
         <P106>Intellectual Product</P106>
+        <P325>Terminology relevant to the test codes that describe findings from ophthalmic examinations.</P325>
+        <P372>No</P372>
+        <P90>CDISC SDTM Ophthalmic Exam Test Code Terminology</P90>
         <P90>OETESTCD</P90>
         <P90>Ophthalmic Exam Test Code</P90>
         <P90>SDTM-OETESTCD</P90>
-         <P372>No</P372>
         <rdfs:label>CDISC SDTM Ophthalmic Exam Test Code Terminology</rdfs:label>
     </owl:Class>
     <owl:Axiom>
@@ -2392,19 +1083,231 @@ A cultured cell population maintained in vitro: "Rat cortical neurons from 15 da
         <P384>NCI</P384>
     </owl:Axiom>
     
-        <!-- Structured Product Labeling Color Terminology -->
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C12219 -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C12219"/>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123 -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123">
+        <owl:disjointUnionOf rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#BRaf"/>
+            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Erbb2"/>
+            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Mefv"/>
+            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Ras"/>
+            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SHH"/>
+            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SOS"/>
+            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#actin"/>
+            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#k-Ras"/>
+        </owl:disjointUnionOf>
+        <definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The fundamental unit of heredity.</definition>
+        <term>gene</term>
+        <rdfs:label>Gene</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#disjointUnionOf"/>
+        <owl:annotatedTarget rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#BRaf"/>
+            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Erbb2"/>
+            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Mefv"/>
+            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Ras"/>
+            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SHH"/>
+            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SOS"/>
+            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#actin"/>
+            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#k-Ras"/>
+        </owl:annotatedTarget>
+        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">all genes are disjoint.  splicing variants are not considered individual genes.</note>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#definition"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The fundamental unit of heredity.</owl:annotatedTarget>
+        <provenance rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gregor Mendel</provenance>
+        <source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Encyclopedia</source>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term"/>
+        <owl:annotatedTarget>gene</owl:annotatedTarget>
+        <source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Wikipedia</source>
+        <term_type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PT</term_type>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C25377 -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C25377"/>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C37927 -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C37927">
+        <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C25377"/>
+        <A8 rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C117743</A8>
+        <P325>The appearance of objects (or light sources) described in terms of a person&apos;s perception of their hue and lightness (or brightness) and saturation. (NCI)</P325>
+        <P90>COLOR</P90>
+        <P90>Color</P90>
+        <rdfs:label>Color</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48323 -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48323">
+        <A8 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C117743"/>
+        <A8 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C54453"/>
+        <NHC0>C48323</NHC0>
+        <P106>Qualitative Concept</P106>
+        <P108>Black</P108>
+        <P322>FDA</P322>
+        <P322>TEST</P322>
+        <P372>Yes</P372>
+        <P90>BLACK</P90>
+        <P90>Black</P90>
+        <P97>Of darkest color; producing or reflecting comparatively little light and having no predominant hue; being the color of coal or carbon.</P97>
+        <rdfs:label>Black</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48323"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
+        <owl:annotatedTarget>BLACK</owl:annotatedTarget>
+        <P383>PT</P383>
+        <P384>FDA</P384>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48323"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
+        <owl:annotatedTarget>Black</owl:annotatedTarget>
+        <P383>PT</P383>
+        <P384>NCI</P384>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48323"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97"/>
+        <owl:annotatedTarget>Of darkest color; producing or reflecting comparatively little light and having no predominant hue; being the color of coal or carbon.</owl:annotatedTarget>
+        <P378>NCI</P378>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48325 -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48325">
+        <A8 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C54453"/>
+        <NHC0>C48325</NHC0>
+        <P106>Qualitative Concept</P106>
+        <P108>White</P108>
+        <P322>FDA</P322>
+        <P325>rgb(255, 255, 255)</P325>
+        <P372>Yes</P372>
+        <P90>WHITE</P90>
+        <P90>White</P90>
+        <P90>White Color</P90>
+        <P97>The achromatic color of maximum lightness; the color of objects that reflect nearly all light of all visible wavelengths; the complement or antagonist of black, the other extreme of the neutral gray series.</P97>
+        <rdfs:label>White</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48325"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P325"/>
+        <owl:annotatedTarget>rgb(255, 255, 255)</owl:annotatedTarget>
+        <P378>SPL</P378>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48325"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
+        <owl:annotatedTarget>WHITE</owl:annotatedTarget>
+        <P383>PT</P383>
+        <P384>FDA</P384>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48325"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
+        <owl:annotatedTarget>White</owl:annotatedTarget>
+        <P383>PT</P383>
+        <P384>NCI</P384>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48325"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
+        <owl:annotatedTarget>White Color</owl:annotatedTarget>
+        <P383>SY</P383>
+        <P384>NCI</P384>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48325"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97"/>
+        <owl:annotatedTarget>The achromatic color of maximum lightness; the color of objects that reflect nearly all light of all visible wavelengths; the complement or antagonist of black, the other extreme of the neutral gray series.</owl:annotatedTarget>
+        <P378>NCI</P378>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48333 -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48333">
+        <A8 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C54453"/>
+        <NHC0>C48333</NHC0>
+        <P106>Qualitative Concept</P106>
+        <P108>BLUE</P108>
+        <P207>C1260957</P207>
+        <P317>SPL Color (C-DRG-00927)</P317>
+        <P322>FDA</P322>
+        <P366>BLUE</P366>
+        <P372>Yes</P372>
+        <P90>BLUE</P90>
+        <P97>The hue of that portion of the visible spectrum lying between green and indigo.</P97>
+        <rdfs:label>BLUE</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48333"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
+        <owl:annotatedTarget>BLUE</owl:annotatedTarget>
+        <P383>PT</P383>
+        <P384>FDA</P384>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48333"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
+        <owl:annotatedTarget>BLUE</owl:annotatedTarget>
+        <P383>PT</P383>
+        <P384>NCI</P384>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48333"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97"/>
+        <owl:annotatedTarget>The hue of that portion of the visible spectrum lying between green and indigo.</owl:annotatedTarget>
+        <P378>NCI</P378>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C54443 -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C54443"/>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C54453 -->
 
     <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C54453">
-        <rdfs:label>Structured Product Labeling Color Terminology</rdfs:label>
         <NHC0>C54453</NHC0>
         <P106>Intellectual Product</P106>
         <P108>Structured Product Labeling Color Terminology</P108>
+        <P322>FDA</P322>
         <P366>Labeling_Color_Terminology</P366>
         <P372>Yes</P372>
-        <P322>FDA</P322>
         <P90>SPL Color Terminology</P90>
         <P90>Structured Product Labeling Color Terminology</P90>
         <P97>Terminology used for representation of the information on pharmaceutical product color in the framework of the Structured Product Labeling documents.</P97>
+        <rdfs:label>Structured Product Labeling Color Terminology</rdfs:label>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C54453"/>
@@ -2427,247 +1330,1403 @@ A cultured cell population maintained in vitro: "Rat cortical neurons from 15 da
         <P378>NCI</P378>
     </owl:Axiom>
     
-        <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48333 -->
 
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48333">
-        <A8 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C54453"/>
-        <NHC0>C48333</NHC0>
-        <P106>Qualitative Concept</P106>
-        <P108>BLUE</P108>
-        <P207>C1260957</P207>
-        <P317>SPL Color (C-DRG-00927)</P317>
-        <P322>FDA</P322>
-        <P366>BLUE</P366>
-        <P372>Yes</P372>
-        <P90>BLUE</P90>
-        <P90>BLUE</P90>
-        <P97>The hue of that portion of the visible spectrum lying between green and indigo.</P97>
-        <rdfs:label>BLUE</rdfs:label>
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C61410 -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C61410">
+        <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C54443"/>
+        <P376>&lt;p&gt;&lt;a href=&quot;http://www.cdisc.org/&quot;&gt;Clinical Data Interchange Standards Consortium (CDISC)&lt;/a&gt; is an international, non-profit organization that develops and supports global data standards for medical research. &lt;a href=&quot;http://www.cancer.gov/cancertopics/cancerlibrary/terminologyresources/cdisc&quot;&gt;CDISC collaborates with EVS&lt;/a&gt; to develop and support controlled terminology for a wide spectrum of clinical and nonclinical studies.  CDISC terminology goes through an extensive process of content development and public review before it is declared ready for release.&lt;/p&gt;&lt;p&gt;The value sets presented here represent the various CDISC codesets stored within the NCI Thesaurus.  These are also available for download from the &lt;a href=&quot;http://evs.nci.nih.gov/ftp1/CDISC&quot;&gt;EVS FTP site&lt;/a&gt;&lt;/p&gt;</P376>
+        <P90>CDISC</P90>
+        <P90>CDISC Terminology</P90>
+        <P90>Clinical Data Interchange Standards Consortium Terminology</P90>
+        <P97>The terminology that includes terms relevant to the Clinical Data Interchange Standards Consortium.</P97>
+        <rdfs:label>Clinical Data Interchange Standards Consortium Terminology</rdfs:label>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48333"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
-        <owl:annotatedTarget>BLUE</owl:annotatedTarget>
-        <P383>PT</P383>
-        <P384>FDA</P384>
-        <P386>SPL</P386>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48333"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
-        <owl:annotatedTarget>BLUE</owl:annotatedTarget>
-        <P383>PT</P383>
-        <P384>NCI</P384>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48333"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97"/>
-        <owl:annotatedTarget>The hue of that portion of the visible spectrum lying between green and indigo.</owl:annotatedTarget>
-        <P378>NCI</P378>
-        <P381>American Heritage Dictionary - Bartelby.com</P381>
-    </owl:Axiom>
     
-        <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C98989">
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C98989 -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C98989">
         <A8 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48333"/>
-        <rdfs:label>Bluer than blue</rdfs:label>
         <P106>Qualitative Concept</P106>
         <P108>Bluer</P108>
-        <P372>Yes</P372>
         <P322>FDA</P322>
+        <P372>Yes</P372>
         <P90>BLACKER</P90>
         <P90>Bluer</P90>
         <P90>color characterized as dark</P90>
         <P97>Of even darker color</P97>
+        <rdfs:label>Bluer than blue</rdfs:label>
     </owl:Class>
     
-        <!-- Black -->
 
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48323">
-        <A8 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C54453"/>
-        <A8 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C117743"/>
-        <rdfs:label>Black</rdfs:label>
-        <NHC0>C48323</NHC0>
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C99988 -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C99988">
+        <A8 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C99999"/>
         <P106>Qualitative Concept</P106>
-        <P108>Black</P108>
-        <P372>Yes</P372>
+        <P108>Ack</P108>
         <P322>FDA</P322>
-        <P322>TEST</P322>
-        <P90>BLACK</P90>
-        <P90>Black</P90>
-        <P97>Of darkest color; producing or reflecting comparatively little light and having no predominant hue; being the color of coal or carbon.</P97>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48323"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
-        <owl:annotatedTarget>BLACK</owl:annotatedTarget>
-        <P383>PT</P383>
-        <P384>FDA</P384>
-        <P386>SPL</P386>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48323"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
-        <owl:annotatedTarget>Black</owl:annotatedTarget>
-        <P383>PT</P383>
-        <P384>NCI</P384>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48323"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97"/>
-        <owl:annotatedTarget>Of darkest color; producing or reflecting comparatively little light and having no predominant hue; being the color of coal or carbon.</owl:annotatedTarget>
-        <P378>NCI</P378>
-    </owl:Axiom>
-    
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C99999">
-        <A8 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48323"/>
-        <rdfs:label>Blacker</rdfs:label>
-        <P106>Qualitative Concept</P106>
-        <P108>Blacker</P108>
         <P372>Yes</P372>
-        <P322>FDA</P322>
-        <P90>BLACKER</P90>
-        <P90>Blacker</P90>
+        <P90>ACK</P90>
+        <P90>ack</P90>
         <P90>color characterized as dark</P90>
-        <P97>Of even darker color</P97>
+        <P97>Of even acker color</P97>
+        <rdfs:label>Ack</rdfs:label>
     </owl:Class>
     
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C99989 -->
+
     <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C99989">
         <A8 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C99999"/>
-        <rdfs:label>Bla</rdfs:label>
         <P106>Qualitative Concept</P106>
         <P108>Bla</P108>
-		<P372>Yes</P372>
         <P322>FDA</P322>
+        <P372>Yes</P372>
         <P90>BLA</P90>
         <P90>Bla</P90>
         <P90>color characterized as dark</P90>
         <P97>Of even bla color</P97>
+        <rdfs:label>Bla</rdfs:label>
     </owl:Class>
     
-   <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C99988">
-        <A8 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C99999"/>
-        <rdfs:label>Ack</rdfs:label>
-        <P106>Qualitative Concept</P106>
-        <P108>Ack</P108>
-        <P372>Yes</P372>
-        <P322>FDA</P322>
-        <P90>ACK</P90>
-        <P90>ack</P90>
-         <P90>color characterized as dark</P90>
-        <P97>Of even acker color</P97>
-    </owl:Class>
-    
-     <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C99998">
-        <A8 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48323"/>
-        <rdfs:label>UberBlack</rdfs:label>
-        <P106>Qualitative Concept</P106>
-        <P108>UberBlack</P108>
-        <P372>Yes</P372>
-        <P322>FDA</P322>
-        <P90>UberBLACKER</P90>
-        <P90>BlackUber</P90>
-        <P90>color characterized as dark</P90>
-        <P97>Uber dark color</P97>
-    </owl:Class>
-    
-       <!-- White -->
 
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48325">
-        <rdfs:label>White</rdfs:label>
-        <A8 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C54453"/>
-        <NHC0>C48325</NHC0>
-        <P106>Qualitative Concept</P106>
-        <P108>White</P108>
-        <P372>Yes</P372>
-        <P322>FDA</P322>
-        <P90>WHITE</P90>
-        <P90>White</P90>
-        <P90>White Color</P90>
-        <P97>The achromatic color of maximum lightness; the color of objects that reflect nearly all light of all visible wavelengths; the complement or antagonist of black, the other extreme of the neutral gray series.</P97>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48325"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P325"/>
-        <owl:annotatedTarget>rgb(255, 255, 255)</owl:annotatedTarget>
-        <P378>SPL</P378>
-        <P379>DEFAULT_Review</P379>
-        <P380>060127</P380>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48325"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
-        <owl:annotatedTarget>WHITE</owl:annotatedTarget>
-        <P383>PT</P383>
-        <P384>FDA</P384>
-        <P386>SPL</P386>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48325"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
-        <owl:annotatedTarget>White</owl:annotatedTarget>
-        <P383>PT</P383>
-        <P384>NCI</P384>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48325"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
-        <owl:annotatedTarget>White Color</owl:annotatedTarget>
-        <P383>SY</P383>
-        <P384>NCI</P384>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48325"/>
-        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P97"/>
-        <owl:annotatedTarget>The achromatic color of maximum lightness; the color of objects that reflect nearly all light of all visible wavelengths; the complement or antagonist of black, the other extreme of the neutral gray series.</owl:annotatedTarget>
-        <P378>NCI</P378>
-        <P379>Nicole Thomas</P379>
-        <P380>060724</P380>
-        <P381>American Heritage Dictionary - Bartelby.com</P381>
-    </owl:Axiom>
-    
-    
-    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C99997">
-        <rdfs:label>ArchWhite</rdfs:label>
-        <A8 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48325"/>
-        <NHC0>C48325</NHC0>
-        <P106>Qualitative Concept</P106>
-        <P108>ArchWhite</P108>
-        <P372>Yes</P372>
-        <P322>FDA</P322>
-        <P90>ARCHWHITE</P90>
-        <P90>ArchWhite</P90>
-        <P90>Archly White Color</P90>
-        <P97>The archly achromatic color of maximum lightness; </P97>
-    </owl:Class>
-    
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C99996 -->
+
     <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C99996">
-        <rdfs:label>BlindingWhite</rdfs:label>
         <A8 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48325"/>
         <NHC0>C48325</NHC0>
         <P106>Qualitative Concept</P106>
         <P108>BlindingWhite</P108>
-        <P372>Yes</P372>
         <P322>FDA</P322>
+        <P372>Yes</P372>
         <P90>BlindingWHITE</P90>
         <P90>BlindingWhite</P90>
         <P90>Blindingly White Color</P90>
         <P97>The Blindingly achromatic color of maximum lightness; </P97>
+        <rdfs:label>BlindingWhite</rdfs:label>
     </owl:Class>
     
-      <!-- http://purl.obolibrary.org/obo/IAO_0000032 -->
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C99997 -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C99997">
+        <A8 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48325"/>
+        <NHC0>C48325</NHC0>
+        <P106>Qualitative Concept</P106>
+        <P108>ArchWhite</P108>
+        <P322>FDA</P322>
+        <P372>Yes</P372>
+        <P90>ARCHWHITE</P90>
+        <P90>ArchWhite</P90>
+        <P90>Archly White Color</P90>
+        <P97>The archly achromatic color of maximum lightness; </P97>
+        <rdfs:label>ArchWhite</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C99998 -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C99998">
+        <A8 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48323"/>
+        <P106>Qualitative Concept</P106>
+        <P108>UberBlack</P108>
+        <P322>FDA</P322>
+        <P372>Yes</P372>
+        <P90>BlackUber</P90>
+        <P90>UberBLACKER</P90>
+        <P90>color characterized as dark</P90>
+        <P97>Uber dark color</P97>
+        <rdfs:label>UberBlack</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C99999 -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C99999">
+        <A8 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C48323"/>
+        <P106>Qualitative Concept</P106>
+        <P108>Blacker</P108>
+        <P322>FDA</P322>
+        <P372>Yes</P372>
+        <P90>BLACKER</P90>
+        <P90>Blacker</P90>
+        <P90>color characterized as dark</P90>
+        <P97>Of even darker color</P97>
+        <rdfs:label>Blacker</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#CancerPatient -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#CancerPatient">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SickPatient"/>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <owl:Class>
+                                <owl:intersectionOf rdf:parseType="Collection">
+                                    <owl:Restriction>
+                                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_finding"/>
+                                        <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#TumorBenign"/>
+                                    </owl:Restriction>
+                                    <owl:Restriction>
+                                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_prognosis"/>
+                                        <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood"/>
+                                    </owl:Restriction>
+                                </owl:intersectionOf>
+                            </owl:Class>
+                            <owl:Class>
+                                <owl:intersectionOf rdf:parseType="Collection">
+                                    <owl:Restriction>
+                                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_finding"/>
+                                        <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#TumorMalignant"/>
+                                    </owl:Restriction>
+                                    <owl:Restriction>
+                                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_prognosis"/>
+                                        <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisBad"/>
+                                    </owl:Restriction>
+                                </owl:intersectionOf>
+                            </owl:Class>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#CancerPatient"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
+        <owl:annotatedTarget>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SickPatient"/>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <owl:Class>
+                                <owl:intersectionOf rdf:parseType="Collection">
+                                    <owl:Restriction>
+                                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_finding"/>
+                                        <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#TumorBenign"/>
+                                    </owl:Restriction>
+                                    <owl:Restriction>
+                                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_prognosis"/>
+                                        <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood"/>
+                                    </owl:Restriction>
+                                </owl:intersectionOf>
+                            </owl:Class>
+                            <owl:Class>
+                                <owl:intersectionOf rdf:parseType="Collection">
+                                    <owl:Restriction>
+                                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_finding"/>
+                                        <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#TumorMalignant"/>
+                                    </owl:Restriction>
+                                    <owl:Restriction>
+                                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_prognosis"/>
+                                        <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisBad"/>
+                                    </owl:Restriction>
+                                </owl:intersectionOf>
+                            </owl:Class>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:annotatedTarget>
+        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">test of annotation on role group subclass</note>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Clinical_Infection -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Clinical_Infection">
+        <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Infectious_Disorder"/>
+        <FULL_SYN rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Clinical Infection</FULL_SYN>
+        <Preferred_Name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Clinical Infection</Preferred_Name>
+        <Semantic_Type rdf:datatype="http://www.w3.org/2001/XMLScheme#string">Disease of Syndrome</Semantic_Type>
+        <code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C128366</code>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Clinical Infection</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Cold -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Cold">
+        <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Disease"/>
+    </owl:Class>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Disease -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Disease">
+        <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#DiseasesDisordersFindings"/>
+        <definition>any entity that impacts the health of a patient.</definition>
+        <term>disease</term>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Disease"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#DiseasesDisordersFindings"/>
+        <definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">One of the three entities in the parent covering partition.</definition>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Disease"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#definition"/>
+        <owl:annotatedTarget>any entity that impacts the health of a patient.</owl:annotatedTarget>
+        <provenance>joe blow via lily librarian</provenance>
+        <source>nih</source>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Disease"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term"/>
+        <owl:annotatedTarget>disease</owl:annotatedTarget>
+        <source>nci</source>
+        <term_type>pt</term_type>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#DiseasesDisordersFindings -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#DiseasesDisordersFindings">
+        <owl:disjointWith rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Person"/>
+        <definition>any entitie categorized as a disease, a disorder, or a finding.</definition>
+        <term>diseases, disorders, and findings</term>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#DiseasesDisordersFindings"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#disjointWith"/>
+        <owl:annotatedTarget rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Person"/>
+        <note>treat disorders as always disjoint with people.</note>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#DiseasesDisordersFindings"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#definition"/>
+        <owl:annotatedTarget>any entitie categorized as a disease, a disorder, or a finding.</owl:annotatedTarget>
+        <provenance>pers. comm.</provenance>
+        <source>ctep</source>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#DiseasesDisordersFindings"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term"/>
+        <owl:annotatedTarget>diseases, disorders, and findings</owl:annotatedTarget>
+        <source>nci</source>
+        <term_type>sy</term_type>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#EpithelialCell -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#EpithelialCell">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL_0000000"/>
+        <definition>a cell located in an epithelial surface.</definition>
+        <term>epithelial cell</term>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#EpithelialCell"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/CL_0000000"/>
+        <definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">an isa relation to an external entity.</definition>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#EpithelialCell"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#definition"/>
+        <owl:annotatedTarget>a cell located in an epithelial surface.</owl:annotatedTarget>
+        <provenance rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NLM</provenance>
+        <source>nci</source>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#EpithelialCell"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term"/>
+        <owl:annotatedTarget>epithelial cell</owl:annotatedTarget>
+        <source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">caDSR</source>
+        <term_type>pt</term_type>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Erbb2 -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Erbb2">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#gene_expressed_in"/>
+                        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CL_0000148"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Erbb2"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
+        <owl:annotatedTarget>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#gene_expressed_in"/>
+                        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CL_0000148"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:annotatedTarget>
+        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">test of annotation on object restriction subclass to external class</note>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Finding -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Finding">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#DiseasesDisordersFindings"/>
+                    <owl:Class>
+                        <owl:oneOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Fever"/>
+                            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PaleSkin"/>
+                            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#ShallowBreathing"/>
+                        </owl:oneOf>
+                    </owl:Class>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <semanticType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Disease</semanticType>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Finding"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
+        <owl:annotatedTarget>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#DiseasesDisordersFindings"/>
+                    <owl:Class>
+                        <owl:oneOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Fever"/>
+                            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PaleSkin"/>
+                            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#ShallowBreathing"/>
+                        </owl:oneOf>
+                    </owl:Class>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:annotatedTarget>
+        <definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">One of the three entities in the parent covering partition.</definition>
+        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">the extension of the class</note>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientDrivingAround -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientDrivingAround">
+        <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Patient"/>
+    </owl:Class>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientWalkingAround -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientWalkingAround">
+        <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Patient"/>
+    </owl:Class>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HealthyPatient -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HealthyPatient">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Patient"/>
+                    <owl:Class>
+                        <owl:complementOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SickPatient"/>
+                    </owl:Class>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HealthyPatient"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
+        <owl:annotatedTarget>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Patient"/>
+                    <owl:Class>
+                        <owl:complementOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SickPatient"/>
+                    </owl:Class>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:annotatedTarget>
+        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">definitely you are healthy if you are not sick.</note>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Infectious_Disorder -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Infectious_Disorder"/>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Mefv -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Mefv">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#gene_related_to_disease"/>
+                        <owl:hasValue rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Fever"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Mefv"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
+        <owl:annotatedTarget>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#gene_related_to_disease"/>
+                        <owl:hasValue rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Fever"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:annotatedTarget>
+        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">test of annotation on object restriction value subclass</note>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#MildlySickCancerPatient -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#MildlySickCancerPatient">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#MildlySickPatient"/>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_finding"/>
+                                <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#TumorBenign"/>
+                            </owl:Restriction>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_prognosis"/>
+                                <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <P108>slightly sick cancer patient</P108>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#MildlySickCancerPatient"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
+        <owl:annotatedTarget>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#MildlySickPatient"/>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_finding"/>
+                                <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#TumorBenign"/>
+                            </owl:Restriction>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_prognosis"/>
+                                <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:annotatedTarget>
+        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">test of annotation on intersection of object restriction subclass</note>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#MildlySickPatient -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#MildlySickPatient">
+        <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SickPatient"/>
+    </owl:Class>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#NeoplasticDisease -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#NeoplasticDisease">
+        <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Disease"/>
+        <semanticType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Disease</semanticType>
+    </owl:Class>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#OncogeneTim -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#OncogeneTim">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#has_physical_location"/>
+                        <owl:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12345</owl:hasValue>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#OncogeneTim"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
+        <owl:annotatedTarget>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#has_physical_location"/>
+                        <owl:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12345</owl:hasValue>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:annotatedTarget>
+        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">test of annotation on datatype restriction value subclass</note>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Patient -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Patient">
+        <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Person"/>
+        <semanticType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Organism</semanticType>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Patient"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Person"/>
+        <definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a role taken by a person on a health care provider visit.</definition>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PatientWithCold -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PatientWithCold">
+        <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#MildlySickPatient"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_finding"/>
+                <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Cold"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <P108>Patient With Cold</P108>
+        <P90>slightly sick patient</P90>
+        <term>slightly sick patient</term>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PatientWithCold"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term"/>
+        <owl:annotatedTarget>slightly sick patient</owl:annotatedTarget>
+        <source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CDISC</source>
+        <term_type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PT</term_type>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Person -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Person">
+        <definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Any human being.</definition>
+        <term rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human</term>
+        <term rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Person</term>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Person"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#definition"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Any human being.</owl:annotatedTarget>
+        <source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">common knowledge</source>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Person"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human</owl:annotatedTarget>
+        <source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LOC</source>
+        <term_type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SY</term_type>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Person"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Person</owl:annotatedTarget>
+        <source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NCI</source>
+        <term_type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PT</term_type>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#DiseasesDisordersFindings"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#disjointWith"/>
+        <owl:annotatedTarget rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Person"/>
+        <note>treat disorders as always disjoint with people.</note>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PersonRole -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PersonRole">
+        <definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Any role adopted by a person.</definition>
+        <term rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Personal Role</term>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PersonRole"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#definition"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Any role adopted by a person.</owl:annotatedTarget>
+        <provenance rdf:datatype="http://www.w3.org/2001/XMLSchema#string">JQ Public</provenance>
+        <source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ONC</source>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PersonRole"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Personal Role</owl:annotatedTarget>
+        <source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NCI</source>
+        <term_type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SY</term_type>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Prognosis -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Prognosis">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#DiseasesDisordersFindings"/>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisBad"/>
+                            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <semanticType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Disease</semanticType>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Prognosis"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
+        <owl:annotatedTarget>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#DiseasesDisordersFindings"/>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisBad"/>
+                            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:annotatedTarget>
+        <definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">One of the three entities in the parent covering partition.</definition>
+        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">essentially the sum of subclasses</note>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisBad -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisBad">
+        <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Prognosis"/>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisBad"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Prognosis"/>
+        <definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">One of the two entities in the parent undeclared covering partition.</definition>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood">
+        <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Prognosis"/>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Prognosis"/>
+        <definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">One of the two entities in the parent undeclared covering partition.</definition>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Ras -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Ras">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#has_physical_location"/>
+                        <owl:someValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#positiveInteger"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Ras"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
+        <owl:annotatedTarget>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#has_physical_location"/>
+                        <owl:someValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#positiveInteger"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:annotatedTarget>
+        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">test of annotation on datatype restriction subclass</note>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SHH -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SHH">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#gene_related_to_disease"/>
+                        <owl:allValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#NeoplasticDisease"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SHH"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
+        <owl:annotatedTarget>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#gene_related_to_disease"/>
+                        <owl:allValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#NeoplasticDisease"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:annotatedTarget>
+        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">test of annotation on object restriction subclass</note>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SOS -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SOS">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#gene_related_to_disease"/>
+                        <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#NeoplasticDisease"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SOS"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
+        <owl:annotatedTarget>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#gene_related_to_disease"/>
+                        <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#NeoplasticDisease"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:annotatedTarget>
+        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">test of annotation on object restriction subclass</note>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SickPatient -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SickPatient">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Patient"/>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#CancerPatient"/>
+                            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#MildlySickPatient"/>
+                            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#VerySickPatient"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SickPatient"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
+        <owl:annotatedTarget>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Patient"/>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#CancerPatient"/>
+                            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#MildlySickPatient"/>
+                            <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#VerySickPatient"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:annotatedTarget>
+        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">essentially the sum of subclasses</note>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#TotalPerson -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#TotalPerson">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Person"/>
+                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PersonRole"/>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#TotalPerson"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
+        <owl:annotatedTarget>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Person"/>
+                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PersonRole"/>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:annotatedTarget>
+        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">in real life, probably a union.</note>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#TumorBenign -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#TumorBenign">
+        <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#NeoplasticDisease"/>
+    </owl:Class>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#TumorMalignant -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#TumorMalignant">
+        <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#NeoplasticDisease"/>
+    </owl:Class>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#VerySickCancerPatient -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#VerySickCancerPatient">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#VerySickPatient"/>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_finding"/>
+                                <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#TumorMalignant"/>
+                            </owl:Restriction>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_prognosis"/>
+                                <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisBad"/>
+                            </owl:Restriction>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <P108>very sick cancer patient</P108>
+        <term>very sick cancer patient</term>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#VerySickCancerPatient"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
+        <owl:annotatedTarget>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#VerySickPatient"/>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_finding"/>
+                                <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#TumorMalignant"/>
+                            </owl:Restriction>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_prognosis"/>
+                                <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisBad"/>
+                            </owl:Restriction>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:annotatedTarget>
+        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">test of annotation on union of object restriction subclass</note>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#VerySickCancerPatient"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term"/>
+        <owl:annotatedTarget>very sick cancer patient</owl:annotatedTarget>
+        <source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NCI</source>
+        <term_type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PT</term_type>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#VerySickPatient -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#VerySickPatient">
+        <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SickPatient"/>
+        <term rdf:datatype="http://www.w3.org/2001/XMLSchema#string">very sick patient</term>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#VerySickPatient"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">very sick patient</owl:annotatedTarget>
+        <source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NCI</source>
+        <term_type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PT</term_type>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#actin -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#actin">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#gene_expressed_in"/>
+                                <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#EpithelialCell"/>
+                            </owl:Restriction>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#in_organism"/>
+                                <owl:hasValue>all organisms</owl:hasValue>
+                            </owl:Restriction>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#actin"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
+        <owl:annotatedTarget>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#gene_expressed_in"/>
+                                <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#EpithelialCell"/>
+                            </owl:Restriction>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#in_organism"/>
+                                <owl:hasValue>all organisms</owl:hasValue>
+                            </owl:Restriction>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:annotatedTarget>
+        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">test of annotation on union of datatype and object restriction subclass</note>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#k-Ras -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#k-Ras">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#has_physical_location"/>
+                        <owl:allValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#positiveInteger"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#k-Ras"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
+        <owl:annotatedTarget>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#C123"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#has_physical_location"/>
+                        <owl:allValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#positiveInteger"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:annotatedTarget>
+        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">test of annotation on datatype restriction subclass</note>
+    </owl:Axiom>
+    
+
+
+    <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#112233 -->
+
+    <owl:Class rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#112233">
+        <rdfs:label>NumericalID</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://org.semanticweb.owlapi/error#Error1 -->
+
+    <owl:Class rdf:about="http://org.semanticweb.owlapi/error#Error1"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/BFO_0000001 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000001">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <owl:disjointWith rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
+        <obo:BFO_0000179>entity</obo:BFO_0000179>
+        <obo:BFO_0000180>Entity</obo:BFO_0000180>
+        <obo:IAO_0000111 xml:lang="en">entity</obo:IAO_0000111>
+        <obo:IAO_0000112 xml:lang="en">Julius Caesar</obo:IAO_0000112>
+        <obo:IAO_0000112 xml:lang="en">Verdi’s Requiem</obo:IAO_0000112>
+        <obo:IAO_0000112 xml:lang="en">the Second World War</obo:IAO_0000112>
+        <obo:IAO_0000112 xml:lang="en">your body mass index</obo:IAO_0000112>
+        <obo:IAO_0000116 xml:lang="en">BFO 2 Reference: In all areas of empirical inquiry we encounter general terms of two sorts. First are general terms which refer to universals or types:animaltuberculosissurgical procedurediseaseSecond, are general terms used to refer to groups of entities which instantiate a given universal but do not correspond to the extension of any subuniversal of that universal because there is nothing intrinsic to the entities in question by virtue of which they – and only they – are counted as belonging to the given group. Examples are: animal purchased by the Emperortuberculosis diagnosed on a Wednesdaysurgical procedure performed on a patient from Stockholmperson identified as candidate for clinical trial #2056-555person who is signatory of Form 656-PPVpainting by Leonardo da VinciSuch terms, which represent what are called ‘specializations’ in [81</obo:IAO_0000116>
+        <obo:IAO_0000116 xml:lang="en">Entity doesn&apos;t have a closure axiom because the subclasses don&apos;t necessarily exhaust all possibilites. For example Werner Ceusters &apos;portions of reality&apos; include 4 sorts, entities (as BFO construes them), universals, configurations, and relations. It is an open question as to whether entities as construed in BFO will at some point also include these other portions of reality. See, for example, &apos;How to track absolutely everything&apos; at http://www.referent-tracking.com/_RTU/papers/CeustersICbookRevised.pdf</obo:IAO_0000116>
+        <obo:IAO_0000600 xml:lang="en">An entity is anything that exists or has existed or will exist. (axiom label in BFO2 Reference: [001-001])</obo:IAO_0000600>
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/bfo.owl"/>
+        <rdfs:label xml:lang="en">entity</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000001"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000116"/>
+        <owl:annotatedTarget xml:lang="en">Entity doesn&apos;t have a closure axiom because the subclasses don&apos;t necessarily exhaust all possibilites. For example Werner Ceusters &apos;portions of reality&apos; include 4 sorts, entities (as BFO construes them), universals, configurations, and relations. It is an open question as to whether entities as construed in BFO will at some point also include these other portions of reality. See, for example, &apos;How to track absolutely everything&apos; at http://www.referent-tracking.com/_RTU/papers/CeustersICbookRevised.pdf</owl:annotatedTarget>
+        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/0000004"/>
+        <rdfs:comment>per discussion with Barry Smith</rdfs:comment>
+        <rdfs:seeAlso rdf:resource="http://www.referent-tracking.com/_RTU/papers/CeustersICbookRevised.pdf"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000001"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000600"/>
+        <owl:annotatedTarget xml:lang="en">An entity is anything that exists or has existed or will exist. (axiom label in BFO2 Reference: [001-001])</owl:annotatedTarget>
+        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/001-001"/>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/BFO_0000002 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000002">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000001"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000003"/>
+        <obo:BFO_0000179>continuant</obo:BFO_0000179>
+        <obo:BFO_0000180>Continuant</obo:BFO_0000180>
+        <obo:IAO_0000111 xml:lang="en">continuant</obo:IAO_0000111>
+        <obo:IAO_0000115 xml:lang="en">An entity that exists in full at any time in which it exists at all, persists through time while maintaining its identity and has no temporal parts.</obo:IAO_0000115>
+        <obo:IAO_0000116 xml:lang="en">BFO 2 Reference: Continuant entities are entities which can be sliced to yield parts only along the spatial dimension, yielding for example the parts of your table which we call its legs, its top, its nails. ‘My desk stretches from the window to the door. It has spatial parts, and can be sliced (in space) in two. With respect to time, however, a thing is a continuant.’ [60, p. 240</obo:IAO_0000116>
+        <obo:IAO_0000116 xml:lang="en">Continuant doesn&apos;t have a closure axiom because the subclasses don&apos;t necessarily exhaust all possibilites. For example, in an expansion involving bringing in some of Ceuster&apos;s other portions of reality, questions are raised as to whether universals are continuants</obo:IAO_0000116>
+        <obo:IAO_0000600 xml:lang="en">A continuant is an entity that persists, endures, or continues to exist through time while maintaining its identity. (axiom label in BFO2 Reference: [008-002])</obo:IAO_0000600>
+        <obo:IAO_0000601 xml:lang="en">if b is a continuant and if, for some t, c has_continuant_part b at t, then c is a continuant. (axiom label in BFO2 Reference: [126-001])</obo:IAO_0000601>
+        <obo:IAO_0000601 xml:lang="en">if b is a continuant and if, for some t, cis continuant_part of b at t, then c is a continuant. (axiom label in BFO2 Reference: [009-002])</obo:IAO_0000601>
+        <obo:IAO_0000601 xml:lang="en">if b is a material entity, then there is some temporal interval (referred to below as a one-dimensional temporal region) during which b exists. (axiom label in BFO2 Reference: [011-002])</obo:IAO_0000601>
+        <obo:IAO_0000602>(forall (x y) (if (and (Continuant x) (exists (t) (continuantPartOfAt y x t))) (Continuant y))) // axiom label in BFO2 CLIF: [009-002] </obo:IAO_0000602>
+        <obo:IAO_0000602>(forall (x y) (if (and (Continuant x) (exists (t) (hasContinuantPartOfAt y x t))) (Continuant y))) // axiom label in BFO2 CLIF: [126-001] </obo:IAO_0000602>
+        <obo:IAO_0000602>(forall (x) (if (Continuant x) (Entity x))) // axiom label in BFO2 CLIF: [008-002] </obo:IAO_0000602>
+        <obo:IAO_0000602>(forall (x) (if (Material Entity x) (exists (t) (and (TemporalRegion t) (existsAt x t))))) // axiom label in BFO2 CLIF: [011-002] </obo:IAO_0000602>
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/bfo.owl"/>
+        <rdfs:label xml:lang="en">continuant</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000116"/>
+        <owl:annotatedTarget xml:lang="en">Continuant doesn&apos;t have a closure axiom because the subclasses don&apos;t necessarily exhaust all possibilites. For example, in an expansion involving bringing in some of Ceuster&apos;s other portions of reality, questions are raised as to whether universals are continuants</owl:annotatedTarget>
+        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/0000007"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000600"/>
+        <owl:annotatedTarget xml:lang="en">A continuant is an entity that persists, endures, or continues to exist through time while maintaining its identity. (axiom label in BFO2 Reference: [008-002])</owl:annotatedTarget>
+        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/008-002"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000601"/>
+        <owl:annotatedTarget xml:lang="en">if b is a continuant and if, for some t, c has_continuant_part b at t, then c is a continuant. (axiom label in BFO2 Reference: [126-001])</owl:annotatedTarget>
+        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/126-001"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000601"/>
+        <owl:annotatedTarget xml:lang="en">if b is a continuant and if, for some t, cis continuant_part of b at t, then c is a continuant. (axiom label in BFO2 Reference: [009-002])</owl:annotatedTarget>
+        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/009-002"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000601"/>
+        <owl:annotatedTarget xml:lang="en">if b is a material entity, then there is some temporal interval (referred to below as a one-dimensional temporal region) during which b exists. (axiom label in BFO2 Reference: [011-002])</owl:annotatedTarget>
+        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/011-002"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/>
+        <owl:annotatedTarget>(forall (x y) (if (and (Continuant x) (exists (t) (continuantPartOfAt y x t))) (Continuant y))) // axiom label in BFO2 CLIF: [009-002] </owl:annotatedTarget>
+        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/009-002"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/>
+        <owl:annotatedTarget>(forall (x y) (if (and (Continuant x) (exists (t) (hasContinuantPartOfAt y x t))) (Continuant y))) // axiom label in BFO2 CLIF: [126-001] </owl:annotatedTarget>
+        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/126-001"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/>
+        <owl:annotatedTarget>(forall (x) (if (Continuant x) (Entity x))) // axiom label in BFO2 CLIF: [008-002] </owl:annotatedTarget>
+        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/008-002"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/>
+        <owl:annotatedTarget>(forall (x) (if (Material Entity x) (exists (t) (and (TemporalRegion t) (existsAt x t))))) // axiom label in BFO2 CLIF: [011-002] </owl:annotatedTarget>
+        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/011-002"/>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/BFO_0000003 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000003"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/BFO_0000004 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000004"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/BFO_0000015 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000015"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/BFO_0000017 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000017"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/BFO_0000023 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000023"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/BFO_0000182 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000182">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000015"/>
+        <obo:BFO_0000179>history</obo:BFO_0000179>
+        <obo:BFO_0000180>History</obo:BFO_0000180>
+        <obo:IAO_0000111 xml:lang="en">history</obo:IAO_0000111>
+        <obo:IAO_0000600 xml:lang="en">A history is a process that is the sum of the totality of processes taking place in the spatiotemporal region occupied by a material entity or site, including processes on the surface of the entity or within the cavities to which it serves as host. (axiom label in BFO2 Reference: [138-001])</obo:IAO_0000600>
+        <obo:IAO_0000600 xml:lang="en">A history is a process. (axiom label in BFO2 Reference: [138-001])</obo:IAO_0000600>
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/bfo.owl"/>
+        <rdfs:label xml:lang="en">history</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000182"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000600"/>
+        <owl:annotatedTarget xml:lang="en">A history is a process. (axiom label in BFO2 Reference: [138-001])</owl:annotatedTarget>
+        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/138-001"/>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_15956 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_15956">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/REO_0000280"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000087"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/REO_0000171"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">biotin</obo:IAO_0000111>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An organic heterobicyclic compound that consists of 2-oxohexahydro-1H-thieno[3,4-d]imidazole having a valeric acid substituent attached to the tetrahydrothiophene ring. The parent of the class of biotins.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/chebi.owl"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">biotin</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CL_0000000 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_0000000">
+        <definition>external class from the cl.</definition>
+        <rdfs:label>Cell</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_0000000"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#definition"/>
+        <owl:annotatedTarget>external class from the cl.</owl:annotatedTarget>
+        <provenance>lily librarian</provenance>
+        <source>cl</source>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CL_0000001 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_0000001">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL_0000010"/>
+        <rdfs:subClassOf>
+            <owl:Class>
+                <owl:complementOf>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000312"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0600037"/>
+                    </owl:Restriction>
+                </owl:complementOf>
+            </owl:Class>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Class>
+                <owl:complementOf>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001000"/>
+                        <owl:someValuesFrom>
+                            <owl:Class>
+                                <owl:intersectionOf rdf:parseType="Collection">
+                                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CL_0000010"/>
+                                    <owl:Restriction>
+                                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000312"/>
+                                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0600037"/>
+                                    </owl:Restriction>
+                                </owl:intersectionOf>
+                            </owl:Class>
+                        </owl:someValuesFrom>
+                    </owl:Restriction>
+                </owl:complementOf>
+            </owl:Class>
+        </rdfs:subClassOf>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">primary cultured cell</obo:IAO_0000111>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A cultured cell that is freshly isolated from a organismal source, or derives in culture from such a cell prior to the culture being passaged.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/cl.owl"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">primary cultured cell</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CL_0000010 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_0000010"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CL_0000148 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_0000148">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL_0000000"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000027 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000027"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000030 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000030"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000032 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000032">
+        <rdfs:subClassOf rdf:resource="http://org.semanticweb.owlapi/error#Error1"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000109"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0001938"/>
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0001931"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000039"/>
-                <owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minCardinality>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
@@ -2687,7 +2746,129 @@ this case we explicitly refer to the singular form</obo:IAO_0000116>
         <rdfs:label xml:lang="en">scalar measurement datum</rdfs:label>
     </owl:Class>
     
-        <!-- http://purl.obolibrary.org/obo/OBI_0001873 -->
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000033 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000033">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000030"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/BFO_0000017"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <obo:IAO_0000111 xml:lang="en">directive information entity</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000115 xml:lang="en">An information content entity whose concretizations indicate to their bearer how to realize them in a process.</obo:IAO_0000115>
+        <obo:IAO_0000116 xml:lang="en">2009-03-16: provenance: a term realizable information entity was proposed for OBI (OBI_0000337) , edited by the PlanAndPlannedProcess branch. Original definition was  &quot;is the specification of a process that can be concretized and realized by an actor&quot; with alternative term  &quot;instruction&quot;.It has been subsequently moved to IAO where the objective for which the original term was defined was satisfied with the definitionof this, different, term.</obo:IAO_0000116>
+        <obo:IAO_0000116 xml:lang="en">2013-05-30 Alan Ruttenberg: What differentiates a directive information entity from an information concretization is that it can have concretizations that are either qualities or realizable entities. The concretizations that are realizable entities are created when an individual chooses to take up the direction, i.e. has the intention to (try to) realize it.</obo:IAO_0000116>
+        <obo:IAO_0000116 xml:lang="en">8/6/2009 Alan Ruttenberg: Changed label from &quot;information entity about a realizable&quot; after discussions at ICBO</obo:IAO_0000116>
+        <obo:IAO_0000116 xml:lang="en">Werner pushed back on calling it realizable information entity as it isn&apos;t realizable. However this name isn&apos;t right either. An example would be a recipe. The realizable entity would be a plan, but the information entity isn&apos;t about the plan, it, once concretized, *is* the plan. -Alan</obo:IAO_0000116>
+        <obo:IAO_0000117 xml:lang="en">PERSON: Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">PERSON: Bjoern Peters</obo:IAO_0000117>
+        <rdfs:label xml:lang="en">directive information entity</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000078 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000078"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000104 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000104"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000109 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000109"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0000011 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000011"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0000047 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000047"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0000070 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000070"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0000272 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000272"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0000441 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000441"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0000699 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000699">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0000070"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000293"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0100026"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000299"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000789"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0100026"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000417"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000441"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">survival assessment</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Survival assessment is an assay that measures the occurrence of death events in one or more organisms that are monitored over time</obo:IAO_0000115>
+        <obo:IAO_0000116 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Need to point out more specifically that survival / death is measured.</obo:IAO_0000116>
+        <obo:OBI_9991118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></obo:OBI_9991118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">survival assessment</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0000789 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000789"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0001873 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0001873">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000027"/>
@@ -2715,7 +2896,199 @@ PMID: 23587118. see table2</obo:IAO_0000112>
         <rdfs:label xml:lang="en">number of errors</rdfs:label>
     </owl:Class>
     
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0001931 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0001931"/>
     
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0001933 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0001933"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0100026 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0100026"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0100060 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0100060">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0000047"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000312"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0600024"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000643"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CL_0000010"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000643"/>
+                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CL_0000010"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cultured cell population</obo:IAO_0000111>
+        <obo:IAO_0000112>A cultured cell population applied in an experiment: &quot;293 cells expressing TrkA were serum-starved for 18 hours and then neurotrophins were added for 10 min before cell harvest.&quot;  (Lee, Ramee, et al. &quot;Regulation of cell survival by secreted proneurotrophins.&quot; Science 294.5548 (2001): 1945-1948).
+
+A cultured cell population maintained in vitro: &quot;Rat cortical neurons from 15 day embryos are grown in dissociated cell culture and maintained in vitro for 8–12 weeks&quot; (Dichter, Marc A. &quot;Rat cortical neurons in cell culture: culture methods, cell morphology, electrophysiology, and synapse formation.&quot; Brain Research 149.2 (1978): 279-293).</obo:IAO_0000112>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A processed material comprised of a collection of cultured cells that has been continuously maintained together in culture and shares a common propagation history.</obo:IAO_0000115>
+        <obo:IAO_0000116 xml:lang="en">2013-6-5 MHB: This OBI class was formerly called &apos;cell culture&apos;, but label changed and definition updated following CLO alignment efforts in spring 2013, during which the intent of this class was clarified to refer to portions of a culture or line rather than a complete cell culture or line.</obo:IAO_0000116>
+        <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PERSON:Matthew Brush</obo:IAO_0000117>
+        <obo:IAO_0000118>cell culture sample</obo:IAO_0000118>
+        <obo:IAO_0000119 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PERSON:Matthew Brush</obo:IAO_0000119>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The extent of a &apos;cultured cell population&apos; is restricted only in that all cell members must share a propagation history (ie be derived through a common lineage of passages from an initial culture). In being defined in this way, this class can be used to refer to the populations that researchers actually use in the practice of science - ie are the inputs to culturing, experimentation, and sharing. The cells in such populations will be a relatively uniform population as they have experienced similar selective pressures due to their continuous co-propagation. And this population will also have a single passage number, again owing to their common passaging history. Cultured cell populations represent only a collection of cells (ie do not include media, culture dishes, etc), and include populations of cultured unicellular organisms or cultured multicellular organism cells. They can exist under active culture, stored in a quiescent state for future use, or applied experimentally.</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cultured cell population</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0100061 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0100061">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0100060"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000643"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CL_0000001"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000643"/>
+                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CL_0000001"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000312"/>
+                <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">0</owl:qualifiedCardinality>
+                <owl:onClass rdf:resource="http://purl.obolibrary.org/obo/OBI_0600037"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <obo:IAO_0000111 xml:lang="en">primary cultured cell population</obo:IAO_0000111>
+        <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Spleen cells put directly into culture;  Cold storage of biopsies from wild endangered native Chilean species in field conditions and subsequent isolation of primary culture cell lines. In Vitro Cell Dev Biol Anim. 2008 Jul 2. PMID: 18594934</obo:IAO_0000112>
+        <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cells that have been isolated from some organismal source, expanded in culture, but not undergone a complete passaging (ie are still in culture, or have been lifted from culture and frozen in aliquots for future use)</obo:IAO_0000112>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A cultured cell population comprised of cells expanded directly from living tissue prior to being passaged.
+
+</obo:IAO_0000115>
+        <obo:IAO_0000116>2013-6-5 MHB: This OBI class was formerly called &apos;primary cell culture&apos;, but label changed and definition updated following CLO alignment work.  Previous definition: &apos;a primary cell culture is a cell culture where the cells derive from a fresh tissue source.&apos;</obo:IAO_0000116>
+        <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PERSON:Matthew Brush</obo:IAO_0000117>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">primary cell culture</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">primary cell culture sample</obo:IAO_0000118>
+        <obo:IAO_0000119 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PERSON:Matthew Brush</obo:IAO_0000119>
+        <rdfs:label xml:lang="en">primary cultured cell population</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0100063 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0100063">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0100060"/>
+        <obo:IAO_0000111 xml:lang="en">cultured clonal cell population</obo:IAO_0000111>
+        <obo:IAO_0000112 xml:lang="en">cell cut                                                                                                                                                                                      
+Stem cell functions assessed in clonal culture. Soc Gen Physiol Ser. 1988;43:39-45. Review. PMID: 3077557</obo:IAO_0000112>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+        <obo:IAO_0000115 xml:lang="en">A cultured cell population comprised of cells which can all be traced back to a single ancestor cell, and which therefore can be treated as identical.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PERSON: Susanna Sansone</obo:IAO_0000117>
+        <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PERSON:Matthew Brush</obo:IAO_0000117>
+        <obo:IAO_0000118>clonal cell culture sample</obo:IAO_0000118>
+        <obo:IAO_0000119 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GROUP: OBI Biomaterial Branch</obo:IAO_0000119>
+        <rdfs:label xml:lang="en">cultured clonal cell population</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0500000 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0500000">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000104"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OBI_0000272"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <obo:IAO_0000111 xml:lang="en">study design</obo:IAO_0000111>
+        <obo:IAO_0000112 xml:lang="en">a matched pairs study design describes criteria by which subjects are identified as pairs which then undergo the same protocols, and the data generated is analyzed by comparing the differences between the paired subjects, which constitute the results of the executed study design.</obo:IAO_0000112>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A plan specification comprised of protocols (which may specify how and what kinds of data will be gathered) that are executed as part of an investigation and is realized during a study design execution.</obo:IAO_0000115>
+        <obo:IAO_0000116 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Editor note: there is at least an implicit restriction on the kind of data transformations that can be done based on the measured data available.</obo:IAO_0000116>
+        <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PERSON: Chris Stoeckert</obo:IAO_0000117>
+        <obo:IAO_0000118 xml:lang="en">experimental design</obo:IAO_0000118>
+        <obo:IAO_0000232 xml:lang="en">rediscussed at length (MC/JF/BP). 12/9/08). The definition was clarified to differentiate it from protocol.</obo:IAO_0000232>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+        <rdfs:label xml:lang="en">study design</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0600024 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0600024"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0600037 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0600037"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/REO_0000171 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/REO_0000171">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000023"/>
+        <obo:IAO_0000111 xml:lang="en">molecular label role</obo:IAO_0000111>
+        <obo:IAO_0000115>a reagent role inhering in a molecular entity intended to associate with some molecular target to serve as a proxy for the presence, abundance, or location of this target in a detection of molecular label assay.</obo:IAO_0000115>
+        <obo:IAO_0000116>MHB (9-29-13): &apos;molecular label role&apos; imported from the Reagent Ontology and replaced OBI:OBI_0000140 (label role)</obo:IAO_0000116>
+        <obo:IAO_0000118>molecular tracer role</obo:IAO_0000118>
+        <obo:IAO_0000119>OBI developer call, 3-12-12</obo:IAO_0000119>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/reo.owl"/>
+        <rdfs:label xml:lang="en">molecular label role</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/REO_0000280 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/REO_0000280"/>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#ObsoleteClass -->
+
+    <owl:Class rdf:about="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
+    
+
+
+    <!-- http://www.w3.org/2002/07/owl#Nothing -->
+
+    <owl:Class rdf:about="http://www.w3.org/2002/07/owl#Nothing">
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Nothing"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.w3.org/2002/07/owl#Thing -->
+
+    <owl:Class rdf:about="http://www.w3.org/2002/07/owl#Thing"/>
+    
+
+
     <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //
@@ -2729,66 +3102,65 @@ PMID: 23587118. see table2</obo:IAO_0000112>
 
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Fever -->
 
-    <owl:NamedIndividual rdf:about="&owl2lexevs;Fever">
-        <rdf:type rdf:resource="&owl2lexevs;Finding"/>
-        <term rdf:datatype="&xsd;string">High Temperature</term>
+    <owl:NamedIndividual rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Fever">
+        <rdf:type rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Finding"/>
+        <term rdf:datatype="http://www.w3.org/2001/XMLSchema#string">High Temperature</term>
     </owl:NamedIndividual>
     <owl:Axiom>
-        <owl:annotatedTarget rdf:datatype="&xsd;string">High Temperature</owl:annotatedTarget>
-        <term_type rdf:datatype="&xsd;string">SY</term_type>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;Fever"/>
-        <owl:annotatedProperty rdf:resource="&owl2lexevs;term"/>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Fever"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#term"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">High Temperature</owl:annotatedTarget>
+        <term_type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SY</term_type>
     </owl:Axiom>
     
 
 
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientDrivingAround -->
 
-    <owl:NamedIndividual rdf:about="&owl2lexevs;HappyPatientDrivingAround">
-        <AssociationV1 rdf:resource="&owl2lexevs;PrognosisGood"/>
+    <owl:NamedIndividual rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientDrivingAround">
+        <AssociationV1 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood"/>
     </owl:NamedIndividual>
     <owl:Axiom>
-        <note rdf:datatype="&xsd;string">annotation on an AssociationV1 of a class.</note>
-        <owl:annotatedProperty rdf:resource="&owl2lexevs;AssociationV1"/>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;HappyPatientDrivingAround"/>
-        <owl:annotatedTarget rdf:resource="&owl2lexevs;PrognosisGood"/>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientDrivingAround"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationV1"/>
+        <owl:annotatedTarget rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood"/>
+        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">annotation on an AssociationV1 of a class.</note>
     </owl:Axiom>
-    
     
 
 
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientWalkingAround -->
 
-    <owl:NamedIndividual rdf:about="&owl2lexevs;HappyPatientWalkingAround">
+    <owl:NamedIndividual rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientWalkingAround">
         <AssociationV1 rdf:resource="http://purl.obolibrary.org/obo/CL_0000148"/>
     </owl:NamedIndividual>
     <owl:Axiom>
-        <note rdf:datatype="&xsd;string">annotation on an AssociationV! of external.class (rdf:resource).</note>
-        <owl:annotatedProperty rdf:resource="&owl2lexevs;AssociationV1"/>
-        <owl:annotatedSource rdf:resource="&owl2lexevs;HappyPatientWalkingAround"/>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientWalkingAround"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationV1"/>
         <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/CL_0000148"/>
+        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">annotation on an AssociationV! of external.class (rdf:resource).</note>
     </owl:Axiom>
     
 
 
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PaleSkin -->
 
-    <owl:NamedIndividual rdf:about="&owl2lexevs;PaleSkin">
-        <rdf:type rdf:resource="&owl2lexevs;Finding"/>
+    <owl:NamedIndividual rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PaleSkin">
+        <rdf:type rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Finding"/>
     </owl:NamedIndividual>
     
 
 
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood -->
 
-    <owl:NamedIndividual rdf:about="&owl2lexevs;PrognosisGood"/>
+    <owl:NamedIndividual rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood"/>
     
 
 
     <!-- http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#ShallowBreathing -->
 
-    <owl:NamedIndividual rdf:about="&owl2lexevs;ShallowBreathing">
-        <rdf:type rdf:resource="&owl2lexevs;Finding"/>
+    <owl:NamedIndividual rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#ShallowBreathing">
+        <rdf:type rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Finding"/>
     </owl:NamedIndividual>
     
 
@@ -2797,19 +3169,105 @@ PMID: 23587118. see table2</obo:IAO_0000112>
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/CL_0000148"/>
     
+
+
     <!-- http://purl.obolibrary.org/obo/IAO_0000122 -->
 
-    <owl:Thing rdf:about="http://purl.obolibrary.org/obo/IAO_0000122"><!-- ready for release -->
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/IAO_0000078"/><!-- curation status specification -->
+    <owl:Thing rdf:about="http://purl.obolibrary.org/obo/IAO_0000122">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
-        <rdfs:label xml:lang="en">ready for release</rdfs:label>
-        <obo:IAO_0000115 xml:lang="en">Class has undergone final review, is ready for use, and will be included in the next release. Any class lacking "ready_for_release" should be considered likely to change place in hierarchy, have its definition refined, or be obsoleted in the next release.  Those classes deemed "ready_for_release" will also derived from a chain of ancestor classes that are also "ready_for_release."</obo:IAO_0000115>
+        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/IAO_0000078"/>
         <obo:IAO_0000111 xml:lang="en">ready for release</obo:IAO_0000111>
+        <obo:IAO_0000115 xml:lang="en">Class has undergone final review, is ready for use, and will be included in the next release. Any class lacking &quot;ready_for_release&quot; should be considered likely to change place in hierarchy, have its definition refined, or be obsoleted in the next release.  Those classes deemed &quot;ready_for_release&quot; will also derived from a chain of ancestor classes that are also &quot;ready_for_release.&quot;</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">ready for release</rdfs:label>
     </owl:Thing>
+    
 
-        <!-- http://purl.obolibrary.org/obo/obi.owl -->
+
+    <!-- http://purl.obolibrary.org/obo/obi.owl -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/obi.owl"/>
+    <rdf:Description>
+        <owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minCardinality>
+    </rdf:Description>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Annotations
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationV1">
+        <term rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Association</term>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientDrivingAround">
+        <AssociationSTR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood</AssociationSTR>
+        <AssociationLIT>http://ncicb.nci.nih.gov/xml/owl/evs/owl2lexevs.owl#PrognosisGood</AssociationLIT>
+        <InvalidAssociationURIAsResource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood"/>
+        <AssociationV1 rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood"/>
+        <AssociationURIAsResource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood"/>
+        <AssociationURI rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood"/>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientDrivingAround"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationSTR"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood</owl:annotatedTarget>
+        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">annotation on an AssociationSTR.</note>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientDrivingAround"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationLIT"/>
+        <owl:annotatedTarget>http://ncicb.nci.nih.gov/xml/owl/evs/owl2lexevs.owl#PrognosisGood</owl:annotatedTarget>
+        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">annotation on an AssociationLIT.</note>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientDrivingAround"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationURI"/>
+        <owl:annotatedTarget rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#PrognosisGood"/>
+        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">annotation on an AssociationURI of a class (rdf:resource).</note>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientWalkingAround">
+        <AssociationLIT>http://purl.obolibrary.org/obo/cl_0000148</AssociationLIT>
+        <AssociationV1 rdf:resource="http://purl.obolibrary.org/obo/CL_0000148"/>
+        <AssociationURI rdf:resource="http://purl.obolibrary.org/obo/CL_0000148"/>
+        <AssociationURI rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://purl.obolibrary.org/obo/CL_0000148</AssociationURI>
+        <AssociationSTR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.obolibrary.org/obo/CL_0000148</AssociationSTR>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientWalkingAround"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationLIT"/>
+        <owl:annotatedTarget>http://purl.obolibrary.org/obo/cl_0000148</owl:annotatedTarget>
+        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">annotation on an AssociationLIT of external.</note>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientWalkingAround"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationURI"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/CL_0000148"/>
+        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">annotation on an AssociationURI of external class (rdf:resource)</note>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientWalkingAround"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationURI"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://purl.obolibrary.org/obo/CL_0000148</owl:annotatedTarget>
+        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">annotation on an AssociationURI of external.</note>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#HappyPatientWalkingAround"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#AssociationSTR"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://purl.obolibrary.org/obo/CL_0000148</owl:annotatedTarget>
+        <note rdf:datatype="http://www.w3.org/2001/XMLSchema#string">annotation on an AssociationSTR of external.</note>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#semanticType">
+        <semanticType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Conceptual</semanticType>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CL_0000148">
+        <rdfs:label>melanocyte</rdfs:label>
+    </rdf:Description>
+    
+
 
     <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
@@ -2820,22 +3278,22 @@ PMID: 23587118. see table2</obo:IAO_0000112>
      -->
 
     <owl:Axiom>
-        <provenance>joe blow</provenance>
-        <note>gci testing</note>
-        <source>nci</source>
-        <owl:annotatedTarget rdf:resource="&owl2lexevs;SickPatient"/>
-        <owl:annotatedProperty rdf:resource="&rdfs;subClassOf"/>
         <owl:annotatedSource>
             <owl:Restriction>
-                <rdfs:subClassOf rdf:resource="&owl2lexevs;SickPatient"/>
-                <owl:onProperty rdf:resource="&owl2lexevs;patient_has_finding"/>
-                <owl:someValuesFrom rdf:resource="&owl2lexevs;Finding"/>
+                <owl:onProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#patient_has_finding"/>
+                <owl:someValuesFrom rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#Finding"/>
+                <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SickPatient"/>
             </owl:Restriction>
         </owl:annotatedSource>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
+        <owl:annotatedTarget rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#SickPatient"/>
+        <note>gci testing</note>
+        <provenance>joe blow</provenance>
+        <source>nci</source>
     </owl:Axiom>
 </rdf:RDF>
 
 
 
-<!-- Generated by the OWL API (version 3.5.0) http://owlapi.sourceforge.net -->
+<!-- Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi -->
 

--- a/lbTest/src/test/java/edu/mayo/informatics/lexgrid/convert/directConversions/owl2/OWL2SpecialCaseSnippetTestIT.java
+++ b/lbTest/src/test/java/edu/mayo/informatics/lexgrid/convert/directConversions/owl2/OWL2SpecialCaseSnippetTestIT.java
@@ -730,6 +730,50 @@ public class OWL2SpecialCaseSnippetTestIT extends DataLoadTestBaseSpecialCases {
 
 		}
 		
+		@Test
+		public void testValidateNumericalEntityLoadDesignation() throws LBException{
+			CodingSchemeVersionOrTag versionOrTag = new CodingSchemeVersionOrTag();
+			versionOrTag.setVersion("0.1.5");
+			CodedNodeSet set = lbs.getCodingSchemeConcepts(
+					LexBIGServiceTestCase.OWL2_SNIPPET_INDIVIDUAL_URN, versionOrTag);
+			set.restrictToMatchingDesignations("NumericalId", null, "exactMatch", null);
+			ResolvedConceptReferencesIterator itr = set.resolve(null, null, null, null);
+			assertNotNull(itr);
+			assertTrue(itr.hasNext());
+			while(itr.hasNext()){
+				boolean found = false;
+				ResolvedConceptReference ref = itr.next();
+				if(ref.getConceptCode().equals("112233")){
+					Presentation pres = ref.getEntity().getPresentationAsReference().stream().filter(x -> x.getValue().
+							getContent().equals("NumericalID")).findFirst().get();
+					assertNotNull(pres);
+				}
+			}
+
+		}
+		
+		@Test
+		public void testValidateNumericalEntityLoadCode() throws LBException{
+			CodingSchemeVersionOrTag versionOrTag = new CodingSchemeVersionOrTag();
+			versionOrTag.setVersion("0.1.5");
+			CodedNodeSet set = lbs.getCodingSchemeConcepts(
+					LexBIGServiceTestCase.OWL2_SNIPPET_INDIVIDUAL_URN, versionOrTag);
+			set.restrictToCodes(Constructors.createConceptReferenceList("112233"));
+			ResolvedConceptReferencesIterator itr = set.resolve(null, null, null, null);
+			assertNotNull(itr);
+			assertTrue(itr.hasNext());
+			while(itr.hasNext()){
+				boolean found = false;
+				ResolvedConceptReference ref = itr.next();
+				if(ref.getConceptCode().equals("112233")){
+					Presentation pres = ref.getEntity().getPresentationAsReference().stream().filter(x -> x.getValue().
+							getContent().equals("NumericalID")).findFirst().get();
+					assertNotNull(pres);
+				}
+			}
+
+		}
+		
 		public void testCodingSchemeSourceDefinition() throws LBException{
 			CodingScheme scheme = lbs.resolveCodingScheme("owl2lexevs" , Constructors.createCodingSchemeVersionOrTagFromVersion("0.1.5"));
 			assertTrue(scheme.getSourceAsReference().stream().anyMatch(x -> x.getContent().equals("nci evs")));

--- a/lgConverter/src/edu/mayo/informatics/lexgrid/convert/directConversions/owlapi/OwlApi2LG.java
+++ b/lgConverter/src/edu/mayo/informatics/lexgrid/convert/directConversions/owlapi/OwlApi2LG.java
@@ -401,9 +401,8 @@ public class OwlApi2LG {
                 
         // The idea is to iterate through all the OWL classes
         messages_.info("Processing concepts: ");
-        for (OWLClass namedClass : ontology.getClassesInSignature()) {
-
-            resolveConcept(namedClass);
+        for (Object namedClass : ontology.classesInSignature().toArray()) {
+            resolveConcept((OWLClass) namedClass);
             count++;
             if (count % 5000 == 0) {
                 messages_.info("OWL classes processed: " + count);
@@ -3102,11 +3101,25 @@ public class OwlApi2LG {
     }
     
     String getLocalName(IRI iri) {
-        return iri.getFragment();
+        if(!StringUtils.isBlank(iri.getFragment())){ return iri.getFragment();}
+        ManchesterOWLSyntaxPrefixNameShortFormProvider prov = new ManchesterOWLSyntaxPrefixNameShortFormProvider(ontology);
+        // find the base IRI string 
+        Map<String, String> prefix2NamespaceMapp = prov
+                .getPrefixName2PrefixMap();
+        String prefix = prefix2NamespaceMapp.values().stream().filter(x -> iri.getIRIString().contains(x)).findFirst().get();
+        String fragment = StringUtils.remove(iri.getIRIString(), prefix);
+        return fragment;
     }
     
     String getLocalName(OWLEntity entity) {
-        return entity.getIRI().getFragment();
+        if(!StringUtils.isBlank(entity.getIRI().getFragment())){ return entity.getIRI().getFragment();}
+        ManchesterOWLSyntaxPrefixNameShortFormProvider prov = new ManchesterOWLSyntaxPrefixNameShortFormProvider(ontology);
+        // find the base IRI string 
+        Map<String, String> prefix2NamespaceMapp = prov
+                .getPrefixName2PrefixMap();
+        String prefix = prefix2NamespaceMapp.values().stream().filter(x -> entity.getIRI().getIRIString().contains(x)).findFirst().get();
+        String fragment = StringUtils.remove(entity.getIRI().getIRIString(), prefix);
+        return fragment;
     }
 
     protected String getNameSpace(OWLEntity entity) {
@@ -3127,7 +3140,7 @@ public class OwlApi2LG {
         // find the base IRI string 
         Map<String, String> prefix2NamespaceMap = prov
                 .getPrefixName2PrefixMap();
-        for (Iterator i$ = prefix2NamespaceMap.keySet().iterator(); i$.hasNext();) {
+        for (Iterator<String> i$ = prefix2NamespaceMap.keySet().iterator(); i$.hasNext();) {
             String keyName = (String) i$.next();
             String prefix = (String) prefix2NamespaceMap.get(keyName);
             if (defaultPrefix.equals(keyName)) {


### PR DESCRIPTION
This corrects an issue created by the OWL API where it doesn't recognize the numeric remainder.