### PR TITLE
LEXEVS-4812 - updated version for buidling snapshot

### DIFF
--- a/lbPackager/build.properties
+++ b/lbPackager/build.properties
@@ -1,5 +1,5 @@
 #Product version - major release
-vMajor=SNAPSHOT.DEV.SPRINT119.2019.10.17
+vMajor=SNAPSHOT.DEV.SPRINT123.2019.12.05
 
 #Product version - minor release
 vMinor=5


### PR DESCRIPTION
Bugfix/lexevs 4812 - updated version for buidling snapshot.