### PR TITLE
LEXEVS-4768.  Allowing queries against an untokenized, source-code named, qualifier

### DIFF
--- a/lbImpl/src/org/LexGrid/LexBIG/Impl/dataAccess/RestrictionImplementations.java
+++ b/lbImpl/src/org/LexGrid/LexBIG/Impl/dataAccess/RestrictionImplementations.java
@@ -297,6 +297,12 @@ public class RestrictionImplementations {
                     NameAndValue qualNameAndValue = propertyQualifiers.getNameAndValue(i);
                     String name = qualNameAndValue.getName();
                     String value = qualNameAndValue.getContent();
+                    if(name.equals("source-code")){
+                        nestedQuery.add(new BooleanClause(new TermQuery(new Term("hasSource", name)), Occur.SHOULD));
+                            if(value != null){
+                                nestedQuery.add(new BooleanClause(new TermQuery(new Term("sourceValue", value)), Occur.SHOULD));
+                            }
+                        }
                     QueryParser parser = new QueryParser("qualifiers",LuceneLoaderCode.getAnaylzer());
                     Query queryNameAndValue = parser.parse("\"" +name
                                 + LuceneLoaderCode.QUALIFIER_NAME_VALUE_SPLIT_TOKEN

--- a/lbImpl/src/org/LexGrid/LexBIG/Impl/dataAccess/RestrictionImplementations.java
+++ b/lbImpl/src/org/LexGrid/LexBIG/Impl/dataAccess/RestrictionImplementations.java
@@ -298,10 +298,15 @@ public class RestrictionImplementations {
                     String name = qualNameAndValue.getName();
                     String value = qualNameAndValue.getContent();
                     if(name.equals("source-code")){
-                        nestedQuery.add(new BooleanClause(new TermQuery(new Term("hasSource", name)), Occur.SHOULD));
+                        BooleanQuery.Builder deepQuery = new BooleanQuery.Builder();
+                        deepQuery.setMinimumNumberShouldMatch(1);
+                        deepQuery.add(new BooleanClause(new TermQuery(new Term("hasSource", name)), Occur.SHOULD));
                             if(value != null){
-                                nestedQuery.add(new BooleanClause(new TermQuery(new Term("sourceValue", value)), Occur.SHOULD));
+                                deepQuery.add(new BooleanClause(new TermQuery(new Term("sourceValue", value)), Occur.SHOULD));
                             }
+                            
+                       
+                        nestedQuery.add(new BooleanClause(deepQuery.build(), Occur.MUST));
                         }
                     QueryParser parser = new QueryParser("qualifiers",LuceneLoaderCode.getAnaylzer());
                     Query queryNameAndValue = parser.parse("\"" +name

--- a/lbTest/resources/testData/owl2/owl2-special-cases-Defined-Annotated.owl
+++ b/lbTest/resources/testData/owl2/owl2-special-cases-Defined-Annotated.owl
@@ -440,6 +440,12 @@
         <rdfs:label>term-source</rdfs:label>
     </owl:AnnotationProperty>
     
+    <owl:AnnotationProperty rdf:about="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P385">
+        <P108>source-code</P108>
+        <NHC0>P385</NHC0>
+        <rdfs:label>source-code</rdfs:label>
+    </owl:AnnotationProperty>
+    
     
     <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
@@ -1028,6 +1034,12 @@
         <owl:annotatedSource rdf:resource="&owl2lexevs;EpithelialCell"/>
         <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/CL_0000000"/>
         <owl:annotatedProperty rdf:resource="&rdfs;subClassOf"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_0000000"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/CL_0000000"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
+        <P385>CTESTCODE</P385>
     </owl:Axiom>
     <owl:Axiom>
         <provenance rdf:datatype="&xsd;string">NLM</provenance>

--- a/lbTest/resources/testData/owl2/owl2-special-cases-Defined-Annotated.owl
+++ b/lbTest/resources/testData/owl2/owl2-special-cases-Defined-Annotated.owl
@@ -2280,6 +2280,12 @@ A cultured cell population maintained in vitro: "Rat cortical neurons from 15 da
         <term-group rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PT</term-group>
         <term-source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NCI</term-source>
     </owl:Axiom>
+        <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_0000000"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/CL_0000000"/>
+        <owl:annotatedProperty rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl#P90"/>
+        <P385>CTESTCODETOO</P385>
+    </owl:Axiom>
 
     <!-- http://purl.obolibrary.org/obo/OBI_0000699 -->
 

--- a/lbTest/src/test/java/edu/mayo/informatics/lexgrid/convert/directConversions/graphdb/TestGraphQueryMethodsTestData.java
+++ b/lbTest/src/test/java/edu/mayo/informatics/lexgrid/convert/directConversions/graphdb/TestGraphQueryMethodsTestData.java
@@ -1,0 +1,53 @@
+package edu.mayo.informatics.lexgrid.convert.directConversions.graphdb;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.lexevs.locator.LexEvsServiceLocator;
+
+import com.arangodb.ArangoCursor;
+import com.arangodb.ArangoDBException;
+import com.arangodb.ArangoDatabase;
+
+public class TestGraphQueryMethodsTestData {
+	private static final int HashMap = 0;
+	static ArangoDatabase db;
+
+	@BeforeClass
+	public static void setUp() throws Exception {
+	db =  LexEvsServiceLocator.getInstance().getDatabaseServiceManager().getGraphingDatabaseService()
+				.getRels2graph().getGraphSourceMgr().getDataSource("http://ncicb.nci.nih.gov/xml/owl/EVS/owl2lexevs.owl", "0.1.5").getDbInstance();
+	}
+
+	@Test
+	public void testqueryAllVertices() throws ArangoDBException {
+		String queryString = "FOR v IN 1..10 INBOUND @id GRAPH @graph "
+				+ "OPTIONS {bfs: true, uniqueVertices: 'global'} RETURN {code: v._key, namespace: v.namespace}";
+		 Map<String, Object> bindVars = new java.util.HashMap<String,Object>();
+		 bindVars.put("id", "V_subClassOf/Disease");
+		 bindVars.put("graph", "subClassOf");
+		 ArangoCursor<String> cursor = db.query(queryString, bindVars, null, String.class);
+		List<String> result = cursor.asListRemaining();
+		assertEquals(4, result.size());
+	}
+	
+	@Test
+	public void testqueryAllLevel1Vertices() throws ArangoDBException {
+		String queryString = "FOR v IN 1..#depth INBOUND @id GRAPH @graph "
+				+ "OPTIONS {bfs: true, uniqueVertices: 'global'} RETURN {code: v._key, namespace: v.namespace}";
+		queryString = queryString.replaceAll("#depth", "1");
+		 Map<String, Object> bindVars = new java.util.HashMap<String,Object>();
+		 bindVars.put("id", "V_subClassOf/Disease");
+		 bindVars.put("graph", "subClassOf");
+		 ArangoCursor<String> cursor = db.query(queryString, bindVars, null, String.class);
+		List<String> result = cursor.asListRemaining();
+		assertEquals(2, result.size());
+	}
+
+}

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestUntokenizedQualifierForSourceCode.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestUntokenizedQualifierForSourceCode.java
@@ -40,6 +40,26 @@ public class TestUntokenizedQualifierForSourceCode extends LexBIGServiceTestCase
         assertTrue(Stream.of(nodeRefs.getResolvedConceptReference())
         		.anyMatch(x -> entityPropertyQualifierExistsForValue(x , "CTESTCODE")));
 	}
+	
+	@Test
+	public void testToo() throws LBException {
+        CodedNodeSet cns = ServiceHolder.instance().getLexBIGService()
+        		.getCodingSchemeConcepts(OWL2_SNIPPET_INDIVIDUAL_URN, 
+        				Constructors.createCodingSchemeVersionOrTagFromVersion(OWL2_SNIPPET_SPECIAL_CASE_INDIVIDUAL_VERSION));
+        cns.restrictToProperties(null, 
+        		new PropertyType[]{PropertyType.PRESENTATION}, 
+        		null, 
+        		null, 
+        		Constructors.createNameAndValueList("source-code", "CTESTCODETOO"));
+        ResolvedConceptReferenceList nodeRefs = cns.resolveToList(null, null, null, -1);
+        assertNotNull(nodeRefs);
+        assertTrue(nodeRefs.getResolvedConceptReferenceCount() > 0);
+        assertEquals(1, nodeRefs.getResolvedConceptReferenceCount());
+        assertTrue(Stream.of(nodeRefs.getResolvedConceptReference())
+        		.anyMatch(x -> entityPropertyQualifierExistsForName(x , "source-code")));
+        assertTrue(Stream.of(nodeRefs.getResolvedConceptReference())
+        		.anyMatch(x -> entityPropertyQualifierExistsForValue(x , "CTESTCODETOO")));
+	}
 
 	@Override
 	protected String getTestID() {

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestUntokenizedQualifierForSourceCode.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/function/query/TestUntokenizedQualifierForSourceCode.java
@@ -1,0 +1,62 @@
+package org.LexGrid.LexBIG.Impl.function.query;
+
+import static org.junit.Assert.*;
+
+import java.util.stream.Stream;
+
+import org.LexGrid.LexBIG.DataModel.Collections.ResolvedConceptReferenceList;
+import org.LexGrid.LexBIG.DataModel.Core.ResolvedConceptReference;
+import org.LexGrid.LexBIG.Exceptions.LBException;
+import org.LexGrid.LexBIG.Impl.function.LexBIGServiceTestCase;
+import org.LexGrid.LexBIG.Impl.testUtility.ServiceHolder;
+import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet;
+import org.LexGrid.LexBIG.LexBIGService.CodedNodeSet.PropertyType;
+import org.LexGrid.LexBIG.Utility.Constructors;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestUntokenizedQualifierForSourceCode extends LexBIGServiceTestCase {
+
+	@Before
+	public void setUp() throws Exception {
+	}
+
+	@Test
+	public void test() throws LBException {
+        CodedNodeSet cns = ServiceHolder.instance().getLexBIGService()
+        		.getCodingSchemeConcepts(OWL2_SNIPPET_INDIVIDUAL_URN, 
+        				Constructors.createCodingSchemeVersionOrTagFromVersion(OWL2_SNIPPET_SPECIAL_CASE_INDIVIDUAL_VERSION));
+        cns.restrictToProperties(null, 
+        		new PropertyType[]{PropertyType.PRESENTATION}, 
+        		null, 
+        		null, 
+        		Constructors.createNameAndValueList("source-code", "CTESTCODE"));
+        ResolvedConceptReferenceList nodeRefs = cns.resolveToList(null, null, null, -1);
+        assertNotNull(nodeRefs);
+        assertTrue(nodeRefs.getResolvedConceptReferenceCount() > 0);
+        assertEquals(1, nodeRefs.getResolvedConceptReferenceCount());
+        assertTrue(Stream.of(nodeRefs.getResolvedConceptReference())
+        		.anyMatch(x -> entityPropertyQualifierExistsForName(x , "source-code")));
+        assertTrue(Stream.of(nodeRefs.getResolvedConceptReference())
+        		.anyMatch(x -> entityPropertyQualifierExistsForValue(x , "CTESTCODE")));
+	}
+
+	@Override
+	protected String getTestID() {
+		return "Untokenized Source Code";
+	}
+	
+	private boolean entityPropertyQualifierExistsForName(ResolvedConceptReference ref, String name){
+		return Stream.of(ref.getEntity().getPresentation())
+		.anyMatch(x -> Stream.of(x.getPropertyQualifier())
+				.anyMatch(y -> y.getPropertyQualifierName().equals(name)));
+	}
+	
+	private boolean entityPropertyQualifierExistsForValue(ResolvedConceptReference ref, String value){
+		return Stream.of(ref.getEntity().getPresentation())
+		.anyMatch(x -> Stream.of(x.getPropertyQualifier())
+				.anyMatch(y -> y.getValue().getContent().equals(value)));
+	}
+	
+
+}

--- a/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/testUtility/AllTestsNormalConfig.java
+++ b/lbTest/src/test/java/org/LexGrid/LexBIG/Impl/testUtility/AllTestsNormalConfig.java
@@ -139,6 +139,7 @@ import org.LexGrid.LexBIG.Impl.function.query.TestSpecifyReturnOrder;
 import org.LexGrid.LexBIG.Impl.function.query.TestSubsetExtraction;
 import org.LexGrid.LexBIG.Impl.function.query.TestTransitiveClosure;
 import org.LexGrid.LexBIG.Impl.function.query.TestTraverseGraphviaRoleLinks;
+import org.LexGrid.LexBIG.Impl.function.query.TestUntokenizedQualifierForSourceCode;
 import org.LexGrid.LexBIG.Impl.function.query.TestVersionChanges;
 import org.LexGrid.LexBIG.Impl.function.query.TestVersioningandAuthorityEnumeration;
 import org.LexGrid.LexBIG.Impl.function.query.TestforCurrentOrObsoleteConcept;
@@ -468,6 +469,7 @@ public class AllTestsNormalConfig {
         functionalTests.addTestSuite(TestOWLLoaderPreferences.class);
         functionalTests.addTestSuite(TestSameCodeDifferentNamespace.class);
         functionalTests.addTestSuite(TestPasswordEncryption.class);
+        functionalTests.addTestSuite(TestUntokenizedQualifierForSourceCode.class);
         mainSuite.addTest(functionalTests);
 
         TestSuite treeTests = new TestSuite("tree extension tests");

--- a/lexevs-dao/src/main/java/org/lexevs/dao/index/indexer/LuceneLoaderCode.java
+++ b/lexevs-dao/src/main/java/org/lexevs/dao/index/indexer/LuceneLoaderCode.java
@@ -369,6 +369,12 @@ public abstract class LuceneLoaderCode {
         if (qualifiers != null && qualifiers.length > 0) {
             StringBuffer temp = new StringBuffer();
             for (int i = 0; i < qualifiers.length; i++) {
+            	if(qualifiers[i].qualifierName.equals("source-code")){
+            		generator_.addTextField("hasSource", qualifiers[i].qualifierName, false, true, false);
+            		if(qualifiers[i].qualifierValue != null){
+            		generator_.addTextField("sourceValue", qualifiers[i].qualifierValue, false, true, false);
+            		}
+            	}
                 temp.append(qualifiers[i].qualifierName + QUALIFIER_NAME_VALUE_SPLIT_TOKEN
                         + qualifiers[i].qualifierValue);
                 if (i + 1 < qualifiers.length) {


### PR DESCRIPTION
source-code qualifier named qualifiers are broken out of the indexed qualifier list and redone with a seperate set of fields.