### PR TITLE
LEXEVS-4896 Updated version for snapshot 131.

### DIFF
--- a/lbPackager/build.properties
+++ b/lbPackager/build.properties
@@ -1,5 +1,5 @@
 #Product version - major release
-vMajor=SNAPSHOT.DEV.SPRINT130.2020.03.12
+vMajor=SNAPSHOT.DEV.SPRINT131.2020.03.31
 
 #Product version - minor release
 vMinor=5


### PR DESCRIPTION
LEXEVS-4896 Updated version for snapshot 131.